### PR TITLE
feat(dsl): when X else Y per-effect predicate clause

### DIFF
--- a/crates/dsl_ast/tests/ability_parser_wave_1_5.rs
+++ b/crates/dsl_ast/tests/ability_parser_wave_1_5.rs
@@ -217,6 +217,44 @@ fn parses_when_existing_atomic_still_works() {
     assert_eq!(cond.when_cond, "target.hp < 30");
 }
 
+// Task #228 — `when A else B` per-effect predicate clause. The `else`
+// branch is a full condition expression (no leading `when`); both
+// branches are captured verbatim so lowering can re-parse them through
+// the same predicate vocabulary as the `when` branch.
+
+#[test]
+fn when_else_parses_simple_atoms() {
+    let src = "ability X { target: enemy cooldown: 1s damage 50 when target.hp < 30 else target.hp > 70 }";
+    let file = parse_ability_file(src).expect("must parse");
+    let cond = file.abilities[0].effects[0].condition.as_ref().unwrap();
+    assert_eq!(cond.when_cond, "target.hp < 30");
+    assert_eq!(cond.else_cond.as_deref(), Some("target.hp > 70"));
+}
+
+#[test]
+fn when_else_with_compound_left_branch() {
+    // `when A && B else C` — left branch is compound, right is atom.
+    let src = "ability X { target: enemy cooldown: 1s damage 50 when target.hp < 30 && target.armor < 5 else target.magic_resist < 5 }";
+    let file = parse_ability_file(src).expect("must parse");
+    let cond = file.abilities[0].effects[0].condition.as_ref().unwrap();
+    assert_eq!(cond.when_cond, "target.hp < 30 && target.armor < 5");
+    assert_eq!(cond.else_cond.as_deref(), Some("target.magic_resist < 5"));
+}
+
+#[test]
+fn when_else_with_compound_right_branch() {
+    // `when A else B || C` — left branch is atom, right branch is
+    // compound. The else body extends to end-of-statement (`}` here).
+    let src = "ability X { target: enemy cooldown: 1s damage 50 when target.hp < 30 else target.armor < 5 || target.magic_resist < 5 }";
+    let file = parse_ability_file(src).expect("must parse");
+    let cond = file.abilities[0].effects[0].condition.as_ref().unwrap();
+    assert_eq!(cond.when_cond, "target.hp < 30");
+    assert_eq!(
+        cond.else_cond.as_deref(),
+        Some("target.armor < 5 || target.magic_resist < 5"),
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 5. `chance N%`
 // ---------------------------------------------------------------------------

--- a/crates/dsl_compiler/src/ability_lower.rs
+++ b/crates/dsl_compiler/src/ability_lower.rs
@@ -975,39 +975,6 @@ pub fn lower_ability_decl(decl: &AbilityDecl) -> Result<AbilityProgram, LowerErr
         // (`target.htp` for `target.hp`) that the syntax check
         // alone misses.
         let when = if let Some(c) = stmt.condition.as_ref() {
-            let when_expr = match dsl_ast::parser::parse_expression(&c.when_cond) {
-                Ok(e) => e,
-                Err(e) => {
-                    return Err(LowerError::WhenConditionParseError {
-                        ability:   decl.name.clone(),
-                        clause:    "when",
-                        predicate: c.when_cond.clone(),
-                        reason:    e.message.clone(),
-                        span:      c.span,
-                    });
-                }
-            };
-            if let Some((binder, field)) = first_unknown_agent_field(&when_expr) {
-                return Err(LowerError::WhenConditionUnknownField {
-                    ability: decl.name.clone(),
-                    clause:  "when",
-                    binder,
-                    field,
-                    span:    c.span,
-                });
-            }
-            // Wave 1.5#7 GPU eval (this slice): reject `else <cond>`
-            // at lower time. The CPU + GPU evaluators ignore else_cond
-            // — accepting it silently would misrepresent the gate's
-            // semantics. Open task #163-followup.
-            if c.else_cond.is_some() {
-                return Err(LowerError::WhenConditionUnsupported {
-                    ability: decl.name.clone(),
-                    clause:  "else",
-                    reason:  "deferred — open task #163-followup".to_string(),
-                    span:    c.span,
-                });
-            }
             // Task #227: lower the predicate to a Boolean tree
             // (`WhenPredicate`) with `EffectPredicate` atoms at the
             // leaves. The tree handles `&&` / `||` / `!`; the simple
@@ -1018,12 +985,26 @@ pub fn lower_ability_decl(decl: &AbilityDecl) -> Result<AbilityProgram, LowerErr
             // working. Restricted leaf vocab (form
             // `<binder>.<field> <op> <literal>`); anything else
             // surfaces WhenConditionUnsupported / -UnsupportedField.
-            let when_compound = extract_when_predicate(
-                &when_expr,
-                &decl.name,
-                "when",
-                c.span,
+            let when_then = parse_when_branch(
+                &c.when_cond, "when", &decl.name, c.span,
             )?;
+            // Task #228: optional `else <cond>` branch — semantically
+            // equivalent to `when X || Y` for this slice. The
+            // structural distinction (which branch matched) lives at
+            // the source-text layer (`EffectWhenCondition::else_cond`
+            // is preserved verbatim below) so future extensions can
+            // light up branch-distinguishing semantics without an IR
+            // bump. Combining via `Or` lets the existing RPN encoding
+            // and both backend evaluators handle it transparently —
+            // no new sentinels, no schema bump.
+            let when_compound = if let Some(else_text) = c.else_cond.as_ref() {
+                let when_else = parse_when_branch(
+                    else_text, "else", &decl.name, c.span,
+                )?;
+                WhenPredicate::Or(Box::new(when_then), Box::new(when_else))
+            } else {
+                when_then
+            };
             // Bound the RPN stride. Counting nodes here gives an early
             // diagnostic at the author's screen rather than a defensive
             // truncate at SoA pack time.
@@ -1046,7 +1027,11 @@ pub fn lower_ability_decl(decl: &AbilityDecl) -> Result<AbilityProgram, LowerErr
             };
             Some(EffectWhenCondition {
                 when_cond:     c.when_cond.clone(),
-                else_cond:     None, // gated above; guaranteed None here
+                // Task #228: preserve verbatim else-branch source text
+                // so future extensions can recover which branch
+                // matched. The lowered `when_compound` already encodes
+                // both branches as `Or(then, else)` for execution.
+                else_cond:     c.else_cond.clone(),
                 when_compiled,
                 when_compound: Some(when_compound),
             })
@@ -2236,6 +2221,40 @@ fn summon_template_hash(template: &str) -> u32 {
     // mixes bits well; this is a pure compaction step.
     let full = h.finish();
     ((full >> 32) as u32) ^ (full as u32)
+}
+
+/// Task #228: parse + validate one branch of a per-effect predicate
+/// clause (the `when` body or the optional `else` body) and lower it
+/// to a [`WhenPredicate`] tree. Re-parses the verbatim source slice
+/// the AST captured (since Wave 1.5's parser stops at the next
+/// modifier keyword without validating the predicate grammar), then
+/// runs the same vocabulary check the legacy `when` path uses, so the
+/// `else` branch surfaces typos with a `clause: "else"` diagnostic.
+fn parse_when_branch(
+    source:  &str,
+    clause:  &'static str,
+    ability: &str,
+    span:    Span,
+) -> Result<WhenPredicate, LowerError> {
+    let expr = dsl_ast::parser::parse_expression(source).map_err(|e| {
+        LowerError::WhenConditionParseError {
+            ability:   ability.to_string(),
+            clause,
+            predicate: source.to_string(),
+            reason:    e.message.clone(),
+            span,
+        }
+    })?;
+    if let Some((binder, field)) = first_unknown_agent_field(&expr) {
+        return Err(LowerError::WhenConditionUnknownField {
+            ability: ability.to_string(),
+            clause,
+            binder,
+            field,
+            span,
+        });
+    }
+    extract_when_predicate(&expr, ability, clause, span)
 }
 
 /// Task #227: recursive extraction of a [`WhenPredicate`] tree from

--- a/crates/dsl_compiler/tests/ability_lower_wave_1_5.rs
+++ b/crates/dsl_compiler/tests/ability_lower_wave_1_5.rs
@@ -914,17 +914,78 @@ fn lower_when_predicate_literal_lhs_flips_op() {
 }
 
 #[test]
-fn lower_when_predicate_else_clause_errors() {
+fn lower_when_predicate_else_clause_lowers_to_or() {
+    // Task #228: `when A else B` is sugar for `when A || B` — both
+    // branches yield the same effect application. The lower path
+    // wraps the two branches as `Or(then, else)` so the existing
+    // CPU + GPU evaluators handle it transparently. Source text for
+    // both branches is preserved on the slot for future
+    // branch-distinguishing extensions.
     use dsl_ast::parse_ability_file;
-    use dsl_compiler::ability_lower::{lower_ability_decl, LowerError};
+    use dsl_compiler::ability_lower::lower_ability_decl;
+    use engine::ability::program::WhenPredicate;
     let file = parse_ability_file(
         "ability X { target: enemy cooldown: 1s damage 50 when target.hp < 30 else target.hp > 70 }"
     ).expect("parser");
-    let err = lower_ability_decl(&file.abilities[0]).unwrap_err();
-    assert!(
-        matches!(err, LowerError::WhenConditionUnsupported { clause: "else", .. }),
-        "expected WhenConditionUnsupported{{clause:\"else\"}}, got {err:?}",
-    );
+    let prog = lower_ability_decl(&file.abilities[0])
+        .expect("`when X else Y` must lower (task #228)");
+    let cond = prog.when_per_effect[0].as_ref().expect("slot populated");
+    // Source text for both branches preserved verbatim.
+    assert_eq!(cond.when_cond, "target.hp < 30");
+    assert_eq!(cond.else_cond.as_deref(), Some("target.hp > 70"));
+    // Lowered tree is Or(then, else) — execution semantics match
+    // `when A || B`.
+    let tree = cond.when_compound.as_ref().expect("compound tree populated");
+    match tree {
+        WhenPredicate::Or(lhs, rhs) => {
+            assert!(matches!(lhs.as_ref(), WhenPredicate::Atom(_)),
+                "lhs must be the `when` branch atom (target.hp < 30)");
+            assert!(matches!(rhs.as_ref(), WhenPredicate::Atom(_)),
+                "rhs must be the `else` branch atom (target.hp > 70)");
+        }
+        other => panic!("expected WhenPredicate::Or, got {other:?}"),
+    }
+    // Compound trees do not populate the legacy single-atom slot.
+    assert!(cond.when_compiled.is_none(),
+        "Or(then, else) is compound — `when_compiled` should be None");
+}
+
+#[test]
+fn lower_when_else_packs_identically_to_or() {
+    // Task #228: `when A else B` and `when A || B` must produce
+    // identical packed RPN bytes — they share the same lowered tree
+    // shape (`Or(then, else)`) and pack via the same `0xFD` OR
+    // sentinel. This is the brief's core invariant: per-effect `else`
+    // is parser-and-lower sugar with zero IR / schema-hash impact.
+    use dsl_ast::parse_ability_file;
+    use dsl_compiler::ability_lower::lower_ability_decl;
+    use engine::ability::packed::PackedAbilityRegistry;
+    use engine::ability::AbilityRegistryBuilder;
+    let with_else = parse_ability_file(
+        "ability X { target: enemy cooldown: 1s damage 50 when target.hp < 30 else target.armor < 5 }"
+    ).expect("parser");
+    let with_or = parse_ability_file(
+        "ability X { target: enemy cooldown: 1s damage 50 when target.hp < 30 || target.armor < 5 }"
+    ).expect("parser");
+    let prog_else = lower_ability_decl(&with_else.abilities[0]).expect("else lowers");
+    let prog_or   = lower_ability_decl(&with_or.abilities[0]).expect("or lowers");
+    let mut b_else = AbilityRegistryBuilder::new();
+    b_else.register(prog_else);
+    let mut b_or = AbilityRegistryBuilder::new();
+    b_or.register(prog_or);
+    // Pack both and compare the four `when_pred_*` SoA columns
+    // (binder / field / op / literal). These columns ARE the RPN
+    // encoding — identical bytes prove cross-backend parity.
+    let packed_else = PackedAbilityRegistry::pack(&b_else.build());
+    let packed_or   = PackedAbilityRegistry::pack(&b_or.build());
+    assert_eq!(packed_else.when_pred_binder, packed_or.when_pred_binder,
+        "`when A else B` and `when A || B` must pack to identical RPN binder bytes");
+    assert_eq!(packed_else.when_pred_field, packed_or.when_pred_field,
+        "`when A else B` and `when A || B` must pack to identical RPN field bytes");
+    assert_eq!(packed_else.when_pred_op, packed_or.when_pred_op,
+        "`when A else B` and `when A || B` must pack to identical RPN op bytes");
+    assert_eq!(packed_else.when_pred_literal, packed_or.when_pred_literal,
+        "`when A else B` and `when A || B` must pack to identical RPN literal bytes");
 }
 
 #[test]
@@ -1095,4 +1156,37 @@ fn lower_when_predicate_tree_too_large_errors() {
         matches!(err, LowerError::WhenConditionTreeTooLarge { .. }),
         "expected WhenConditionTreeTooLarge, got {err:?}",
     );
+}
+
+#[test]
+fn lower_when_else_else_branch_only_match_fires_effect() {
+    // Task #228 behavioral end-to-end: parse `when A else B`, lower,
+    // then apply with stats that satisfy ONLY the else branch. The
+    // effect must fire — confirms `else` is wired into the runtime
+    // evaluator, not just parsed into source-text.
+    //
+    // Predicate: `when target.hp < 30 else target.hp > 70` with a
+    // target at hp = 80 → only the else branch is true → fires.
+    use dsl_ast::parse_ability_file;
+    use dsl_compiler::ability_lower::lower_ability_decl;
+    use engine::ability::apply::apply_program;
+    use engine::ability::program::CasterStats;
+    use engine::ids::AgentId;
+    let file = parse_ability_file(
+        "ability X { target: enemy cooldown: 1s damage 50 when target.hp < 30 else target.hp > 70 }"
+    ).expect("parser");
+    let prog = lower_ability_decl(&file.abilities[0]).expect("lower");
+    let caster = AgentId::new(1).unwrap();
+    let target = AgentId::new(2).unwrap();
+    let target_hi = CasterStats { hp: 80.0, ..Default::default() };
+    let evs = apply_program(&prog, caster, target, 0, 0xCAFE,
+        &CasterStats::default(), &target_hi);
+    assert_eq!(evs.len(), 1,
+        "target.hp=80 satisfies else branch (>70) — effect must fire");
+    // Sanity: middle band where neither branch holds → effect skipped.
+    let target_mid = CasterStats { hp: 50.0, ..Default::default() };
+    let evs = apply_program(&prog, caster, target, 0, 0xCAFE,
+        &CasterStats::default(), &target_mid);
+    assert_eq!(evs.len(), 0,
+        "target.hp=50 satisfies neither branch — effect must skip");
 }


### PR DESCRIPTION
## Summary

- Per-effect `when <cond>` modifiers (spec §6.1 slot 7) now accept an optional `else <cond>` continuation. `when A else B` lowers to `WhenPredicate::Or(then, else)` and packs to **identical** `when_pred_*` SoA bytes as `when A || B` (proved by `lower_when_else_packs_identically_to_or`).
- Verbatim `when_cond` and `else_cond` source text are preserved on `EffectWhenCondition` so future extensions (branch-attributed logging, per-branch scaling) can recover which clause matched without an IR migration.
- Replaces the previous hard reject (`WhenConditionUnsupported { clause: "else" }`) from the original Wave 1.5 GPU-eval slice. Else-branch parse / unknown-field errors are clause-attributed (`clause: "else"`).
- No engine evaluator changes. No new RPN sentinels. Schema hash unchanged.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p dsl_ast --release` — 3 new parser tests (`when_else_parses_simple_atoms`, `when_else_with_compound_left_branch`, `when_else_with_compound_right_branch`)
- [x] `cargo test -p dsl_compiler --release` — replaced rejection test with `lower_when_predicate_else_clause_lowers_to_or`; added `lower_when_else_packs_identically_to_or` (RPN-byte equality vs `||`) and `lower_when_else_else_branch_only_match_fires_effect` (end-to-end behavioral)
- [x] `cargo test -p engine --release --test schema_hash` — schema hash unchanged
- [x] `RUST_MIN_STACK=33554432 cargo test -p spy_network_runtime --release --lib`
- [x] `RUST_MIN_STACK=33554432 cargo test -p village_economy_runtime --release --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)