### PR TITLE
fix(compiler): fusion analyzer enumerates ApplyAbility chronicle writes

### DIFF
--- a/assets/sim/village_economy.sim
+++ b/assets/sim/village_economy.sim
@@ -263,27 +263,26 @@ verb OfferDeal(self, target: Agent) =
 // busy_until_tick are deferred per P1 — the chronicle record landing
 // is the behavioral pin.
 //
-// SCHEDULING NOTE: the compiler fuses FoldTravel with the
+// SCHEDULING NOTE: pre-Task #235 the compiler fused FoldTravel with the
 // verb_chronicle_WalkToWorkshop dispatcher into ONE PerEvent kernel.
-// Within a single kernel pass, FoldTravel's read can't see the
-// kind=70 records the dispatcher will write later in the same pass
+// Within a single kernel pass, FoldTravel's read couldn't see the
+// kind=70 records the dispatcher would write later in the same pass
 // (no within-kernel barrier between producer + consumer threads on
-// the GPU). The runtime works around this by DISPATCHING THE FUSED
-// KERNEL TWICE PER TICK — first pass writes the chronicle records,
-// second pass folds them. This double-counts the OTHER FoldX rules
-// (FoldRecipe, FoldWear, FoldSkill, FoldAnnounce — all of which
-// consume kinds emitted by ForgeIron's separate chronicle kernel),
-// but the behavioral pin only checks > 0 so the doubled counters
-// stay correct-by-direction.
+// the GPU). The runtime worked around this by dispatching the fused
+// kernel TWICE per tick.
 //
-// ROOT CAUSE: the `producer_consumer_event_witness` analyzer rule
-// (cg/schedule/fusion.rs Rule 4) only recognises explicit `Emit`
-// statements as event-ring writes — `ApplyAbility` synthesizes the
-// events at runtime but the static analyzer pushes a placeholder
-// `EventKindId(0)` instead of the real emitted kinds (see
-// fusion.rs::collect_emits_in_list ApplyAbility arm). Until that
-// analyzer learns to enumerate ApplyAbility's dispatched kinds via
-// the AbilityRegistry, the runtime double-dispatch stands.
+// Task #235 (`fix(compiler): fusion analyzer enumerates ApplyAbility
+// chronicle writes`) fixed the root cause: the
+// `producer_consumer_event_witness` analyzer rule (cg/schedule/
+// fusion.rs Rule 4) now consults the build-time AbilityRegistry to
+// resolve `apply_ability <literal>` to the chronicle event kinds the
+// WGSL dispatcher will write (kind=70 for TravelTo, etc.). The
+// analyzer also walks every member of the in-progress fusion group
+// (not just the tail) so the producer/consumer relationship between
+// FoldTravel (added first) and verb_chronicle_WalkToWorkshop (added
+// last) gets caught. With the fix, WalkToWorkshop dispatches as its
+// own kernel BEFORE the fold pass and the per-kernel barrier makes
+// the kind=70 records visible to FoldTravel.
 @phase(post)
 physics FoldTravel {
   on EffectTravelToApplied { actor: a, target: _, dest_packed: _, eta_ticks: _ } {

--- a/crates/dsl_compiler/src/cg/schedule/fusion.rs
+++ b/crates/dsl_compiler/src/cg/schedule/fusion.rs
@@ -58,8 +58,11 @@
 
 use std::collections::BTreeSet;
 
+use engine::ability::AbilityRegistry;
+
 use crate::cg::data_handle::{CycleEdgeKey, DataHandle, EventRingId, ViewId};
 use crate::cg::dispatch::{DispatchShape, PerPairSource};
+use crate::cg::expr::{CgExpr, LitValue};
 use crate::cg::op::{ComputeOp, ComputeOpKind, EventKindId, OpId};
 use crate::cg::program::CgProgram;
 use crate::cg::stmt::{CgStmt, CgStmtListId};
@@ -284,6 +287,16 @@ pub fn fusion_candidates(prog: &CgProgram, deps: &DepGraph) -> Vec<FusionGroup> 
     fusion_decisions(prog, deps).0
 }
 
+/// Registry-aware variant of [`fusion_candidates`]. See
+/// [`fusion_decisions_with_registry`] for the rationale (Task #235).
+pub fn fusion_candidates_with_registry(
+    prog: &CgProgram,
+    deps: &DepGraph,
+    registry: Option<&AbilityRegistry>,
+) -> Vec<FusionGroup> {
+    fusion_decisions_with_registry(prog, deps, registry).0
+}
+
 /// Compute the fusion-group partition AND the diagnostic stream
 /// explaining each grouping/split decision. Both outputs are returned in
 /// topological-walk order; the diagnostics are emitted in the same order
@@ -306,6 +319,32 @@ pub fn fusion_candidates(prog: &CgProgram, deps: &DepGraph) -> Vec<FusionGroup> 
 pub fn fusion_decisions(
     prog: &CgProgram,
     deps: &DepGraph,
+) -> (Vec<FusionGroup>, Vec<FusionDiagnostic>) {
+    fusion_decisions_with_registry(prog, deps, None)
+}
+
+/// Registry-aware variant of [`fusion_decisions`]. When `registry` is
+/// `Some`, the producer/consumer event-ring split (rule 4) sees real
+/// `EventKindId`s emitted by `ApplyAbility`'s WGSL dispatcher (the
+/// chronicle-record writes synthesised at GPU dispatch time) and can
+/// split the dispatcher kernel out of any same-tick consumer kernel
+/// that subscribes to those kinds. When `None`, the analyzer falls
+/// back to a placeholder (`EventKindId(0)`) — preserves the pre-#235
+/// behaviour for call sites that don't yet plumb the registry through.
+///
+/// See `assets/sim/village_economy.sim::FoldTravel` (in tree at the
+/// time of writing) for the worked example: WalkToWorkshop dispatches
+/// `EffectTravelToApplied` (kind=70); FoldTravel `on
+/// EffectTravelToApplied` consumes it. Pre-#235 the analyzer didn't
+/// witness the producer's emission and fused the two into one kernel
+/// — the runtime worked around the within-kernel barrier gap by
+/// dispatching the fused kernel twice. Post-#235 (with the registry
+/// plumbed through) rule 4 fires correctly and the schedule splits
+/// FoldTravel into its own PerEvent kernel.
+pub fn fusion_decisions_with_registry(
+    prog: &CgProgram,
+    deps: &DepGraph,
+    registry: Option<&AbilityRegistry>,
 ) -> (Vec<FusionGroup>, Vec<FusionDiagnostic>) {
     let mut groups: Vec<FusionGroup> = Vec::new();
     let mut diagnostics: Vec<FusionDiagnostic> = Vec::new();
@@ -348,6 +387,7 @@ pub fn fusion_decisions(
         // why not.
         let join_decision = decide_join(
             prog,
+            registry,
             &current_shape,
             &current_ops,
             &current_writes,
@@ -504,6 +544,7 @@ enum JoinDecision {
 ///    `docs/superpowers/notes/2026-05-04-abilities_probe.md`.
 fn decide_join(
     prog: &CgProgram,
+    registry: Option<&AbilityRegistry>,
     current_shape: &Option<DispatchShape>,
     current_ops: &[OpId],
     current_writes: &BTreeSet<CycleEdgeKey>,
@@ -537,8 +578,30 @@ fn decide_join(
     };
     // Cross-domain split (rules 1 + 2 + 4) — fires regardless of
     // write disjointness.
-    if let Some(decision) = cross_domain_split_decision(prog, prev_op, op) {
+    if let Some(decision) = cross_domain_split_decision(prog, registry, prev_op, op) {
         return decision;
+    }
+    // Rule 4 extension (Task #235): the pairwise check above only
+    // looks at `prev_op`, which catches the common case (producer
+    // and consumer adjacent in topo order). When the topo walk
+    // places several consumers first and the producer last, the
+    // producer/consumer round-trip lives between `op` and an
+    // EARLIER member of the group — checked here. Lift-A's
+    // village_economy fixture surfaces this: FoldTravel/.../
+    // verb_chronicle_WalkToWorkshop walks 7 consumers then 1
+    // producer; only FoldTravel (added first) matches kind=70 with
+    // verb_chronicle_WalkToWorkshop's apply_ability dispatch.
+    for &member_id in current_ops.split_last().map(|(_, rest)| rest).unwrap_or(&[]) {
+        let Some(member_op) = prog.ops.get(member_id.0 as usize) else {
+            continue;
+        };
+        if let Some(witness) =
+            producer_consumer_event_witness(prog, registry, member_op, op)
+        {
+            return JoinDecision::SplitWrite(event_ring_split_witness(
+                member_op, op, witness,
+            ));
+        }
     }
     // Same-view ViewFold accumulator override (rule 3) and the
     // conventional WAW-conflict check.
@@ -577,6 +640,7 @@ fn waw_check(
 /// considered explicitly.
 fn cross_domain_split_decision(
     prog: &CgProgram,
+    registry: Option<&AbilityRegistry>,
     prev: &ComputeOp,
     next: &ComputeOp,
 ) -> Option<JoinDecision> {
@@ -588,7 +652,7 @@ fn cross_domain_split_decision(
     // side's `on_event`. A non-empty intersection means same-tick
     // event-ring round-trip — un-fusable for read-before-write
     // correctness (see rule-4 doc on `decide_join`).
-    if let Some(witness) = producer_consumer_event_witness(prog, prev, next) {
+    if let Some(witness) = producer_consumer_event_witness(prog, registry, prev, next) {
         return Some(JoinDecision::SplitWrite(
             event_ring_split_witness(prev, next, witness),
         ));
@@ -882,15 +946,16 @@ fn cross_replayability_split_witness(
 /// safe.
 fn producer_consumer_event_witness(
     prog: &CgProgram,
+    registry: Option<&AbilityRegistry>,
     prev: &ComputeOp,
     next: &ComputeOp,
 ) -> Option<EventKindId> {
     // prev produces, next consumes
-    if let Some(witness) = event_round_trip_witness(prog, prev, next) {
+    if let Some(witness) = event_round_trip_witness(prog, registry, prev, next) {
         return Some(witness);
     }
     // next produces, prev consumes (symmetric)
-    event_round_trip_witness(prog, next, prev)
+    event_round_trip_witness(prog, registry, next, prev)
 }
 
 /// Returns the first `EventKindId` that `producer` emits in its body
@@ -899,6 +964,7 @@ fn producer_consumer_event_witness(
 /// the consumer reads.
 fn event_round_trip_witness(
     prog: &CgProgram,
+    registry: Option<&AbilityRegistry>,
     producer: &ComputeOp,
     consumer: &ComputeOp,
 ) -> Option<EventKindId> {
@@ -927,7 +993,7 @@ fn event_round_trip_witness(
         | ComputeOpKind::Plumbing { .. } => return None,
     };
     let mut emits: Vec<EventKindId> = Vec::new();
-    collect_emits_in_list(body, prog, &mut emits);
+    collect_emits_in_list(body, prog, registry, &mut emits);
     emits.into_iter().find(|e| *e == consumed)
 }
 
@@ -940,9 +1006,22 @@ fn event_round_trip_witness(
 /// (the schedule analyzer must stay below lowering in the dep
 /// graph). Listed exhaustively over `CgStmt` variants — adding a
 /// new emit-bearing statement variant forces an explicit case here.
+///
+/// `registry` (Task #235): when `Some`, an `ApplyAbility { ability }`
+/// whose `ability` operand is a literal `AbilityId` is resolved to its
+/// registry program and the per-effect `EventKindId` it dispatches into
+/// the chronicle ring (via the `EFFECT_KIND_TO_EVENT_KIND_ID` table) is
+/// pushed to `out` — rather than the historic `EventKindId(0)`
+/// placeholder. This lets [`producer_consumer_event_witness`] (rule 4)
+/// detect same-tick event round-trips through the dispatcher and split
+/// the producer kernel out of the consumer kernel. When `registry` is
+/// `None`, or the ability operand isn't a literal, fall back to the
+/// placeholder so the analyzer at least conservatively flags
+/// "writes to the shared ring".
 fn collect_emits_in_list(
     list_id: CgStmtListId,
     prog: &CgProgram,
+    registry: Option<&AbilityRegistry>,
     out: &mut Vec<EventKindId>,
 ) {
     let Some(list) = prog.stmt_lists.get(list_id.0 as usize) else {
@@ -955,37 +1034,79 @@ fn collect_emits_in_list(
         match stmt {
             CgStmt::Emit { event, .. } => out.push(*event),
             CgStmt::If { then, else_, .. } => {
-                collect_emits_in_list(*then, prog, out);
+                collect_emits_in_list(*then, prog, registry, out);
                 if let Some(else_list) = else_ {
-                    collect_emits_in_list(*else_list, prog, out);
+                    collect_emits_in_list(*else_list, prog, registry, out);
                 }
             }
             CgStmt::Match { arms, .. } => {
                 for arm in arms {
-                    collect_emits_in_list(arm.body, prog, out);
+                    collect_emits_in_list(arm.body, prog, registry, out);
                 }
             }
             CgStmt::ForEachNeighborBody { body, .. } => {
-                collect_emits_in_list(*body, prog, out);
+                collect_emits_in_list(*body, prog, registry, out);
             }
             CgStmt::Assign { .. }
             | CgStmt::Let { .. }
             | CgStmt::ForEachAgent { .. }
             | CgStmt::ForEachNeighbor { .. } => {}
-            CgStmt::ApplyAbility { .. } => {
-                // Mirrors the driver's collect_emits_in_list arm —
-                // ApplyAbility's WGSL dispatcher writes to the
-                // chronicle ring, so push a placeholder kind to
-                // trigger the EventRing(Append) write recording.
-                // Fusion uses the kinds list to decide whether
-                // adjacent ops can fuse based on shared event-ring
-                // writes; with the synthetic kind, an
-                // ApplyAbility-bearing op is treated as "writes to
-                // the shared ring" the same way an Emit-bearing op
-                // is.
-                out.push(EventKindId(0));
+            CgStmt::ApplyAbility { ability, .. } => {
+                push_apply_ability_event_kinds(*ability, prog, registry, out);
             }
         }
+    }
+}
+
+/// Resolve an `ApplyAbility { ability, .. }` to the chronicle event
+/// kinds its WGSL dispatcher will write, and push them to `out`.
+///
+/// Walks the ability operand:
+///   - if it's a literal `CgExpr::Lit(LitValue::U32(N))` AND `registry`
+///     is `Some` AND the registry has a program at slot `N`, enumerate
+///     that program's `EffectOp`s, look each effect kind up in the
+///     `EFFECT_KIND_TO_EVENT_KIND_ID` table, and push the resulting
+///     `EventKindId`s. This is the path that lets
+///     [`producer_consumer_event_witness`] split the dispatcher kernel
+///     from same-tick consumer rules (Task #235);
+///   - on any miss (no registry, non-literal, unknown slot, unmapped
+///     effect kind), fall back to `EventKindId(0)` so the analyzer
+///     conservatively still records "writes to the shared ring" — this
+///     preserves the pre-#235 behaviour that the binding scanner
+///     depends on for the EventRing(Append) write recording.
+fn push_apply_ability_event_kinds(
+    ability: crate::cg::data_handle::CgExprId,
+    prog: &CgProgram,
+    registry: Option<&AbilityRegistry>,
+    out: &mut Vec<EventKindId>,
+) {
+    use crate::cg::emit::wgsl_body::event_kind_id_for_effect_kind;
+    use engine::ability::packed::pack_effect;
+    use engine::ability::AbilityId;
+
+    let program = prog
+        .exprs
+        .get(ability.0 as usize)
+        .and_then(|e| match e {
+            CgExpr::Lit(LitValue::U32(n)) => AbilityId::new(*n),
+            _ => None,
+        })
+        .zip(registry)
+        .and_then(|(id, reg)| reg.get(id));
+    let before = out.len();
+    if let Some(program) = program {
+        out.extend(program.effects.iter().filter_map(|op| {
+            let (effect_kind, _, _) = pack_effect(*op);
+            event_kind_id_for_effect_kind(effect_kind).map(EventKindId)
+        }));
+    }
+    if out.len() == before {
+        // Conservative placeholder — keeps the EventRing(Append) write
+        // recording shape the binding scanner depends on when no
+        // resolved kinds got pushed (no registry, non-literal operand,
+        // unknown slot, or every effect in the program lacked an
+        // EFFECT_KIND_TO_EVENT_KIND_ID mapping).
+        out.push(EventKindId(0));
     }
 }
 

--- a/crates/dsl_compiler/src/cg/schedule/mod.rs
+++ b/crates/dsl_compiler/src/cg/schedule/mod.rs
@@ -33,14 +33,16 @@ pub mod synthesis;
 pub mod topology;
 
 pub use fusion::{
-    dispatch_shape_key, fusion_candidates, fusion_decisions, DispatchShapeKey, FusibilityClass,
-    FusionDiagnostic, FusionDiagnosticKind, FusionGroup,
+    dispatch_shape_key, fusion_candidates, fusion_candidates_with_registry, fusion_decisions,
+    fusion_decisions_with_registry, DispatchShapeKey, FusibilityClass, FusionDiagnostic,
+    FusionDiagnosticKind, FusionGroup,
 };
 pub use strategy::{
-    fusion_candidates_with_strategy, fusion_decisions_with_strategy, ScheduleStrategy,
+    fusion_candidates_with_strategy, fusion_decisions_with_strategy,
+    fusion_decisions_with_strategy_and_registry, ScheduleStrategy,
 };
 pub use synthesis::{
-    synthesize_schedule, ComputeSchedule, ComputeStage, KernelTopology, ScheduleDiagnostic,
-    ScheduleDiagnosticKind, ScheduleSynthesisResult,
+    synthesize_schedule, synthesize_schedule_with_registry, ComputeSchedule, ComputeStage,
+    KernelTopology, ScheduleDiagnostic, ScheduleDiagnosticKind, ScheduleSynthesisResult,
 };
 pub use topology::{dependency_graph, topological_sort, CycleError, DepGraph};

--- a/crates/dsl_compiler/src/cg/schedule/strategy.rs
+++ b/crates/dsl_compiler/src/cg/schedule/strategy.rs
@@ -81,13 +81,15 @@
 //!   here so downstream consumers see consistent behaviour across
 //!   strategies.
 
+use engine::ability::AbilityRegistry;
+
 use crate::cg::dispatch::DispatchShape;
 use crate::cg::op::OpId;
 use crate::cg::program::CgProgram;
 
 use super::fusion::{
-    classify, fusion_decisions, FusibilityClass, FusionDiagnostic, FusionDiagnosticKind,
-    FusionGroup,
+    classify, fusion_decisions_with_registry, FusibilityClass, FusionDiagnostic,
+    FusionDiagnosticKind, FusionGroup,
 };
 use super::topology::{topological_sort, DepGraph};
 
@@ -177,8 +179,24 @@ pub fn fusion_decisions_with_strategy(
     deps: &DepGraph,
     strategy: ScheduleStrategy,
 ) -> (Vec<FusionGroup>, Vec<FusionDiagnostic>) {
+    fusion_decisions_with_strategy_and_registry(prog, deps, strategy, None)
+}
+
+/// Registry-aware variant of [`fusion_decisions_with_strategy`]. Threads
+/// the optional [`AbilityRegistry`] view down into the `Default` strategy's
+/// rule-4 (producer/consumer event-ring split) check so the schedule layer
+/// can split `apply_ability` dispatcher kernels out from same-tick consumer
+/// kernels that subscribe to the dispatched chronicle event kinds (Task
+/// #235). `Conservative` and `Megakernel` ignore the registry — their
+/// grouping policies don't consult per-op event-kind sets.
+pub fn fusion_decisions_with_strategy_and_registry(
+    prog: &CgProgram,
+    deps: &DepGraph,
+    strategy: ScheduleStrategy,
+    registry: Option<&AbilityRegistry>,
+) -> (Vec<FusionGroup>, Vec<FusionDiagnostic>) {
     match strategy {
-        ScheduleStrategy::Default => fusion_decisions(prog, deps),
+        ScheduleStrategy::Default => fusion_decisions_with_registry(prog, deps, registry),
         ScheduleStrategy::Conservative => conservative_decisions(prog, deps),
         ScheduleStrategy::Megakernel => megakernel_decisions(prog, deps),
     }

--- a/crates/dsl_compiler/src/cg/schedule/synthesis.rs
+++ b/crates/dsl_compiler/src/cg/schedule/synthesis.rs
@@ -65,13 +65,15 @@
 
 use std::fmt;
 
+use engine::ability::AbilityRegistry;
+
 use crate::cg::data_handle::EventRingId;
 use crate::cg::dispatch::DispatchShape;
 use crate::cg::op::{ComputeOpKind, OpId, PlumbingKind};
 use crate::cg::program::CgProgram;
 
 use super::fusion::{FusibilityClass, FusionDiagnostic, FusionGroup};
-use super::strategy::{fusion_decisions_with_strategy, ScheduleStrategy};
+use super::strategy::{fusion_decisions_with_strategy_and_registry, ScheduleStrategy};
 use super::topology::dependency_graph;
 
 // ---------------------------------------------------------------------------
@@ -398,9 +400,31 @@ pub fn synthesize_schedule(
     prog: &CgProgram,
     strategy: ScheduleStrategy,
 ) -> ScheduleSynthesisResult {
+    synthesize_schedule_with_registry(prog, strategy, None)
+}
+
+/// Registry-aware variant of [`synthesize_schedule`]. When `registry`
+/// is `Some`, the underlying fusion analyzer (rule 4 — producer/consumer
+/// event-ring split) sees the real `EventKindId`s that
+/// `CgStmt::ApplyAbility` will dispatch into the chronicle ring at
+/// runtime, instead of the historic `EventKindId(0)` placeholder. Same-
+/// tick consumers (`physics on EffectXApplied { ... }`,
+/// `view_fold on EffectYApplied { ... }`) split out of the dispatcher
+/// kernel into their own PerEvent kernels so a per-tick GPU dispatch
+/// barrier sits between the producer write and the consumer read.
+///
+/// When `None`, the analyzer falls back to the placeholder semantics —
+/// preserves the pre-#235 behaviour for build sites that don't yet
+/// thread the registry through. See [`super::fusion::collect_emits_in_list`]
+/// for the upstream resolution logic.
+pub fn synthesize_schedule_with_registry(
+    prog: &CgProgram,
+    strategy: ScheduleStrategy,
+    registry: Option<&AbilityRegistry>,
+) -> ScheduleSynthesisResult {
     let deps = dependency_graph(prog);
     let (groups, fusion_diagnostics) =
-        fusion_decisions_with_strategy(prog, &deps, strategy);
+        fusion_decisions_with_strategy_and_registry(prog, &deps, strategy, registry);
 
     let mut stages: Vec<ComputeStage> = Vec::with_capacity(groups.len());
     let mut schedule_diagnostics: Vec<ScheduleDiagnostic> = Vec::new();

--- a/crates/engine/src/ability/packed.rs
+++ b/crates/engine/src/ability/packed.rs
@@ -950,7 +950,7 @@ fn pack_delivery(d: &Delivery) -> u32 {
 /// so a GPU shader doing `bitcast<i32>(payload_a)` recovers the signed
 /// value losslessly.
 #[inline]
-fn pack_effect(op: EffectOp) -> (u32, u32, u32) {
+pub fn pack_effect(op: EffectOp) -> (u32, u32, u32) {
     // The discriminant matches `#[repr(u8)]` ordinals on `EffectOp`; the
     // schema_hash string pins those ordinals.
     match op {

--- a/crates/village_economy_runtime/build.rs
+++ b/crates/village_economy_runtime/build.rs
@@ -27,7 +27,9 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let corpus_dir = workspace_root.join("assets/ability_test/village_economy");
-    for name in ["ForgeIron.ability", "OfferDeal.ability", "WalkToWorkshop.ability"] {
+    const ABILITY_NAMES: &[&str] =
+        &["ForgeIron.ability", "OfferDeal.ability", "WalkToWorkshop.ability"];
+    for name in ABILITY_NAMES {
         println!("cargo:rerun-if-changed={}", corpus_dir.join(name).display());
     }
 
@@ -44,9 +46,32 @@ fn main() {
             o.program
         }
     };
-    let schedule_result = dsl_compiler::cg::schedule::synthesize_schedule(
+
+    // Task #235 — build the AbilityRegistry at build time so the
+    // schedule synthesizer's fusion analyzer can resolve every
+    // `apply_ability <literal>` to the chronicle event kinds the WGSL
+    // dispatcher will write. This unfuses FoldTravel from
+    // verb_chronicle_WalkToWorkshop (rule 4 — producer/consumer event-
+    // ring split) so the runtime no longer needs to dispatch the fused
+    // kernel twice as a barrier workaround.
+    let ability_files: Vec<(String, _)> = ABILITY_NAMES
+        .iter()
+        .map(|name| {
+            let path = corpus_dir.join(name);
+            let src = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let parsed = dsl_ast::parse_ability_file(&src)
+                .unwrap_or_else(|e| panic!("parse {name}: {e:?}"));
+            (name.to_string(), parsed)
+        })
+        .collect();
+    let built_registry = dsl_compiler::ability_registry::build_registry(&ability_files)
+        .expect("build village_economy AbilityRegistry");
+
+    let schedule_result = dsl_compiler::cg::schedule::synthesize_schedule_with_registry(
         &cg,
         dsl_compiler::cg::schedule::ScheduleStrategy::Default,
+        Some(&built_registry.registry),
     );
     let artifacts = dsl_compiler::cg::emit::emit_cg_program(&schedule_result.schedule, &cg)
         .expect("emit village_economy CG program");

--- a/crates/village_economy_runtime/src/lib.rs
+++ b/crates/village_economy_runtime/src/lib.rs
@@ -31,31 +31,40 @@
 //!      (WalkToWorkshop) + mask_1 (ForgeIron) + mask_2 (OfferDeal).
 //!   3. scoring — PerAgent argmax over 3 rows; emits ActionSelected.
 //!   4. physics_verb_chronicle_ForgeIron — gates action_id==1u, walks
-//!      ForgeIron's program; emits 4 chronicle records per cast.
+//!      ForgeIron's program; emits 4 chronicle records per cast (kinds
+//!      71/72/74/75).
 //!   5. physics_verb_chronicle_OfferDeal — gates action_id==2u, walks
-//!      OfferDeal's program; emits 2 chronicle records per cast.
-//!   6. physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_
-//!      FoldAnnounce_and_FoldSkill_and_FoldObligation_and_verb_chronicle_
-//!      WalkToWorkshop — fused PerEvent kernel. The seven FoldX sub-
-//!      ops fold the kinds 71-76 events emitted by ForgeIron + OfferDeal
-//!      in steps 4-5; the verb_chronicle_WalkToWorkshop sub-op walks
-//!      WalkToWorkshop's 1-effect program and writes kind=70 records
-//!      into NEW slots in the same kernel pass. FoldTravel at those new
-//!      event_idx values reads kind=70 and bumps the per-agent counter.
-//!   7. seed_indirect_0
+//!      OfferDeal's program; emits 2 chronicle records per cast (kinds
+//!      73/76).
+//!   6. physics_verb_chronicle_WalkToWorkshop — gates action_id==0u,
+//!      walks WalkToWorkshop's program; emits 1 chronicle record per
+//!      cast (kind=70). Task #235 split this kernel out of the fused
+//!      Fold kernel below; see the FoldTravel commentary in
+//!      `assets/sim/village_economy.sim` for the analyzer fix that
+//!      enabled the split.
+//!   7. physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_
+//!      FoldAnnounce_and_FoldSkill_and_FoldObligation — fused PerEvent
+//!      kernel that drains the 7 chronicle kinds (70-76) emitted in
+//!      steps 4-6 and folds them into the per-agent SoA counters.
+//!   8. seed_indirect_0
 //!
 //! ## Fusion-correctness note
 //!
-//! The compiler fuses verb_chronicle_WalkToWorkshop with all 7 FoldX
-//! consumer rules into ONE PerEvent kernel. Within that kernel each
-//! workgroup thread iterates the op chain in source order: FoldX reads
-//! ring[event_idx] (sees stale = no event), then verb_chronicle_Walk
-//! writes kind=70 to a NEW slot via atomicAdd on event_tail. Other
-//! workgroup threads at those new event_idx values read kind=70 and
-//! fold them — provided `event_count` (the kernel's dispatch upper
-//! bound) is ≥ post-write tail size. We dispatch with `event_count =
-//! agent_count * 8` (= 64 for N=8) — plenty of room for the ~14 events
-//! per tick that this fixture emits.
+//! Pre-Task #235 the compiler fused verb_chronicle_WalkToWorkshop with
+//! every FoldX consumer rule into ONE PerEvent kernel because the
+//! schedule analyzer's rule 4 (producer/consumer event-ring split) only
+//! recognised explicit `Emit` statements as event-ring writes; an
+//! `apply_ability <literal>` whose program emits a chronicle kind landed
+//! a placeholder `EventKindId(0)` instead, missing the real kind=70
+//! emission. With the analyzer now enumerating ApplyAbility's
+//! dispatched kinds via the AbilityRegistry (see `dsl_compiler::cg::
+//! schedule::fusion::push_apply_ability_event_kinds`), rule 4 fires and
+//! WalkToWorkshop is dispatched as its own kernel BEFORE the fold pass —
+//! the per-kernel dispatch barrier makes the kind=70 records visible to
+//! the FoldTravel consumer. The same rule already protected ForgeIron /
+//! OfferDeal (their producer kernels were ordered before the consumer
+//! group naturally because the topo walk found their adjacent
+//! producer/consumer pair).
 //!
 //! ## Faction layout (8 agents)
 //!
@@ -142,6 +151,7 @@ pub struct VillageEconomyState {
     scoring_cfg_buf: wgpu::Buffer,
     chronicle_forge_cfg_buf: wgpu::Buffer,
     chronicle_offer_cfg_buf: wgpu::Buffer,
+    chronicle_walk_cfg_buf: wgpu::Buffer,
     fold_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
 
@@ -318,7 +328,19 @@ impl VillageEconomyState {
                 contents: bytemuck::bytes_of(&offer_cfg_init),
                 usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             });
-        let fold_cfg_init = physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_FoldAnnounce_and_FoldSkill_and_FoldObligation_and_verb_chronicle_WalkToWorkshop::PhysicsFoldTravelAndFoldRecipeAndFoldWearAndFoldProposeAndFoldAnnounceAndFoldSkillAndFoldObligationAndVerbChronicleWalkToWorkshopCfg {
+        let walk_cfg_init = physics_verb_chronicle_WalkToWorkshop::PhysicsVerbChronicleWalkToWorkshopCfg {
+            event_count: 0,
+            tick: 0,
+            seed: 0,
+            agent_cap: 0,
+        };
+        let chronicle_walk_cfg_buf =
+            gpu.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("village_economy::chronicle_walk_cfg"),
+                contents: bytemuck::bytes_of(&walk_cfg_init),
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            });
+        let fold_cfg_init = physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_FoldAnnounce_and_FoldSkill_and_FoldObligation::PhysicsFoldTravelAndFoldRecipeAndFoldWearAndFoldProposeAndFoldAnnounceAndFoldSkillAndFoldObligationCfg {
             event_count: 0,
             tick: 0,
             seed: 0,
@@ -368,6 +390,7 @@ impl VillageEconomyState {
             scoring_cfg_buf,
             chronicle_forge_cfg_buf,
             chronicle_offer_cfg_buf,
+            chronicle_walk_cfg_buf,
             fold_cfg_buf,
             seed_cfg_buf,
             registry_gpu,
@@ -683,12 +706,67 @@ impl CompiledSim for VillageEconomyState {
             self.agent_count,
         );
 
-        // (6) Fused PerEvent kernel — folds kinds 71-76 emitted in
-        // steps 4-5; verb_chronicle_WalkToWorkshop sub-op walks Walk's
-        // 1-effect program and writes kind=70 records into NEW slots,
-        // which FoldTravel at those new event_idx values reads.
+        // (6) WalkToWorkshop chronicle dispatch — gates action_id==0u,
+        // walks WalkToWorkshop's program (1 effect: TravelTo); writes
+        // 1 chronicle record per cast (kind=70). Task #235 split this
+        // out from the fused FoldTravel kernel so the runtime can
+        // dispatch the producer kernel before the FoldX consumer
+        // kernel and the per-dispatch barrier makes kind=70 records
+        // visible to the FoldTravel reader.
+        let walk_cfg = physics_verb_chronicle_WalkToWorkshop::PhysicsVerbChronicleWalkToWorkshopCfg {
+            event_count: self.agent_count,
+            tick: self.tick as u32,
+            seed: 0,
+            agent_cap: 0,
+        };
+        self.gpu.queue.write_buffer(
+            &self.chronicle_walk_cfg_buf,
+            0,
+            bytemuck::bytes_of(&walk_cfg),
+        );
+        let walk_bindings =
+            physics_verb_chronicle_WalkToWorkshop::PhysicsVerbChronicleWalkToWorkshopBindings {
+                event_ring: self.event_ring.ring(),
+                event_tail: self.event_ring.tail(),
+                agent_hp: &self.agent_hp_buf,
+                agent_max_hp: &self.agent_max_hp_buf,
+                agent_move_speed: &self.agent_move_speed_buf,
+                agent_armor: &self.agent_armor_buf,
+                agent_magic_resist: &self.agent_magic_resist_buf,
+                agent_attack_damage: &self.agent_attack_damage_buf,
+                agent_mana: &self.agent_mana_buf,
+                ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
+                ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
+                ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
+                ability_registry_chances: &self.registry_gpu.chances,
+                ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
+                ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
+                ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
+                ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
+                ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
+                ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
+                ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
+                ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
+                ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
+                cfg: &self.chronicle_walk_cfg_buf,
+            };
+        dispatch::dispatch_physics_verb_chronicle_walktoworkshop(
+            &mut self.cache,
+            &walk_bindings,
+            &self.gpu.device,
+            &mut encoder,
+            self.agent_count,
+        );
+
+        // (7) Fused PerEvent fold kernel — folds kinds 70-76 emitted in
+        // steps 4-6. Now that the producer kernels (ForgeIron / OfferDeal /
+        // WalkToWorkshop) are all sequenced BEFORE this fold pass, the
+        // per-dispatch GPU barrier guarantees their chronicle records are
+        // visible to every FoldX consumer. The pre-#235 double-dispatch
+        // workaround is gone — see `assets/sim/village_economy.sim::FoldTravel`
+        // for the analyzer fix that enabled the split.
         let event_count_estimate = self.agent_count * 8;
-        let fold_cfg = physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_FoldAnnounce_and_FoldSkill_and_FoldObligation_and_verb_chronicle_WalkToWorkshop::PhysicsFoldTravelAndFoldRecipeAndFoldWearAndFoldProposeAndFoldAnnounceAndFoldSkillAndFoldObligationAndVerbChronicleWalkToWorkshopCfg {
+        let fold_cfg = physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_FoldAnnounce_and_FoldSkill_and_FoldObligation::PhysicsFoldTravelAndFoldRecipeAndFoldWearAndFoldProposeAndFoldAnnounceAndFoldSkillAndFoldObligationCfg {
             event_count: event_count_estimate,
             tick: self.tick as u32,
             seed: 0,
@@ -699,61 +777,17 @@ impl CompiledSim for VillageEconomyState {
             0,
             bytemuck::bytes_of(&fold_cfg),
         );
-        let fold_bindings = physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_FoldAnnounce_and_FoldSkill_and_FoldObligation_and_verb_chronicle_WalkToWorkshop::PhysicsFoldTravelAndFoldRecipeAndFoldWearAndFoldProposeAndFoldAnnounceAndFoldSkillAndFoldObligationAndVerbChronicleWalkToWorkshopBindings {
+        let fold_bindings = physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_FoldAnnounce_and_FoldSkill_and_FoldObligation::PhysicsFoldTravelAndFoldRecipeAndFoldWearAndFoldProposeAndFoldAnnounceAndFoldSkillAndFoldObligationBindings {
             event_ring: self.event_ring.ring(),
             event_tail: self.event_ring.tail(),
             agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
             agent_shield_hp: &self.agent_shield_hp_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
             agent_mana: &self.agent_mana_buf,
             agent_hunger: &self.agent_hunger_buf,
             agent_disguise_expires_at_tick: &self.agent_disguise_expires_at_tick_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_chances: &self.registry_gpu.chances,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             cfg: &self.fold_cfg_buf,
         };
-        dispatch::dispatch_physics_foldtravel_and_foldrecipe_and_foldwear_and_foldpropose_and_foldannounce_and_foldskill_and_foldobligation_and_verb_chronicle_walktoworkshop(
-            &mut self.cache,
-            &fold_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            event_count_estimate,
-        );
-
-        // (6.5) DOUBLE DISPATCH — the compiler fused FoldTravel with
-        // verb_chronicle_WalkToWorkshop into one PerEvent kernel. Within
-        // a single kernel pass FoldTravel can't see the kind=70 records
-        // the dispatcher writes later in the same pass (no GPU barrier
-        // between producer + consumer threads). Dispatching the fused
-        // kernel a SECOND time means: (a) FoldTravel sees the kind=70
-        // records the first pass wrote and bumps the counter; (b) the
-        // FoldRecipe/Wear/Skill/Announce sub-ops re-fold the kinds
-        // 71/72/74/75 events written by ForgeIron's prior kernel,
-        // doubling those counters; (c) verb_chronicle_WalkToWorkshop
-        // re-fires emitting more kind=70 records (further inflating the
-        // travel counter on subsequent ticks but not double-counting
-        // within this tick — those new records get folded next tick's
-        // first pass).
-        //
-        // The behavioral pin only requires counters > 0 — doubling the
-        // numerical magnitudes is fine. Root cause + analyzer-fix path
-        // documented in `assets/sim/village_economy.sim::FoldTravel`.
-        dispatch::dispatch_physics_foldtravel_and_foldrecipe_and_foldwear_and_foldpropose_and_foldannounce_and_foldskill_and_foldobligation_and_verb_chronicle_walktoworkshop(
+        dispatch::dispatch_physics_foldtravel_and_foldrecipe_and_foldwear_and_foldpropose_and_foldannounce_and_foldskill_and_foldobligation(
             &mut self.cache,
             &fold_bindings,
             &self.gpu.device,


### PR DESCRIPTION
## Summary

- The schedule layer's rule 4 (producer/consumer event-ring split) used to push a placeholder `EventKindId(0)` for every `CgStmt::ApplyAbility`, missing the chronicle event kinds the WGSL dispatcher actually writes. Same-tick consumers (`physics on EffectXApplied { ... }`) fused with the dispatcher kernel and raced on the within-kernel barrier gap.
- Plumbed the `&AbilityRegistry` from build scripts through `synthesize_schedule_with_registry` into `collect_emits_in_list`, which now resolves a literal `apply_ability <N>` to its registry program and pushes the real `EventKindId`s its `EffectOp`s map to (via `EFFECT_KIND_TO_EVENT_KIND_ID`).
- Extended rule 4's `decide_join` walk to consider every member of the in-progress group (not just the tail) — Lift-A's village_economy ordered 7 consumers ahead of 1 producer, leaving the producer/consumer match invisible to the prev-only check.
- New entry points (`*_with_registry`) pass the registry through; pre-existing `synthesize_schedule` keeps its signature and forwards `None`, so unrelated runtime crates' build scripts don't change.
- Removed `village_economy_runtime`'s double-dispatch workaround. Fold counters halve as expected (recipes 80→40, tool_wear 15.6→7.8, consent 112→56) — the second pass was re-folding ForgeIron/OfferDeal's chronicle records. `travels_completed` stays at 8 (the prior second pass added the same kind=70 records to a zero from the first pass; now folded once in a single dispatch). No engine schema changes — `crates/engine/.schema_hash` unchanged.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p dsl_compiler --release` (all integration tests pass)
- [x] `cargo test -p engine --release --test schema_hash` (schema hash stable)
- [x] `RUST_MIN_STACK=33554432 cargo test -p village_economy_runtime --release --lib` (behavioral pin passes; counters now reflect single-pass folds)
- [x] `RUST_MIN_STACK=33554432 cargo test -p spy_network_runtime --release --lib`
- [x] `RUST_MIN_STACK=33554432 cargo test -p duel_25v25_runtime --release --lib`
- [x] Workspace-wide `cargo test --workspace --release --lib` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)