### PR TITLE
Add docs index page for GitHub Pages

### DIFF
--- a/docs/OLD/concepts.html
+++ b/docs/OLD/concepts.html
@@ -195,7 +195,7 @@ hr {
 <body>
 <div class="article">
 
-<a href="blog_impala_v4.html" class="back-link">&larr; Back to IMPALA V4 blog post</a>
+<a href="../index.html" class="back-link">&larr; Back to index</a>
 
 <h1>ML Concepts: Visual Explanations</h1>
 <p class="subtitle">Interactive diagrams explaining the machine learning building blocks used in the IMPALA V4 training pipeline. All numbers are from the actual model (d=32, 4 heads, 7 entity slots).</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Project Chimera — AI & ML Documentation</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #0a0c10;
+  --surface: #13161d;
+  --surface2: #1c2029;
+  --surface3: #252a36;
+  --border: #2a2f3e;
+  --border-bright: #3d4459;
+  --text: #b8c0cc;
+  --text-muted: #6b7280;
+  --heading: #e2e8f0;
+  --accent: #60a5fa;
+  --accent-dim: #2563eb;
+  --purple: #a78bfa;
+  --purple-dim: #7c3aed;
+  --green: #34d399;
+  --green-dim: #059669;
+  --red: #f87171;
+  --red-dim: #dc2626;
+  --orange: #fbbf24;
+  --orange-dim: #d97706;
+  --cyan: #22d3ee;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: 'Source Serif 4', Georgia, serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.78;
+  font-size: 17px;
+  -webkit-font-smoothing: antialiased;
+}
+
+.article {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 4rem 2rem 8rem;
+}
+
+header {
+  margin-bottom: 3.5rem;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+h1 {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 2.6rem;
+  font-weight: 700;
+  color: var(--heading);
+  line-height: 1.2;
+  margin-bottom: 1.2rem;
+  letter-spacing: -0.03em;
+}
+
+h1 .chimera {
+  color: var(--accent);
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  font-style: italic;
+  line-height: 1.65;
+  max-width: 680px;
+}
+
+.section-label {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 1.2rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.section-label::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.section {
+  margin-bottom: 4rem;
+}
+
+/* Blog / Dev Log cards */
+.blog-card {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.8rem 2rem;
+  margin-bottom: 1rem;
+  text-decoration: none;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.blog-card:hover {
+  border-color: var(--border-bright);
+  background: var(--surface2);
+}
+
+.blog-date {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.blog-title {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--heading);
+  line-height: 1.3;
+  margin: 0.5rem 0 0.6rem;
+  letter-spacing: -0.02em;
+}
+
+.blog-card:hover .blog-title {
+  color: var(--accent);
+}
+
+.blog-desc {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--purple);
+  background: rgba(167, 139, 250, 0.08);
+  border: 1px solid rgba(167, 139, 250, 0.15);
+  border-radius: 4px;
+  padding: 0.2rem 0.55rem;
+  letter-spacing: 0.01em;
+}
+
+/* Concept cards — learning path */
+.concept-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.concept-card {
+  display: grid;
+  grid-template-columns: 2.5rem 1fr;
+  gap: 0 1.4rem;
+  align-items: start;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 1.4rem 1.6rem;
+  text-decoration: none;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.concept-card:first-child {
+  border-radius: 10px 10px 0 0;
+}
+
+.concept-card:last-child {
+  border-radius: 0 0 10px 10px;
+}
+
+.concept-card:only-child {
+  border-radius: 10px;
+}
+
+.concept-card:hover {
+  border-color: var(--border-bright);
+  background: var(--surface2);
+}
+
+.concept-num {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--surface3);
+  line-height: 1;
+  padding-top: 0.15rem;
+  text-align: center;
+  letter-spacing: -0.03em;
+  transition: color 0.2s;
+}
+
+.concept-card:hover .concept-num {
+  color: var(--accent-dim);
+}
+
+.concept-body {
+  min-width: 0;
+}
+
+.concept-title {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--heading);
+  line-height: 1.3;
+  margin-bottom: 0.35rem;
+  letter-spacing: -0.01em;
+}
+
+.concept-card:hover .concept-title {
+  color: var(--accent);
+}
+
+.concept-topics {
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.concept-topics span {
+  color: var(--border-bright);
+  margin: 0 0.15rem;
+}
+
+/* Path connector line */
+.concept-list {
+  position: relative;
+}
+
+.concept-card {
+  position: relative;
+}
+
+.concept-card::before {
+  content: '';
+  position: absolute;
+  left: calc(1.6rem + 1.25rem);
+  top: -1px;
+  width: 1px;
+  height: calc(100% + 2px);
+  background: var(--border);
+  z-index: 1;
+}
+
+.concept-card:first-child::before {
+  top: 50%;
+  height: 50%;
+}
+
+.concept-card:last-child::before {
+  height: 50%;
+}
+
+@media (max-width: 720px) {
+  .article { padding: 2rem 0.75rem 4rem; }
+  h1 { font-size: 1.8rem; }
+  .blog-card { padding: 1.3rem 1.2rem; }
+  .blog-title { font-size: 1.15rem; }
+  .concept-card { grid-template-columns: 2rem 1fr; gap: 0 1rem; padding: 1.1rem 1.2rem; }
+  .concept-num { font-size: 1.2rem; }
+}
+</style>
+</head>
+<body>
+<div class="article">
+
+<header>
+  <h1>Project <span class="chimera">Chimera</span></h1>
+  <p class="subtitle">
+    AI &amp; ML documentation for a deterministic tactical combat sim —
+    neural ability evaluation, transformer decision heads, self-play RL,
+    and the training infrastructure behind it all.
+  </p>
+</header>
+
+<div class="section">
+  <div class="section-label">Dev Log</div>
+
+  <a href="OLD/blog_impala_v4.html" class="blog-card">
+    <div class="blog-date">2026-03-15</div>
+    <div class="blog-title">IMPALA V4: Behavioral Embeddings, V-Trace, and a SHM Bug</div>
+    <div class="blog-desc">
+      4,096 parallel sims, V-Trace off-policy correction, and a shared memory
+      alignment bug that silently corrupted gradients for two weeks.
+    </div>
+    <div class="tags">
+      <span class="tag">IMPALA</span>
+      <span class="tag">V-Trace</span>
+      <span class="tag">shared memory</span>
+      <span class="tag">behavioral embeddings</span>
+    </div>
+  </a>
+</div>
+
+<div class="section">
+  <div class="section-label">ML Concepts</div>
+
+  <div class="concept-list">
+    <a href="OLD/concepts_foundations.html" class="concept-card">
+      <div class="concept-num">01</div>
+      <div class="concept-body">
+        <div class="concept-title">Foundations</div>
+        <div class="concept-topics">
+          Neural networks <span>&middot;</span>
+          gradient descent <span>&middot;</span>
+          loss functions <span>&middot;</span>
+          batch / epoch / LR <span>&middot;</span>
+          overfitting <span>&middot;</span>
+          normalization
+        </div>
+      </div>
+    </a>
+
+    <a href="OLD/concepts_math.html" class="concept-card">
+      <div class="concept-num">02</div>
+      <div class="concept-body">
+        <div class="concept-title">Math</div>
+        <div class="concept-topics">
+          Probability <span>&middot;</span>
+          expectation <span>&middot;</span>
+          log probability <span>&middot;</span>
+          entropy <span>&middot;</span>
+          KL divergence <span>&middot;</span>
+          dot product <span>&middot;</span>
+          matrix multiplication <span>&middot;</span>
+          cosine similarity <span>&middot;</span>
+          EMA
+        </div>
+      </div>
+    </a>
+
+    <a href="OLD/concepts_architecture.html" class="concept-card">
+      <div class="concept-num">03</div>
+      <div class="concept-body">
+        <div class="concept-title">Architecture</div>
+        <div class="concept-topics">
+          Tokenization <span>&middot;</span>
+          residual connections <span>&middot;</span>
+          autoencoders <span>&middot;</span>
+          latent spaces
+        </div>
+      </div>
+    </a>
+
+    <a href="OLD/concepts_attention.html" class="concept-card">
+      <div class="concept-num">04</div>
+      <div class="concept-body">
+        <div class="concept-title">Attention</div>
+        <div class="concept-topics">
+          Self-attention <span>&middot;</span>
+          cross-attention <span>&middot;</span>
+          logits &amp; softmax <span>&middot;</span>
+          masked language modeling <span>&middot;</span>
+          scaled dot-product attention
+        </div>
+      </div>
+    </a>
+
+    <a href="OLD/concepts_rl_foundations.html" class="concept-card">
+      <div class="concept-num">05</div>
+      <div class="concept-body">
+        <div class="concept-title">RL Foundations</div>
+        <div class="concept-topics">
+          Actor-critic <span>&middot;</span>
+          value &amp; Q-functions <span>&middot;</span>
+          on-policy vs off-policy <span>&middot;</span>
+          reward shaping <span>&middot;</span>
+          replay buffer
+        </div>
+      </div>
+    </a>
+
+    <a href="OLD/concepts_rl_algorithms.html" class="concept-card">
+      <div class="concept-num">06</div>
+      <div class="concept-body">
+        <div class="concept-title">RL Algorithms</div>
+        <div class="concept-topics">
+          REINFORCE <span>&middot;</span>
+          PPO <span>&middot;</span>
+          IMPALA &amp; V-Trace <span>&middot;</span>
+          SAC
+        </div>
+      </div>
+    </a>
+  </div>
+</div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `docs/index.html` as a landing page / table of contents for GitHub Pages
- Dev Log section with IMPALA V4 blog post card (date, description, tags)
- ML Concepts section as a numbered learning path (01–06): Foundations → Math → Architecture → Attention → RL Foundations → RL Algorithms
- Updates `docs/OLD/concepts.html` back-link to point to new index

## Test plan
- [ ] Verify GitHub Pages serves the new index at the root
- [ ] Confirm all links to `OLD/*.html` pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)