### PR TITLE
Add observe verb to .ability lowering

### DIFF
--- a/crates/dsl_compiler/src/ability_lower.rs
+++ b/crates/dsl_compiler/src/ability_lower.rs
@@ -1658,6 +1658,18 @@ fn lower_effect_stmt(stmt: &EffectStmt) -> Result<EffectOp, LowerError> {
                 selector: TargetSelector::Caster,
             })
         }
+        // Wave 3 phase 3.5 — Theory-of-Mind `observe` verb. Single
+        // positional `<id:u8>` arg (agent slot id) — the future-extension
+        // `target_observer` byte; today only `0` (self) is wired engine-
+        // side. Engine op is `EffectOp::Observe { target_observer: u8 }`
+        // (kind=33). Out-of-range ids clamp into 0..=255 to match the
+        // `summon`/`harvest` u8/u16 cast precedent rather than reject.
+        "observe" => {
+            let id_f = require_number_arg(stmt, 0)?;
+            require_arity(stmt, 1)?;
+            let target_observer = id_f.round().clamp(0.0, u8::MAX as f32) as u8;
+            Ok(EffectOp::Observe { target_observer })
+        }
         _ => Err(LowerError::UnknownEffectVerb {
             verb:       stmt.verb.clone(),
             span:       stmt.span,

--- a/crates/dsl_compiler/tests/ability_lower.rs
+++ b/crates/dsl_compiler/tests/ability_lower.rs
@@ -381,6 +381,26 @@ fn target_ground_lowers_to_target_mode_kind_ground() {
     assert!(!prog.gate.hostile_only);
 }
 
+// ---------------------------------------------------------------------------
+// Wave 3 phase 3.5 — Theory-of-Mind `observe` verb. Single positional
+// `<id:u8>` arg (agent slot id) → `EffectOp::Observe { target_observer }`.
+// Mirrors `dash`'s single-positional shape; engine op kind = 33.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lowers_observe() {
+    let src = "ability Spy { target: self cooldown: 1s observe 7 }";
+    let file = parse_ability_file(src).expect("parser");
+    let prog = lower_ability_decl(&file.abilities[0]).expect("lowering");
+    assert_eq!(prog.effects.len(), 1);
+    match prog.effects[0] {
+        EffectOp::Observe { target_observer } => {
+            assert_eq!(target_observer, 7, "observe id payload");
+        }
+        ref other => panic!("expected Observe; got {other:?}"),
+    }
+}
+
 #[test]
 fn unknown_verb_is_rejected() {
     // `whirl` isn't in the Wave 1.6 catalog. (Wave 1.0 parser captures


### PR DESCRIPTION
## Summary
- Adds the `observe <id>` arm to `lower_effect_stmt` so the .ability DSL surfaces the Theory-of-Mind `EffectOp::Observe { target_observer: u8 }` (kind=33) that the engine apply/packed/dispatch path already wires.
- Mirrors `dash`'s single-positional shape; the u8 cast follows the `summon`/`harvest` clamp precedent (round + clamp into 0..=255).
- Adds one unit test (`lowers_observe`) pinning `observe 7` -> `EffectOp::Observe { target_observer: 7 }`.

## Test plan
- [x] `cargo test -p dsl_compiler --release` (all 778+ tests pass)
- [x] `cargo test -p dsl_compiler --test lol_corpus_lowering --release` (172 LoL .ability files still parse + lower)
- [x] `cargo test -p dsl_compiler --release --test ability_lower` includes new `lowers_observe`

Behavioral pin (round-trip apply -> chronicle) is out of scope for this unit per the wave brief.

Generated with [Claude Code](https://claude.com/claude-code)