### PR TITLE
Add disguise verb to .ability lowering

### DIFF
--- a/assets/ability_test/spy_network/Disguise.ability
+++ b/assets/ability_test/spy_network/Disguise.ability
@@ -2,23 +2,22 @@
 // commoner for the test horizon. The verb body in
 // `assets/sim/spy_network.sim` does NOT use apply_ability dispatch —
 // it emits the engine-aliased `EffectDisguiseApplied` chronicle
-// (kind=67) directly. The ability lowers via the existing surface
-// vocabulary (`damage 0`) purely so the registry-binding check has
-// a slot to pin; the real semantics live in the .sim verb body
-// (which mirrors tom_probe.sim's ApplyDisguise consumer rule).
+// (kind=67) directly. The .ability slot below pins the registry
+// binding for the verb dispatch; the real chronicle write still
+// lives in the .sim verb body (mirroring tom_probe.sim's
+// ApplyDisguise consumer rule).
 //
-// `damage 0` is intentional: the .ability lowering doesn't ship a
-// surface verb for `disguise <fake_type> for <duration>` (the
-// `EffectOp::Disguise` engine variant exists with full GPU dispatcher
-// support, but `dsl_compiler::ability_lower::lower_effect_stmt` has
-// no `"disguise"` arm). Per the task constraints, no new lowering
-// surface — the .ability file declares the slot, the .sim verb does
-// the real chronicle write.
+// Wave 3 ToM Phase 4 added the `disguise <fake_type> for <duration>`
+// surface arm to `dsl_compiler::ability_lower::lower_effect_stmt`,
+// so the slot now pins to the matching `EffectOp::Disguise` variant.
+// `fake_type=3` mirrors the creature_type ordinal for commoner per
+// `assets/sim/spy_network.sim` (type_spy=1, type_noble=2, commoner=3);
+// `for 20s` matches the test horizon in the .sim's duration constant.
 
 ability Disguise {
     target: self
     cooldown: 20s
     hint: utility
 
-    damage 0 [UTILITY: 100]
+    disguise 3 for 20s [UTILITY: 100]
 }

--- a/crates/dsl_compiler/src/ability_lower.rs
+++ b/crates/dsl_compiler/src/ability_lower.rs
@@ -1724,6 +1724,24 @@ fn lower_effect_stmt(stmt: &EffectStmt) -> Result<EffectOp, LowerError> {
             let target_observer = id_f.round().clamp(0.0, u8::MAX as f32) as u8;
             Ok(EffectOp::Observe { target_observer })
         }
+        // Wave 3 ToM Phase 4 — `disguise <fake_type> for <duration>`
+        // (spy_network surface). Mirrors `stun`'s shape: one positional
+        // arg + duration-bearing `for` modifier. The positional is a u8
+        // ordinal naming the creature_type the caster publicly poses as
+        // (e.g. `disguise 3 for 20s` for commoner). Apply handlers write
+        // `disguise_fake_type` + `disguise_expires_at_tick` SoA cells;
+        // observers see the fake type until the tick budget elapses.
+        "disguise" => {
+            let fake_type = require_number_arg(stmt, 0)?
+                .round()
+                .clamp(0.0, u8::MAX as f32) as u8;
+            let (dur, arity) = extract_duration(stmt, 1, 2)?;
+            require_arity(stmt, arity)?;
+            Ok(EffectOp::Disguise {
+                fake_type,
+                duration_ticks: duration_to_ticks(dur),
+            })
+        }
         _ => Err(LowerError::UnknownEffectVerb {
             verb:       stmt.verb.clone(),
             span:       stmt.span,
@@ -1869,6 +1887,9 @@ fn is_duration_bearing_verb(verb: &str) -> bool {
         // charm/grounded/suppress have stun-shape (positional duration);
         // reflect has lifesteal-shape (fraction + duration).
         | "charm" | "grounded" | "suppress" | "reflect"
+        // Wave 3 ToM Phase 4 — `disguise <fake_type> for <duration>`
+        // (spy_network surface). Stun-shape with a u8 ordinal positional.
+        | "disguise"
     )
 }
 

--- a/crates/dsl_compiler/tests/ability_lower.rs
+++ b/crates/dsl_compiler/tests/ability_lower.rs
@@ -446,3 +446,28 @@ ability TooMany {
         other => panic!("expected BudgetExceeded; got {other:?}"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Wave 3 ToM Phase 4 — `disguise <fake_type> for <duration>` (spy_network).
+// Mirrors the `stun for <duration>` lowering shape but carries a u8
+// ordinal positional naming the creature_type the caster publicly poses
+// as. The `for`-modifier is the duration source (extract_duration's
+// stun-shape is_duration_bearing_verb path).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lower_disguise_for_duration() {
+    // commoner=3 per `assets/sim/spy_network.sim`'s creature_type table;
+    // 10s @ 100ms/tick = 100 ticks.
+    let src = "ability Spy { target: self cooldown: 20s disguise 3 for 10s }";
+    let file = parse_ability_file(src).expect("parser");
+    let prog = lower_ability_decl(&file.abilities[0]).expect("disguise must lower");
+    assert_eq!(prog.effects.len(), 1);
+    match &prog.effects[0] {
+        EffectOp::Disguise { fake_type, duration_ticks } => {
+            assert_eq!(*fake_type, 3, "fake_type ordinal mirrors creature_type=3 (commoner)");
+            assert_eq!(*duration_ticks, 100, "10s @ 100ms/tick = 100 ticks");
+        }
+        other => panic!("expected Disguise(fake_type=3, ticks=100); got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the `disguise <fake_type> for <duration>` arm to `lower_effect_stmt` in `crates/dsl_compiler/src/ability_lower.rs`, lowering to `EffectOp::Disguise { fake_type: u8, duration_ticks: u32 }` (engine variant 36, already wired with full GPU dispatcher support).
- Mirrors `stun`'s shape: one positional `u8` ordinal + duration via the `for` modifier (also added to `is_duration_bearing_verb`).
- Replaces the `damage 0` placeholder in `assets/ability_test/spy_network/Disguise.ability` with the real `disguise 3 for 20s` body (commoner=3 per the spy_network.sim creature_type table).

## Test plan
- [x] `cargo test -p dsl_compiler --release` — all 778+ tests pass, including the new `lower_disguise_for_duration` unit test that pins `disguise 3 for 10s` → `EffectOp::Disguise { fake_type: 3, duration_ticks: 100 }`.
- [x] `cargo test -p dsl_compiler --test lol_corpus_lowering --release` — 172 LoL `.ability` files still parse + lower cleanly (safety check; none use `disguise`).
- [ ] Behavioral pin deferred to unit 8 per the coordination brief.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>