### PR TITLE
feat(dsl): vec3 strict f32 + surface f32/u32/i32 casts

### DIFF
--- a/crates/dsl_ast/src/ir.rs
+++ b/crates/dsl_ast/src/ir.rs
@@ -1163,6 +1163,21 @@ pub enum Builtin {
     /// All three operands are F32; result is Vec3F32. The lone vec3
     /// literal form supported by the DSL today.
     Vec3,
+    /// `f32(x)` — explicit cast of a numeric scalar to `f32`. Source
+    /// must be `i32` or `u32`; a same-type cast is rejected at lowering
+    /// so authors can't accidentally mask a type-inference mistake.
+    /// Lowers to `BuiltinId::AsF32(<src>)` which emits WGSL `f32(<arg>)`.
+    F32Cast,
+    /// `u32(x)` — explicit cast of a numeric scalar to `u32`. Source
+    /// must be `f32` (lossy truncation toward zero) or `i32` (lossy
+    /// when negative). Lowers to `BuiltinId::AsU32(<src>)` which emits
+    /// WGSL `u32(<arg>)`.
+    U32Cast,
+    /// `i32(x)` — explicit cast of a numeric scalar to `i32`. Source
+    /// must be `f32` (truncation toward zero) or `u32` (high bit may
+    /// flip sign). Lowers to `BuiltinId::AsI32(<src>)` which emits
+    /// WGSL `i32(<arg>)`.
+    I32Cast,
 }
 
 impl Builtin {
@@ -1189,6 +1204,9 @@ impl Builtin {
             Builtin::Sqrt => "sqrt",
             Builtin::SaturatingAdd => "saturating_add",
             Builtin::Vec3 => "vec3",
+            Builtin::F32Cast => "f32",
+            Builtin::U32Cast => "u32",
+            Builtin::I32Cast => "i32",
         }
     }
 
@@ -1200,6 +1218,7 @@ impl Builtin {
             Builtin::Entity => Some(1),
             Builtin::Clamp => Some(3),
             Builtin::Vec3 => Some(3),
+            Builtin::F32Cast | Builtin::U32Cast | Builtin::I32Cast => Some(1),
             Builtin::Abs
             | Builtin::Floor
             | Builtin::Ceil

--- a/crates/dsl_ast/src/resolve.rs
+++ b/crates/dsl_ast/src/resolve.rs
@@ -86,6 +86,14 @@ mod stdlib {
         symbols.builtins.insert("saturating_add".into(), Builtin::SaturatingAdd);
         // Vec3 constructor. Three-arg call returning Vec3F32; operands are F32.
         symbols.builtins.insert("vec3".into(), Builtin::Vec3);
+        // Explicit numeric casts: `f32(x)` / `u32(x)` / `i32(x)`. The
+        // names overlap with the type-name entries in `stdlib_types`;
+        // resolution disambiguates structurally — `f32` as a *call*
+        // target resolves to the builtin (here), `f32` as a bare type
+        // position resolves through `stdlib_types`.
+        symbols.builtins.insert("f32".into(), Builtin::F32Cast);
+        symbols.builtins.insert("u32".into(), Builtin::U32Cast);
+        symbols.builtins.insert("i32".into(), Builtin::I32Cast);
 
         // Typed namespaces. Each has its own field / method schema below.
         for (name, id) in [

--- a/crates/dsl_ast/tests/cast_and_vec3_strict.rs
+++ b/crates/dsl_ast/tests/cast_and_vec3_strict.rs
@@ -1,0 +1,122 @@
+//! Surface-form tests for `vec3(x, y, z)` strict-f32 typing and
+//! explicit `f32(...)` / `u32(...)` / `i32(...)` casts.
+//!
+//! These tests exercise the parser → resolver pipeline only — the CG
+//! lowering of the same constructs is covered by inline tests in
+//! `crates/dsl_compiler/src/cg/lower/expr.rs::tests`. Strict-f32
+//! enforcement on `vec3` happens at CG lowering, not at resolve time,
+//! so the resolver shape is unchanged from before.
+
+use dsl_ast::compile;
+use dsl_ast::ir::{Builtin, IrExpr, IrStmt};
+
+/// Wrap a single statement in a `physics` body so we have a complete
+/// `.sim` source the parser + resolver will accept. Returns the
+/// resolved Compilation. The fixture defines a single `Tick` event
+/// and a `Probe` entity with a `pos: vec3` field so the body can
+/// reference `self.pos` if needed.
+fn compile_physics_body(stmt_src: &str) -> dsl_ast::Compilation {
+    let src = format!(
+        "event Tick {{ }}\n\
+         entity Probe : Agent {{ pos: vec3, }}\n\
+         physics P @phase(per_agent) {{\n\
+           on Tick {{}} where (self.alive) {{\n\
+             {stmt_src}\n\
+           }}\n\
+         }}\n"
+    );
+    compile(&src).unwrap_or_else(|e| panic!("compile failed for body `{stmt_src}`:\n{src}\nerror: {e}"))
+}
+
+/// Pull the first `Let` statement out of the resolved physics body and
+/// return the let's value expression.
+fn first_let_value(comp: &dsl_ast::Compilation) -> &IrExpr {
+    let physics = comp
+        .physics
+        .first()
+        .expect("expected at least one physics rule");
+    let handler = physics
+        .handlers
+        .first()
+        .expect("expected at least one handler");
+    let stmt = handler
+        .body
+        .first()
+        .expect("expected at least one body stmt");
+    match stmt {
+        IrStmt::Let { value, .. } => &value.kind,
+        other => panic!("expected first body stmt to be Let, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// f32 / u32 / i32 surface casts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn f32_cast_lexes_and_parses() {
+    let comp = compile_physics_body("let x = f32(1);");
+    match first_let_value(&comp) {
+        IrExpr::BuiltinCall(Builtin::F32Cast, args) => {
+            assert_eq!(args.len(), 1, "f32(...) takes one arg");
+        }
+        other => panic!("expected BuiltinCall(F32Cast, _), got {other:?}"),
+    }
+}
+
+#[test]
+fn u32_cast_lexes_and_parses() {
+    let comp = compile_physics_body("let x = u32(1.5);");
+    match first_let_value(&comp) {
+        IrExpr::BuiltinCall(Builtin::U32Cast, args) => {
+            assert_eq!(args.len(), 1, "u32(...) takes one arg");
+        }
+        other => panic!("expected BuiltinCall(U32Cast, _), got {other:?}"),
+    }
+}
+
+#[test]
+fn i32_cast_lexes_and_parses() {
+    let comp = compile_physics_body("let x = i32(1.5);");
+    match first_let_value(&comp) {
+        IrExpr::BuiltinCall(Builtin::I32Cast, args) => {
+            assert_eq!(args.len(), 1, "i32(...) takes one arg");
+        }
+        other => panic!("expected BuiltinCall(I32Cast, _), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// vec3 strict-f32 — surface parse always succeeds; CG lowering enforces.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vec3_with_f32_literals_parses() {
+    let comp = compile_physics_body("let x = vec3(1.0, 2.0, 3.0);");
+    match first_let_value(&comp) {
+        IrExpr::BuiltinCall(Builtin::Vec3, args) => {
+            assert_eq!(args.len(), 3, "vec3(...) takes three args");
+        }
+        other => panic!("expected BuiltinCall(Vec3, _), got {other:?}"),
+    }
+}
+
+#[test]
+fn f32_cast_inside_vec3_parses() {
+    // Resolves to a Vec3 builtin whose three children are each an
+    // F32Cast builtin. CG lowering of the same shape is covered by
+    // a sibling inline test in dsl_compiler.
+    let comp = compile_physics_body("let x = vec3(f32(1), f32(2), f32(3));");
+    let val = first_let_value(&comp);
+    let args = match val {
+        IrExpr::BuiltinCall(Builtin::Vec3, args) => args,
+        other => panic!("expected BuiltinCall(Vec3, _), got {other:?}"),
+    };
+    assert_eq!(args.len(), 3);
+    for (i, a) in args.iter().enumerate() {
+        match &a.value.kind {
+            IrExpr::BuiltinCall(Builtin::F32Cast, _) => {}
+            other => panic!("vec3 arg[{i}]: expected BuiltinCall(F32Cast, _), got {other:?}"),
+        }
+    }
+}

--- a/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
+++ b/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
@@ -810,6 +810,11 @@ fn builtin_name(id: BuiltinId) -> String {
         // pins the source type for typing); WGSL infers the source
         // from the argument's type.
         AsF32(_) => "f32".to_string(),
+        // Sibling explicit casts to `u32` / `i32`. WGSL has native
+        // `u32(...)` / `i32(...)` constructors; same emit-as-is
+        // treatment as `AsF32`.
+        AsU32(_) => "u32".to_string(),
+        AsI32(_) => "i32".to_string(),
     }
 }
 

--- a/crates/dsl_compiler/src/cg/expr.rs
+++ b/crates/dsl_compiler/src/cg/expr.rs
@@ -539,7 +539,21 @@ pub enum BuiltinId {
     /// at construction by the only call site (the lowering helper).
     /// Closes Gap #2 from
     /// `docs/superpowers/notes/2026-05-04-pair_scoring_probe.md`.
+    /// Also reachable from the surface DSL via `f32(x)`.
     AsF32(NumericTy),
+    /// `u32(x)` where `x: F32 | I32` — explicit cast of a numeric
+    /// scalar to `u32`. Lowers to WGSL `u32(<arg>)`. The carried
+    /// [`NumericTy`] is the SOURCE type (`F32` or `I32`); `U32` is
+    /// rejected (no-op cast) at the only construction site. Reached
+    /// only from the surface DSL `u32(...)` cast; no implicit
+    /// insertion site today (no implicit lossy conversions).
+    AsU32(NumericTy),
+    /// `i32(x)` where `x: F32 | U32` — explicit cast of a numeric
+    /// scalar to `i32`. Lowers to WGSL `i32(<arg>)`. The carried
+    /// [`NumericTy`] is the SOURCE type (`F32` or `U32`); `I32` is
+    /// rejected (no-op cast) at the only construction site. Reached
+    /// only from the surface DSL `i32(...)` cast.
+    AsI32(NumericTy),
 }
 
 /// Typed signature of a builtin call. `args` is the list of expected
@@ -598,6 +612,14 @@ impl BuiltinId {
                 args: vec![t.cg_ty()],
                 result: CgTy::F32,
             },
+            AsU32(t) => BuiltinSignature::Fixed {
+                args: vec![t.cg_ty()],
+                result: CgTy::U32,
+            },
+            AsI32(t) => BuiltinSignature::Fixed {
+                args: vec![t.cg_ty()],
+                result: CgTy::I32,
+            },
         }
     }
 
@@ -622,6 +644,8 @@ impl BuiltinId {
             ViewCall { view } => format!("view_call.#{}", view.0),
             Vec3Ctor => "vec3".to_string(),
             AsF32(t) => format!("as_f32.{}", t.label()),
+            AsU32(t) => format!("as_u32.{}", t.label()),
+            AsI32(t) => format!("as_i32.{}", t.label()),
         }
     }
 }

--- a/crates/dsl_compiler/src/cg/lower/error.rs
+++ b/crates/dsl_compiler/src/cg/lower/error.rs
@@ -206,6 +206,37 @@ pub enum LoweringError {
         span: Span,
     },
 
+    /// `vec3(...)` was called with a non-`f32` component. The Vec3
+    /// constructor requires strict `f32` typing on every component.
+    /// Distinct from [`Self::IllTypedExpression`] so the diagnostic
+    /// can name the offending component index and suggest the
+    /// `f32(...)` cast or float-literal form (`1.0` instead of `1`).
+    Vec3RequiresF32 {
+        component_index: u8,
+        got: CgTy,
+        span: Span,
+    },
+
+    /// An explicit numeric cast (`f32(x)` / `u32(x)` / `i32(x)`) was
+    /// applied to a value already of the target type. Disallowed so a
+    /// no-op cast doesn't sneak in silently — typical author error is
+    /// forgetting whether the source is signed or unsigned.
+    CastNoOp {
+        target: CgTy,
+        span: Span,
+    },
+
+    /// An explicit numeric cast (`f32(x)` / `u32(x)` / `i32(x)`) was
+    /// applied to a non-numeric value (e.g. `f32(true)` or
+    /// `u32(some_vec3)`). The DSL surface only supports scalar
+    /// numeric conversions; casting from booleans / aggregate types
+    /// is intentionally out of scope.
+    CastNonNumericOperand {
+        target: CgTy,
+        got: CgTy,
+        span: Span,
+    },
+
     /// A `Local` reference whose name isn't `self` (the only local the
     /// expression lowering binds to a CG concept today). Other locals —
     /// `target`, event-pattern bindings, fold binders — light up as the
@@ -1014,6 +1045,27 @@ impl fmt::Display for LoweringError {
                 span.end,
                 operand_index,
                 got
+            ),
+            LoweringError::Vec3RequiresF32 {
+                component_index,
+                got,
+                span,
+            } => write!(
+                f,
+                "lowering: vec3(...) at {}..{} component[{}] is `{}`, expected `f32` — \
+                 wrap with `f32(...)` or use a float literal (e.g. `1.0` instead of `1`)",
+                span.start, span.end, component_index, got
+            ),
+            LoweringError::CastNoOp { target, span } => write!(
+                f,
+                "lowering: explicit `{}(...)` cast at {}..{} is a no-op (operand is already `{}`); \
+                 remove the cast",
+                target, span.start, span.end, target
+            ),
+            LoweringError::CastNonNumericOperand { target, got, span } => write!(
+                f,
+                "lowering: explicit `{}(...)` cast at {}..{} requires a numeric operand, got `{}`",
+                target, span.start, span.end, got
             ),
             LoweringError::UnsupportedLocalBinding { name, span } => write!(
                 f,

--- a/crates/dsl_compiler/src/cg/lower/expr.rs
+++ b/crates/dsl_compiler/src/cg/lower/expr.rs
@@ -2025,10 +2025,10 @@ fn lower_builtin_call(
             // types at type-check time; the lowering just records the
             // CgExpr::Builtin shape with the three arg ids.
             expect_arity(builtin, 3, args.len(), span)?;
-            for arg_ty in &arg_tys {
+            for (idx, arg_ty) in arg_tys.iter().enumerate() {
                 if *arg_ty != CgTy::F32 {
-                    return Err(LoweringError::IllTypedExpression {
-                        expected: CgTy::F32,
+                    return Err(LoweringError::Vec3RequiresF32 {
+                        component_index: idx as u8,
                         got: *arg_ty,
                         span,
                     });
@@ -2044,11 +2044,87 @@ fn lower_builtin_call(
                 span,
             )
         }
+        Builtin::F32Cast => lower_numeric_cast(
+            builtin,
+            CgTy::F32,
+            BuiltinId::AsF32,
+            &arg_ids,
+            &arg_tys,
+            args,
+            span,
+            ctx,
+        ),
+        Builtin::U32Cast => lower_numeric_cast(
+            builtin,
+            CgTy::U32,
+            BuiltinId::AsU32,
+            &arg_ids,
+            &arg_tys,
+            args,
+            span,
+            ctx,
+        ),
+        Builtin::I32Cast => lower_numeric_cast(
+            builtin,
+            CgTy::I32,
+            BuiltinId::AsI32,
+            &arg_ids,
+            &arg_tys,
+            args,
+            span,
+            ctx,
+        ),
         // Already filtered above.
         Builtin::Forall | Builtin::Exists | Builtin::Count | Builtin::Sum => {
             unreachable!("filtered earlier in lower_builtin_call")
         }
     }
+}
+
+/// Lower an explicit numeric cast (`f32(x)` / `u32(x)` / `i32(x)`).
+///
+/// All three share the same shape: arity 1, source must be a different
+/// numeric type than the target (no-op casts are rejected so authors
+/// don't accidentally mask a type-inference mistake), result type is
+/// the target. Lowers to `CgExpr::Builtin { fn_id: AsF32 | AsU32 |
+/// AsI32 }` per the `id_ctor` callback.
+#[allow(clippy::too_many_arguments)]
+fn lower_numeric_cast(
+    builtin: Builtin,
+    target: CgTy,
+    id_ctor: fn(NumericTy) -> BuiltinId,
+    arg_ids: &[CgExprId],
+    arg_tys: &[CgTy],
+    args: &[IrCallArg],
+    span: Span,
+    ctx: &mut LoweringCtx<'_>,
+) -> Result<CgExprId, LoweringError> {
+    expect_arity(builtin, 1, args.len(), span)?;
+    let src_ty = arg_tys[0];
+    let src = match src_ty {
+        CgTy::F32 => NumericTy::F32,
+        CgTy::U32 => NumericTy::U32,
+        CgTy::I32 => NumericTy::I32,
+        _ => {
+            return Err(LoweringError::CastNonNumericOperand {
+                target,
+                got: src_ty,
+                span,
+            });
+        }
+    };
+    if src.cg_ty() == target {
+        return Err(LoweringError::CastNoOp { target, span });
+    }
+    add(
+        ctx,
+        CgExpr::Builtin {
+            fn_id: id_ctor(src),
+            args: arg_ids.to_vec(),
+            ty: target,
+        },
+        span,
+    )
 }
 
 /// Tag distinguishing the three pairwise-numeric AST builtins that
@@ -5655,5 +5731,201 @@ mod tests {
         });
         let err = lower_with_catalog(&ast).unwrap_err();
         assert!(matches!(err, LoweringError::IllTypedExpression { .. }));
+    }
+
+    // ---- Vec3 strict-f32 typing ----
+
+    #[test]
+    fn vec3_with_three_f32_literals_lowers() {
+        // vec3(1.0, 2.0, 3.0) — strict-f32 form, parses + lowers cleanly.
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::Vec3,
+            vec![
+                arg(node(IrExpr::LitFloat(1.0))),
+                arg(node(IrExpr::LitFloat(2.0))),
+                arg(node(IrExpr::LitFloat(3.0))),
+            ],
+        ));
+        let s = lower_to_string(&ast).unwrap();
+        assert_eq!(
+            s,
+            "(builtin.vec3 (lit 1.0f32) (lit 2.0f32) (lit 3.0f32))",
+            "expected vec3(...) to lower as builtin.vec3, got {s:?}"
+        );
+    }
+
+    #[test]
+    fn vec3_with_int_literals_errors_with_helpful_message() {
+        // Int literals widen to U32 in CG IR; the strict Vec3 typing
+        // rule rejects the first non-f32 component with a helpful
+        // Vec3RequiresF32 diagnostic.
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::Vec3,
+            vec![
+                arg(node(IrExpr::LitInt(1))),
+                arg(node(IrExpr::LitInt(2))),
+                arg(node(IrExpr::LitInt(3))),
+            ],
+        ));
+        let err = lower_to_string(&ast).unwrap_err();
+        match err {
+            LoweringError::Vec3RequiresF32 {
+                component_index,
+                got,
+                ..
+            } => {
+                assert_eq!(component_index, 0, "first non-f32 component is index 0");
+                assert_eq!(got, CgTy::U32);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vec3_diagnostic_renders_with_f32_hint() {
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::Vec3,
+            vec![
+                arg(node(IrExpr::LitFloat(1.0))),
+                arg(node(IrExpr::LitInt(2))),
+                arg(node(IrExpr::LitFloat(3.0))),
+            ],
+        ));
+        let err = lower_to_string(&ast).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("vec3"),
+            "diagnostic should name vec3, got: {msg}"
+        );
+        assert!(
+            msg.contains("f32(...)"),
+            "diagnostic should suggest f32(...) cast, got: {msg}"
+        );
+    }
+
+    // ---- Explicit numeric casts ----
+
+    #[test]
+    fn f32_cast_of_u32_literal_lowers() {
+        // f32(5) — int literal lowers to U32; F32Cast wraps it as
+        // BuiltinId::AsF32(U32) emitting WGSL `f32(5u)`.
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::F32Cast,
+            vec![arg(node(IrExpr::LitInt(5)))],
+        ));
+        let s = lower_to_string(&ast).unwrap();
+        assert_eq!(
+            s, "(builtin.as_f32.u32 (lit 5u32))",
+            "expected f32(<u32>) to lower as builtin.as_f32.u32, got {s:?}"
+        );
+    }
+
+    #[test]
+    fn f32_cast_of_i32_literal_lowers() {
+        // f32(-3) — negative int picks I32; F32Cast wraps it as
+        // BuiltinId::AsF32(I32).
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::F32Cast,
+            vec![arg(node(IrExpr::LitInt(-3)))],
+        ));
+        let s = lower_to_string(&ast).unwrap();
+        assert_eq!(s, "(builtin.as_f32.i32 (lit -3i32))");
+    }
+
+    #[test]
+    fn u32_cast_of_f32_literal_lowers() {
+        // u32(1.5) — F32 source; lowers as BuiltinId::AsU32(F32).
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::U32Cast,
+            vec![arg(node(IrExpr::LitFloat(1.5)))],
+        ));
+        let s = lower_to_string(&ast).unwrap();
+        assert_eq!(s, "(builtin.as_u32.f32 (lit 1.5f32))");
+    }
+
+    #[test]
+    fn i32_cast_of_f32_literal_lowers() {
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::I32Cast,
+            vec![arg(node(IrExpr::LitFloat(2.5)))],
+        ));
+        let s = lower_to_string(&ast).unwrap();
+        assert_eq!(s, "(builtin.as_i32.f32 (lit 2.5f32))");
+    }
+
+    #[test]
+    fn f32_cast_of_f32_value_is_noop_rejected() {
+        // f32(1.5) — no-op cast; surfaces as CastNoOp so authors can't
+        // mask a type-inference mistake.
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::F32Cast,
+            vec![arg(node(IrExpr::LitFloat(1.5)))],
+        ));
+        let err = lower_to_string(&ast).unwrap_err();
+        match err {
+            LoweringError::CastNoOp { target, .. } => {
+                assert_eq!(target, CgTy::F32);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn f32_cast_of_bool_rejected() {
+        // f32(true) — non-numeric source; surfaces as CastNonNumericOperand.
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::F32Cast,
+            vec![arg(node(IrExpr::LitBool(true)))],
+        ));
+        let err = lower_to_string(&ast).unwrap_err();
+        match err {
+            LoweringError::CastNonNumericOperand { target, got, .. } => {
+                assert_eq!(target, CgTy::F32);
+                assert_eq!(got, CgTy::Bool);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn f32_cast_arity_mismatch_rejected() {
+        // f32(1, 2) — two args; surfaces as BuiltinArityMismatch.
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::F32Cast,
+            vec![
+                arg(node(IrExpr::LitInt(1))),
+                arg(node(IrExpr::LitInt(2))),
+            ],
+        ));
+        let err = lower_to_string(&ast).unwrap_err();
+        assert!(
+            matches!(err, LoweringError::BuiltinArityMismatch { .. }),
+            "expected BuiltinArityMismatch, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn f32_cast_inside_vec3_works() {
+        // vec3(f32(1), f32(2), f32(3)) — explicit casts in every slot;
+        // each component lowers to as_f32 then feeds Vec3Ctor.
+        let mk_cast = |v: i64| {
+            node(IrExpr::BuiltinCall(
+                Builtin::F32Cast,
+                vec![arg(node(IrExpr::LitInt(v)))],
+            ))
+        };
+        let ast = node(IrExpr::BuiltinCall(
+            Builtin::Vec3,
+            vec![arg(mk_cast(1)), arg(mk_cast(2)), arg(mk_cast(3))],
+        ));
+        let s = lower_to_string(&ast).unwrap();
+        assert_eq!(
+            s,
+            "(builtin.vec3 \
+             (builtin.as_f32.u32 (lit 1u32)) \
+             (builtin.as_f32.u32 (lit 2u32)) \
+             (builtin.as_f32.u32 (lit 3u32)))",
+            "expected vec3(f32(1), f32(2), f32(3)) to lower with three as_f32 children, got {s:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds two DSL ergonomics improvements (task #226):

- **Explicit numeric casts**: `f32(x)` / `u32(x)` / `i32(x)` parse as surface-level cast forms, lower to typed `BuiltinId::AsF32(<src>)` / `AsU32(<src>)` / `AsI32(<src>)` nodes that emit WGSL `f32(...)` / `u32(...)` / `i32(...)`. Same-type casts (`f32(<f32>)`) are rejected with `CastNoOp` so they can't mask a type-inference mistake; non-numeric operands surface as `CastNonNumericOperand`.
- **`vec3` strict-f32 typing**: `vec3(x, y, z)` now requires every component to be `f32`. The previous `IllTypedExpression` rejection is replaced with a richer `Vec3RequiresF32 { component_index, got, span }` diagnostic that names the offending component and suggests the `f32(...)` cast or float-literal fix (`1.0` instead of `1`).

Parser/lowering-only change. Schema_hash unchanged. No `EffectOp` / SoA layout touch.

### Existing fixture migration

Zero existing `.sim` / `.ability` files needed updating. The Vec3 lowering already rejected non-f32 components via `IllTypedExpression`; the only `vec3(int, int, int)` use in the corpus was a single line in `assets/sim/flocking_skirmish.sim` already commented out. All `vec3(...)` call sites in `assets/sim/` use float literals or vec3-component field reads.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test -p dsl_ast --release` (49/49 pass — 5 new tests in `cast_and_vec3_strict.rs`)
- [x] `cargo test -p dsl_compiler --release --lib` (807/807 pass — 9 new inline tests in `cg::lower::expr::tests`)
- [x] `cargo test -p engine --release --test schema_hash` (2/2 pass — schema unchanged)
- [x] `RUST_MIN_STACK=33554432 cargo test -p spy_network_runtime --release --lib` (1/1 pass)
- [x] Spot-checked sibling DSL fixture suites (boids, predator-prey, verb-emit, stress-fixtures-compile, ability-lower) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)