### PR TITLE
docs(spec): audit state.md for drift vs current implementation

### DIFF
--- a/docs/spec/state.md
+++ b/docs/spec/state.md
@@ -3,6 +3,20 @@
 > ⚠️ **Audit 2026-04-26 — scope mismatch:** This catalog covers both per-fight `SimState` (combat engine) **and** the full `WorldState` (campaign / DF-style world sim). The `crates/engine` crate implements only the SoA hot/cold fields under `Agent state`. **Aggregate state (Settlement, RegionState, Faction, GuildState, TradeRoute, ServiceContract, EconomyState, etc.) and World state (VoxelWorld, RegionPlan, NavGrid, FidelityZone, BuildSeed, GroupIndex, etc.) are not implemented in the engine crate** — they live in the `headless_campaign` / `bevy_game` layer (or in legacy worktrees), which the audit did not cover.
 > See `docs/superpowers/notes/2026-04-26-audit-state.md` for the per-section findings (42 ✅ / 18 ⚠️ / 31 ❌ / 7 🤔 / 4 ❓).
 
+> ⚠️ **Audit 2026-05-08 (follow-up):** Two weeks of code work since the
+> 2026-04-26 audit. Rerun against `crates/engine/src/state/mod.rs`,
+> `crates/engine/src/schema_hash.rs`, `crates/engine/.schema_hash`,
+> `crates/dsl_compiler/src/cg/data_handle.rs`, and the chronicle `EventKindId`
+> table. **0 `[CRITICAL]`, 0 `[STATUS-FLIP]`, 5 `[UNDOCUMENTED]`, 0
+> `[MISSING]`, 3 `[STALE]`.** Headlines:
+>
+> - `[UNDOCUMENTED]` Wave 2 piece 1 added `hot_{root,silence,fear,taunt}_expires_at_tick`. Wave 2 piece 4 added `hot_lifesteal_{frac_q8,expires_at_tick}` + `hot_damage_taken_mult_{q8,expires_at_tick}`. Wave 3 ToM Phase 2 added `cold_beliefs: Vec<BoundedMap<AgentId, BeliefState, 8>>` (per-observer, gated by `theory-of-mind` feature). `ability_cooldowns: Vec<[u32; MAX_ABILITIES]>` and `hot_mana` / `hot_max_mana` are also catalog-absent.
+> - `[STALE]` Lift A–D foundation merge (PR #38, commit `7bb0929c`) added `AgentFieldId` variants `BusyUntilTick`, `TravelDestX/Y/Z` and chronicle event ordinals 70–76 (`EffectTravelToApplied=70` … `EffectCreateObligationApplied=76`), but the consumer-side **per-agent SoA columns are not yet allocated** in `SimState`. Doc-comments in `crates/engine/src/cascade/handler.rs` and `crates/engine/src/ability/apply.rs` describe the future-shape (`disguise_expires_at_tick`, `disguise_fake_type`, `busy_until_tick`, `travel_dest_{x,y,z}` columns) — those don't exist in storage today. The catalog correctly omits them.
+> - `[STALE]` ToM `cold_beliefs` is per-observer `BoundedMap`, **not** a flat 6-column SoA. The cascade/apply doc-comments describing "the BeliefState SoA's 6 columns at `[caster_slot * agent_cap + target_slot]`" describe a future-flattened shape that hasn't landed.
+> - `[STALE]` Top-of-file + §Aggregate + §World callouts say missing structs "live in `headless_campaign` / `bevy_game` layer". Neither crate exists in the workspace today — the structs aren't in *any* current crate.
+>
+> See `docs/superpowers/notes/2026-05-08-audit-state-drift.md` for per-item evidence + recommended follow-ups.
+
 Schema-of-record: every SoA field engine code touches, with semantics, writers, and readers.
 
 ## Contents
@@ -43,6 +57,9 @@ Universal entity for any agentic actor (humans, wolves, dragons, goblins). Same 
 **Ground-locked vs volumetric.** Ground-locked types (Human, Elf, Dwarf, Wolf, Goblin) get a post-movement `@phase(post)` cascade snapping `pos.z = surface_height(pos.xy) + creature_height/2` outdoors or `floor_height(pos, building) + creature_height/2` when `inside_building_id` is set. Volumetric types (Dragon, Fish, Bat) skip the snap. `creature_height` derived from `creature_type` config.
 
 #### Combat/Vitality
+
+> ⚠️ **Audit 2026-05-08:** engine-side SoA also carries `hot_mana` / `hot_max_mana` (`state/mod.rs:63-64`, both `Vec<f32>`, init 0.0) which this catalog does not name. Read by the ability cast-gate when `EffectOp` consumers honour the ability's `cost`. See `docs/superpowers/notes/2026-05-08-audit-state-drift.md` U5.
+
 | Field | Type | Meaning | Updated by | Read by |
 |---|---|---|---|---|
 | hp | f32 | Current health | apply_flat (healing/damage), work (eat restores), resting | death check, threat urgency, combat eval |
@@ -87,6 +104,8 @@ Agent → group association.
 
 > 🤔 **Audit 2026-04-26 (spec mismatch):** Spec catalogs `remaining_ms: u32`; implementation stores **absolute expiry tick** in `hot_stun_expires_at_tick` / `hot_slow_expires_at_tick` (Task 143). Per-kind typed payload (Slow{factor}, Buff/Debuff{stat,factor}) is replaced by an opaque `payload_q8: i16`. SmallVec cap=8 (cold), not Vec.
 > See `docs/superpowers/notes/2026-04-26-audit-state.md` and `docs/superpowers/notes/2026-04-26-audit-language-stdlib.md`.
+
+> ⚠️ **Audit 2026-05-08 (additional hot-SoA storage):** Wave 2 piece 1 added four more hot expiry-tick mirrors paired with `hot_stun_expires_at_tick`: `hot_root_expires_at_tick`, `hot_silence_expires_at_tick`, `hot_fear_expires_at_tick`, `hot_taunt_expires_at_tick` (`state/mod.rs:107-110`, all `Vec<u32>`; `0` = never applied / already elapsed). Wave 2 piece 4 added single-slot buff columns `hot_lifesteal_frac_q8: Vec<i16>` + `hot_lifesteal_expires_at_tick: Vec<u32>` and `hot_damage_taken_mult_q8: Vec<i16>` + `hot_damage_taken_mult_expires_at_tick: Vec<u32>` (`state/mod.rs:125-138`; q8 fixed-point, `256 = 1.0×` identity for the multiplier). Stacking semantics tracked in `MEMORY.md` → `project_buff_stacking_rule.md`. None of these eight columns are named at any §AgentSoA catalog row today. See `docs/superpowers/notes/2026-05-08-audit-state-drift.md` U1 + U2.
 
 Temporary state modifier on an entity.
 
@@ -244,6 +263,8 @@ Directional relationship from one NPC toward another (asymmetric).
 > ⚠️ **Audit 2026-04-26:** Feature-gated stub (`#[cfg(feature = "theory-of-mind")]`). `BeliefState` in `engine_data/src/belief.rs` stores observation data (`last_known_pos`, `last_known_hp`, etc.) — **not** the theory-of-mind personality model. Spec's `traits [f32;5]`, `confidence [f32;5]`, and `observation_count` are absent.
 > See `docs/superpowers/notes/2026-04-26-audit-state.md` for detail.
 
+> ⚠️ **Audit 2026-05-08 — `cold_beliefs` actual shape:** Wave 3 ToM Phase 2 landed the per-observer storage as `cold_beliefs: Vec<crate::pool::BoundedMap<AgentId, engine_data::belief::BeliefState, 8>>` (`state/mod.rs:175-176`). One `BoundedMap` per observer, keyed on observed `AgentId`, capacity `BELIEFS_PER_AGENT = 8`. Each cell holds 6 fields: `last_known_pos`, `last_known_hp`, `last_known_max_hp`, `last_known_creature_type`, `last_updated_tick`, `confidence` (eviction below `EVICTION_THRESHOLD = 0.05`). **`[STALE]`:** doc-comments in `crates/engine/src/cascade/handler.rs` (~L260) and `crates/engine/src/ability/apply.rs` (~L186, L213-238) describe consumers writing into "the BeliefState SoA's 6 columns at `[caster_slot * agent_cap + target_slot]`" — that's a future-flattened shape; today the storage is the per-observer `BoundedMap` above. See `docs/superpowers/notes/2026-05-08-audit-state-drift.md` U3 + S2 and `engine.md` §Schema-hash audit callout (cross-ref).
+
 | Field | Type | Meaning | Updated by | Read by |
 |---|---|---|---|---|
 | traits | [f32; 5] | Estimated [risk_tol, social, ambition, altruism, curiosity] | observe_action (action→trait signal, alpha learning) | compatibility calc with own personality, behavior prediction |
@@ -258,6 +279,10 @@ Directional relationship from one NPC toward another (asymmetric).
 
 > ❌ **Audit 2026-04-26:** `GoalStack` and `Goal` struct are **not implemented** in the engine SoA. `crates/tactical_sim` has a GOAP `Goal` but it is the tactical planner, not the world-sim goal stack with push/pop priority preemption.
 > See `docs/superpowers/notes/2026-04-26-audit-state.md` for detail.
+
+> ⚠️ **Audit 2026-05-08:** engine SoA carries `ability_cooldowns: Vec<[u32; MAX_ABILITIES]>` (`state/mod.rs:187`) — per-(agent, ability-slot) local cooldown cursor where the value is the absolute tick that ability slot next becomes ready (`0` = ready). Added 2026-04-22 to fix a shared-cursor bug where the single global `hot_cooldown_next_ready_tick` (GCD) gated every ability on an agent. Catalog row absent today. See `docs/superpowers/notes/2026-05-08-audit-state-drift.md` U4.
+
+> ⚠️ **Audit 2026-05-08 (Lift A–D foundation, `[STALE]` future-shape):** PR #38 (commit `7bb0929c`) added `AgentFieldId` variants `BusyUntilTick`, `TravelDestX`, `TravelDestY`, `TravelDestZ` for multi-tick procedures + Travel, plus chronicle event ordinals 70–76 (`EffectTravelToApplied=70`, `EffectRecipeApplied=71`, `EffectWearToolApplied=72`, `EffectProposeApplied=73`, `EffectAnnounceApplied=74`, `EffectGainSkillApplied=75`, `EffectCreateObligationApplied=76`). The same-named per-agent SoA columns (`hot_busy_until_tick`, `hot_travel_dest_{x,y,z}`, `hot_disguise_expires_at_tick`, `hot_disguise_fake_type`, recipe / wear / propose / announce / skill / obligation cells) are **NOT yet allocated** in `SimState` — the foundation slice landed the dispatcher + chronicle-record writer; the consumer-side SoA wiring lands in subsequent slices. Doc-comments in `cascade/handler.rs` and `ability/apply.rs` that describe writing into these columns describe the future-shape, not current storage. See `docs/superpowers/notes/2026-05-08-audit-state-drift.md` S1 and `engine.md` §Cascade pipeline / §Schema-hash audit callouts.
 
 #### Goal
 
@@ -496,6 +521,8 @@ TRANSFORMATIONS:
 
 > ❌ **Audit 2026-04-26:** This entire section is **not implemented in the engine crate**. Only skeletal `Group` (3 fields) and `Quest` (5–6 fields) exist in `crates/engine/src/aggregate/`. Settlement, RegionState, Faction, GuildState, TradeRoute, ServiceContract, EconomyState, ConstructionMemory, full `Group` (~25 fields), full `Quest` (13 fields), QuestPosting, etc. are absent — they live in legacy `headless_campaign` worktrees not in canonical engine.
 > See `docs/superpowers/notes/2026-04-26-audit-state.md` for detail.
+
+> ⚠️ **Audit 2026-05-08 (`[STALE]` provenance pointer):** Neither `headless_campaign` nor `bevy_game` exists as a workspace crate today (verify via `Cargo.toml`'s `[workspace] members`). Only `SettlementId` (and a few sibling ID types) survives in `crates/engine/src/ids.rs`; the Settlement / RegionState / Faction / GuildState / TradeRoute / EconomyState / etc. *struct* definitions don't live in any current crate. The "lives elsewhere" pointer in the 2026-04-26 callout is no longer accurate — readers shouldn't go looking for these in a sibling crate. Verdict unchanged (still ❌ "not implemented in the engine crate"). See `docs/superpowers/notes/2026-05-08-audit-state-drift.md` S3.
 
 `Group` is the universal social-collective primitive. Settlements, factions, families, guilds, religions, packs, cabals, parties, courts, leagues, monasteries are all `Group` discriminated by `kind`. The Group section at the end gives the canonical shape; per-kind sections describe additional fields.
 

--- a/docs/superpowers/notes/2026-05-08-audit-state-drift.md
+++ b/docs/superpowers/notes/2026-05-08-audit-state-drift.md
@@ -1,0 +1,239 @@
+# `state.md` Drift Audit (2026-05-08)
+
+> Follow-up to the 2026-04-26 audit (`docs/superpowers/notes/2026-04-26-audit-state.md`).
+> Two weeks of code work since then — Wave 2 piece 1 (control-verb expiries),
+> Wave 2 piece 4 (lifesteal + damage_modify buff slots), Wave 3 ToM Phase 2
+> (per-observer `cold_beliefs`), and the Lift A–D foundation merge (chronicle
+> ordinals 70–76 + `AgentFieldId` variants for the future per-agent columns).
+> Audit re-runs `crates/engine/src/state/mod.rs`, `crates/engine/src/schema_hash.rs`,
+> `crates/engine/.schema_hash`, `crates/dsl_compiler/src/cg/data_handle.rs`, and
+> the chronicle-event `EventKindId` table (`crates/engine/src/cascade/handler.rs`).
+> Inline `> ⚠️ Audit 2026-05-08:` callouts at affected sections of `state.md` point
+> back here. **Additive only — no prose was rewritten.**
+
+---
+
+## Summary
+
+| Category | Count |
+|---|---|
+| `[CRITICAL]` (silently miscompiles, or stale field consumed today) | **0** |
+| `[STATUS-FLIP]` (spec said missing, now landed) | **0** |
+| `[UNDOCUMENTED]` (impl has SoA field spec catalog doesn't name) | **5** |
+| `[MISSING]` (spec promises field with no impl) | **0** |
+| `[STALE]` (spec callout / pointer no longer matches reality) | **3** |
+
+No critical drifts. The 2026-04-26 catalog is structurally still accurate — the
+big-rock gaps it called out (`AgentData` blob, `Aggregate`/`World` sections,
+`Goal`/`Aspiration`/`Emotions`/`Source`/`MemEventType`) remain absent from
+`crates/engine`. New drift is concentrated in (a) hot-SoA fields the catalog
+doesn't name (Wave 2 + Wave 3 storage), and (b) Lift A–D vocabulary that landed
+chronicle-event ordinals + `AgentFieldId` variants but **defers** the per-agent
+SoA columns themselves to a follow-up slice.
+
+The previous-audit count (42 ✅ / 18 ⚠️ / 31 ❌ / 7 🤔 / 4 ❓) is left intact;
+this slice does not re-tally per-section status, only adds drift items that
+landed since.
+
+---
+
+## `[UNDOCUMENTED]` items
+
+### U1. Wave 2 piece 1 control-verb expiry mirrors
+
+- **§ in spec**: §Combat/Vitality + §StatusEffect catalog `kind: StatusEffectKind`
+  with enum variants including `Root`, `Silence` (StatusEffect §). The 2026-04-26
+  callout already pinned the `remaining_ms` ↔ `hot_stun_expires_at_tick` shape
+  flip, but only enumerated `hot_stun_expires_at_tick` / `hot_slow_expires_at_tick`.
+- **What code does**: `state/mod.rs:107-110` adds four more hot expiry-tick mirrors
+  for the Wave 2 piece 1 control verbs:
+  - `hot_root_expires_at_tick:    Vec<u32>`
+  - `hot_silence_expires_at_tick: Vec<u32>`
+  - `hot_fear_expires_at_tick:    Vec<u32>`
+  - `hot_taunt_expires_at_tick:   Vec<u32>`
+  Same encoding as `hot_stun_expires_at_tick`: absolute expiry tick, `0` means
+  "never applied / already elapsed". Schema-hash baseline registers them in the
+  same hot block (`schema_hash.rs:21`).
+- **Fix landing in this PR**: §StatusEffect callout enumerates the new four hot
+  expiry mirrors. No catalog row added (these are the SoA-storage shape, not
+  the per-agent typed `StatusEffect` row catalog already covers).
+
+### U2. Wave 2 piece 4 buff-slot SoA columns (lifesteal + damage_taken_mult)
+
+- **§ in spec**: not present. §StatusEffect `kind: StatusEffectKind` enumerates
+  `Buff/Debuff{stat, factor}` (already pinned by the 2026-04-26 callout to
+  `payload_q8: i16`), but the spec doesn't catalog the dedicated single-slot
+  buff columns the engine carries.
+- **What code does**: `state/mod.rs:125-138` adds four hot buff-slot fields:
+  - `hot_lifesteal_frac_q8:                 Vec<i16>` — q8 fraction of damage healed; `0` = no lifesteal active
+  - `hot_lifesteal_expires_at_tick:         Vec<u32>` — gate: `state.tick < expires_at`
+  - `hot_damage_taken_mult_q8:              Vec<i16>` — q8 incoming-damage multiplier; `256` = `1.0×` identity
+  - `hot_damage_taken_mult_expires_at_tick: Vec<u32>` — gate: `state.tick < expires_at`
+  Schema-hash baseline registers all four in the hot block (`schema_hash.rs:21`).
+  Stacking semantics ("incoming wins iff strictly greater magnitude OR equal
+  magnitude with longer remaining duration") are recorded in `MEMORY.md` →
+  `project_buff_stacking_rule.md`, not in `state.md`.
+- **Fix landing in this PR**: §StatusEffect callout enumerates the four new
+  buff-slot columns alongside U1.
+
+### U3. Wave 3 ToM Phase 2 — `cold_beliefs` per-observer `BoundedMap`
+
+- **§ in spec**: §PerceivedPersonality (Theory of Mind) callout (2026-04-26)
+  notes `BeliefState` in `engine_data/src/belief.rs` stores observation data
+  (`last_known_pos`, `last_known_hp`, etc.) — accurate. But the catalog itself
+  never lists a `cold_beliefs` field on `SimState`.
+- **What code does**: `state/mod.rs:175-176` declares
+  `cold_beliefs: Vec<crate::pool::BoundedMap<AgentId, engine_data::belief::BeliefState, 8>>`
+  per-agent (gated by the `theory-of-mind` feature flag). Per-(observer,
+  target) lookup via `BoundedMap` keyed on observed `AgentId`, capacity `N=8`
+  (matches `engine_data::belief::BELIEFS_PER_AGENT`). `BeliefState` is hand-written
+  and carries 6 fields: `last_known_pos`, `last_known_hp`, `last_known_max_hp`,
+  `last_known_creature_type`, `last_updated_tick`, `confidence`. Eviction
+  threshold `EVICTION_THRESHOLD = 0.05`.
+- **Fix landing in this PR**: §PerceivedPersonality callout updated with the
+  actual `cold_beliefs` field shape + capacity. See also S1 below for the
+  related comment-shape divergence in cascade/apply.
+
+### U4. `ability_cooldowns` per-(agent, ability-slot) grid
+
+- **§ in spec**: not present in §AgentData / §Goal / §Equipment. The 2026-04-26
+  callout in §World already mentions `ability_cooldowns` in passing as one of
+  several fields the agent catalog doesn't list, but no §Agent-side callout
+  exists.
+- **What code does**: `state/mod.rs:187`
+  `pub ability_cooldowns: Vec<[u32; MAX_ABILITIES]>` — per-(agent, ability-slot)
+  local cooldown cursor where `[slot * MAX_ABILITIES + ability_idx] = next_ready_tick`.
+  Grouped with cold SoA fields (read only on cast-gate eval). Added 2026-04-22
+  to fix a shared-cursor bug where all abilities on one agent were gated by
+  the single global `hot_cooldown_next_ready_tick`.
+- **Fix landing in this PR**: §Personality / Combat closing area gets a brief
+  note pointing at this field. (Full §Abilities section is deferred — it would
+  duplicate `ability.md`.)
+
+### U5. `hot_mana` / `hot_max_mana`
+
+- **§ in spec**: §Combat/Vitality catalogs `hp`, `max_hp`, `shield_hp`, `armor`,
+  `magic_resist`, `attack_damage`, `attack_range`, `status_effects`. Spec-listed
+  agent-resource catalog stops at HP / shield / armor. Mana is implicit in the
+  `cost: <int>` `.ability` parser default (Mana resource — `dataset/abilities/`
+  corpus convention) but never named at the SoA layer.
+- **What code does**: `state/mod.rs:63-64` declares `hot_mana: Vec<f32>` and
+  `hot_max_mana: Vec<f32>`. Schema-hash baseline registers both
+  (`schema_hash.rs:17`). Initialised to `0.0` by `spawn_agent`. Read by the
+  ability cast-gate when `EffectOp` consumers honour the ability's `cost`.
+- **Note**: 2026-04-26 audit narrative mentions this in the §Combat per-section
+  finding ("engine adds `hot_mana` / `hot_max_mana` which spec does not catalog
+  (engine extension, not spec violation)"), but the spec body itself has no
+  callout. Fix landing in this PR: §Combat/Vitality gets a one-line callout
+  pointer to this audit.
+
+---
+
+## `[STALE]` items
+
+### S1. Lift A–D `AgentFieldId` variants registered, SoA columns NOT yet allocated
+
+- **§ in spec**: not present. The Lift A foundation merge (commit `7bb0929c`,
+  PR #38) added `AgentFieldId` variants `BusyUntilTick`, `TravelDestX`,
+  `TravelDestY`, `TravelDestZ` for the multi-tick-procedure / Travel surface,
+  plus chronicle event ordinals 70–76 (`EffectTravelToApplied=70`,
+  `EffectRecipeApplied=71`, `EffectWearToolApplied=72`, `EffectProposeApplied=73`,
+  `EffectAnnounceApplied=74`, `EffectGainSkillApplied=75`,
+  `EffectCreateObligationApplied=76`).
+- **What's stale**: Doc-comments in `crates/engine/src/cascade/handler.rs` (e.g.
+  L260–272) and `crates/engine/src/ability/apply.rs` (e.g. L186, L213–238)
+  describe the *future-shape* downstream consumers will read — "writes
+  `disguise_expires_at_tick = world.tick + duration_ticks` and
+  `disguise_fake_type = fake_type` into per-agent SoA columns", "sets
+  `busy_until_tick = world.tick + eta_ticks` and populates `travel_dest_{x,y,z}`
+  SoA cells". **Those columns are NOT allocated** in the live `SimState` today
+  — the only hot/cold SoA fields are the ones enumerated in `state/mod.rs`
+  and in `schema_hash.rs`'s baseline. The dispatcher fires the chronicle event
+  but the consumer rule that would *use* the SoA columns doesn't exist yet.
+- **Cross-reference**: this is the same caveat the engine.md audit (PR #40)
+  pinned at §Schema hash and §GPU resident-mirror. Foundation merges land
+  the `EventKindId` ordinal + `EffectOp` variant + `AgentFieldId` vocabulary;
+  the per-agent SoA columns themselves land in subsequent slices.
+- **Fix landing in this PR**: state.md gets a top-level callout warning that
+  the Lift A–D-era doc-comments in code refer to future SoA columns that
+  the catalog correctly omits.
+
+### S2. Wave 3 ToM Phase 2 `BeliefState` is per-observer `BoundedMap`, not flat 6-column SoA
+
+- **§ in spec**: §PerceivedPersonality callout (2026-04-26) describes
+  `BeliefState` as observation data with the right fields — accurate.
+- **What's stale**: cascade / apply doc-comments
+  (`cascade/handler.rs:271`, `ability/program.rs:515,630`,
+  `ability/apply.rs:186`) describe the consumer-side as "the BeliefState SoA's
+  6 columns at `[caster_slot * agent_cap + target_slot]`" — i.e. a flat
+  `agent_cap × agent_cap × 6` column-major layout. The actual storage is
+  `Vec<BoundedMap<AgentId, BeliefState, 8>>` per observer (`state/mod.rs:175-176`):
+  per-observer hash-map keyed on observed `AgentId`, capacity 8, holding
+  one `BeliefState` struct per pair. This is the same comment-shape vs
+  reality divergence the engine.md audit pinned at the §Schema hash callout
+  (`engine.md:124`).
+- **Fix landing in this PR**: §PerceivedPersonality callout updated to point
+  at this audit + the engine.md cross-reference.
+
+### S3. Aggregate/World "live in headless_campaign / bevy_game layer" pointer
+
+- **§ in spec**: top-of-file callout (`state.md:3`) and §Aggregate / §World
+  callouts (lines 497–498, 885–886) say the missing structs "live in the
+  `headless_campaign` / `bevy_game` layer (or in legacy worktrees)".
+- **What's stale**: neither `headless_campaign` nor `bevy_game` exists as a
+  workspace member today. Only `SettlementId` (and other ID stubs) survive in
+  `crates/engine/src/ids.rs` — the Settlement / RegionState / Faction /
+  GuildState / TradeRoute / EconomyState struct definitions don't live in
+  *any* current crate. They were last present in legacy worktrees that have
+  since been cleaned up.
+- **Note for completeness**: this doesn't change the audit verdict (still ❌
+  "not implemented in the engine crate"), but the "lives elsewhere" pointer
+  is no longer accurate. The reader should not go looking for these in a
+  sibling crate. Fix landing in this PR: top-of-file callout + §Aggregate +
+  §World callouts get a "no longer present in any workspace crate" addendum
+  via a single 2026-05-08 follow-up callout.
+
+---
+
+## Items that LOOK like drift but aren't
+
+These were checked and confirmed correctly documented or out of scope:
+
+- **`hot_engaged_with` / `hot_stun_expires_at_tick` / `hot_slow_expires_at_tick`
+  / `hot_slow_factor_q8` / `hot_cooldown_next_ready_tick`** — listed in the
+  2026-04-26 §World callout (line 885). Status unchanged.
+- **`creature_type` enum (Human / Wolf / Deer / Dragon)** — already pinned at
+  §Identity & Lifecycle callout. Status unchanged: Elf / Dwarf / Goblin still
+  absent.
+- **Needs scale (0–1 vs spec 0–100)** — already pinned at §Needs callout.
+  Status unchanged.
+- **`cold_creditor_ledger` / `cold_mentor_lineage` / `cold_class_definitions`** —
+  listed in the §AgentData callout's "exists as separate cold fields" carve-out
+  (line 282). Status unchanged.
+- **`hot_root_expires_at_tick` / `hot_silence_expires_at_tick` etc.** were
+  added 2026-05-04 (Wave 2 piece 1) — see U1 above. Wave 2 piece 4 buff slots
+  added similarly.
+- **`AgentFieldId::Vel`** (Phase 7 boids fixture, 2026-05-02) — used by
+  per-fixture runtime crates that allocate their own velocity column outside
+  `SimState`. The wolf-sim `SimState` has no velocity slot. This isn't a
+  drift item — `state.md` is the wolf-sim catalog, not a per-fixture catalog.
+
+---
+
+## Recommended follow-up tasks
+
+(Out of scope for this docs-only audit slice; tracked for the next pass.)
+
+1. **§Combat/Vitality SoA-storage subsection** — explicit catalog of the hot
+   expiry-tick + buff-slot mirrors (U1 + U2). Currently the spec catalogs the
+   typed `StatusEffect` row but not the parallel per-status hot columns the
+   engine actually reads in masks / scoring.
+2. **§Theory of Mind subsection** — promote the §PerceivedPersonality callout
+   to a real catalog row for `cold_beliefs` (U3). Pair with the `beliefs(...)`
+   DSL surface (currently in the dsl.md drift audit's U3 / U4 deferred items).
+3. **§Lift A–D forward-shape catalog** — when the Lift A–D consumer rules
+   land per-agent SoA columns, backfill them to §Goal & Action Execution and
+   add a §Multi-Tick Procedures section. S1 retires once SoA wiring lands.
+4. **Aggregate/World provenance refresh** — either delete the "lives in
+   headless_campaign" pointers or update them to "deferred; see ROADMAP" once
+   the world-sim plan picks an owning crate. S3 retires.


### PR DESCRIPTION
## Summary

Follow-up audit of `docs/spec/state.md` against the current `crates/engine/src/state/mod.rs`, `schema_hash.rs`, and `crates/dsl_compiler/src/cg/data_handle.rs`. Two weeks of code work since the 2026-04-26 audit landed Wave 2 piece 1, Wave 2 piece 4, Wave 3 ToM Phase 2, and the Lift A-D foundation merge.

**Findings: 0 `[CRITICAL]`, 0 `[STATUS-FLIP]`, 5 `[UNDOCUMENTED]`, 0 `[MISSING]`, 3 `[STALE]`.**

- `[UNDOCUMENTED]` Wave 2 piece 1 hot expiry mirrors (`hot_root/silence/fear/taunt_expires_at_tick`); Wave 2 piece 4 buff slots (`hot_lifesteal_*`, `hot_damage_taken_mult_*`); Wave 3 ToM Phase 2 `cold_beliefs: Vec<BoundedMap<AgentId, BeliefState, 8>>`; `ability_cooldowns: Vec<[u32; MAX_ABILITIES]>`; `hot_mana` / `hot_max_mana`.
- `[STALE]` Lift A-D `AgentFieldId` variants (`BusyUntilTick`, `TravelDestX/Y/Z`) + chronicle ordinals 70-76 are registered but the per-agent SoA columns described in `cascade/handler.rs` and `ability/apply.rs` doc-comments are NOT yet allocated; `cold_beliefs` is per-observer `BoundedMap`, not a flat 6-column SoA the consumer comments describe; `headless_campaign` / `bevy_game` provenance pointer is stale (neither crate exists today).

Additive only - no prose was rewritten. New callouts at top-of-file + Combat/Vitality + StatusEffect + PerceivedPersonality + Goal & Action Execution + Aggregate state sections. Per-item evidence in new `docs/superpowers/notes/2026-05-08-audit-state-drift.md`.

## Test plan

- [x] Verify only `docs/` files modified (`git status -- crates/ assets/` clean)
- [x] Cross-reference Lift A `AgentFieldId` variants vs SoA Vec declarations in `state/mod.rs` (variants exist; SoA columns absent - confirmed)
- [x] Cross-reference `cold_beliefs` shape in `state/mod.rs:175-176` vs cascade/apply doc-comments (per-observer `BoundedMap` vs flat-column descriptions - confirmed divergence)
- [x] Pattern matches existing `2026-05-08-audit-dsl-drift.md` and engine.md audit format

🤖 Generated with [Claude Code](https://claude.com/claude-code)