### PR TITLE
feat(dsl): pin Hull AOE shape semantics (was aliased to Sphere)

### DIFF
--- a/crates/apply_ability_smoke_runtime/tests/aoe_chronicle_pin.rs
+++ b/crates/apply_ability_smoke_runtime/tests/aoe_chronicle_pin.rs
@@ -1047,12 +1047,14 @@ fn aoe_dome_includes_y_zero_plane_on_gpu() {
 }
 
 #[test]
-fn aoe_hull_aliases_sphere_on_gpu() {
-    // #181 Hull — Sphere alias today (no spec semantics; see
-    // `apply_program_aoe_hull_filter` doc-comment NOTE). Fixture: 4-
-    // agent row. Hull(r=2): same gate as Sphere (3D dist² ≤ radius²).
-    // Hits slot 0 + slot 1. Expected: 2 chronicle records. Pin the
-    // alias so a future spec change surfaces here.
+fn aoe_hull_castle_footprint_on_gpu() {
+    // #181 Hull — castle footprint (Task #231): cube(half-extent r) ∩
+    // sphere(r·√2). Fixture: 4-agent row at x={0,1.5,3.0,4.5}. With
+    // r=2: cube gate `|dx| ≤ 2` keeps slots 0+1 only (slots 2/3 have
+    // x=3.0/4.5 > 2.0). Bevel gate is non-binding for axis-aligned
+    // candidates (d=1.5 < 2·√2). Expected: 2 chronicle records (slot
+    // 0 + slot 1). The CPU oracle and GPU branch must agree byte-
+    // wise — pinned via this end-to-end test.
     let mut bulwark = AbilityProgram::new_single_target(
         5.0,
         Gate { cooldown_ticks: 30, hostile_only: true, line_of_sight: false },
@@ -1098,7 +1100,7 @@ fn aoe_hull_aliases_sphere_on_gpu() {
     let tail = state.read_event_tail();
     assert_eq!(
         tail, 2,
-        "Hull(r=2) aliases Sphere — hits slots 0 + 1. Got tail={tail}",
+        "Hull(r=2) castle footprint — cube gate keeps slots 0+1 (x=0, 1.5; x=3.0+ outside cube). Got tail={tail}",
     );
     let mut records = state.read_event_ring(tail);
     records.sort_by_key(|r| (r[3], r[0]));

--- a/crates/apply_ability_smoke_runtime/tests/parity_apply_program_sweep.rs
+++ b/crates/apply_ability_smoke_runtime/tests/parity_apply_program_sweep.rs
@@ -915,12 +915,16 @@ fn build_sweep() -> Vec<(&'static str, AbilityProgram, CasterStats)> {
         CasterStats::default(),
     ));
 
-    // 42. Bulwark-shape — `Damage(5) in hull(2)` (#181 AOE Path B Hull).
-    //     **Hull is a Sphere alias today** (no spec semantics defined —
-    //     see `apply_program_aoe_hull_filter` doc-comment NOTE). With
-    //     radius=2, behaves identically to BlastSphere: under the 4-agent
-    //     row, hits slot 0 + slot 1. Pin the alias so a future spec
-    //     change surfaces here. Both backends emit 2 chronicle records.
+    // 42. Bulwark-shape — `Damage(5) in hull(2)` (#181 AOE Path B Hull;
+    //     semantics pinned in Task #231). Hull = castle-footprint:
+    //     cube(half-extent r) ∩ sphere(r·√2). With r=2 on the 4-agent
+    //     row at x={0, 1.5, 3.0, 4.5}, the cube gate `|dx| ≤ 2` keeps
+    //     slots 0+1 only (slots 2+3 are outside the cube). Bevel gate
+    //     non-binding for axis-aligned candidates. Both backends emit
+    //     2 chronicle records — the predicate runs identically on each
+    //     side. (Distinctness from Sphere/Box is pinned in the engine
+    //     unit tests; this entry exercises the dispatch + chronicle
+    //     write path through the GPU sweep.)
     let mut bulwark = AbilityProgram::new_single_target(
         5.0,
         Gate { cooldown_ticks: 30, hostile_only: true, line_of_sight: false },

--- a/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
+++ b/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
@@ -2792,16 +2792,21 @@ fn build_apply_ability_per_target_body(
          \x20               } // end for dy (dome walk)\n\
          \x20           } // end for dz (dome walk)\n\
          \x20       } else if (area_kind == 11u) {\n\
-         \x20           // Hull (#181). area_args layout: [radius, _, _, _]. NOTE:\n\
-         \x20           // Hull is a Sphere alias today — spec semantics are not\n\
-         \x20           // nailed down (no doc-comment on `ShapeKind::Hull`, no spec\n\
-         \x20           // text under `dataset/abilities/`). Until refined, Hull\n\
-         \x20           // routes through the same `dist² ≤ radius²` gate as Sphere\n\
-         \x20           // (kind=6). When/if Hull's true semantics land, update both\n\
-         \x20           // this branch and `apply_program_aoe_hull_filter` together.\n\
+         \x20           // Hull (#181). area_args layout: [radius, _, _, _].\n\
+         \x20           //\n\
+         \x20           // **Semantics pinned in Task #231 (2026-05-08).** Hull is\n\
+         \x20           // the **castle-footprint** per ability.md §9.2: a cube of\n\
+         \x20           // half-extent `r` with the 8 corners chamfered off by a\n\
+         \x20           // bevel sphere of radius `r·√2`. In-hull predicate:\n\
+         \x20           //   1. Cube gate:  |dx| ≤ r ∧ |dy| ≤ r ∧ |dz| ≤ r\n\
+         \x20           //   2. Bevel gate: dx² + dy² + dz² ≤ 2·r² (= (r·√2)²)\n\
+         \x20           //\n\
+         \x20           // Distinct from both Sphere(r) (smaller — only within r)\n\
+         \x20           // and Box(r,r,r) (larger — corners up to r·√3 not clipped).\n\
+         \x20           // Mirrors `apply_program_aoe_hull_filter` bit-for-bit.\n\
          \x20           let area_args_base: u32 = (effect_base + i) * 4u;\n\
          \x20           let radius: f32 = ability_registry_area_args[area_args_base + 0u];\n\
-         \x20           let radius_sq: f32 = radius * radius;\n\
+         \x20           let bevel_sq: f32 = 2.0 * radius * radius;\n\
          \x20           let aoe_center: vec3<f32> = agent_pos[target_slot];\n\
          \x20           let _self_cell_f = (aoe_center + vec3<f32>(SPATIAL_WORLD_HALF_EXTENT)) / SPATIAL_CELL_SIZE;\n\
          \x20           let _max_idx = i32(SPATIAL_GRID_DIM) - 1;\n\
@@ -2818,7 +2823,12 @@ fn build_apply_ability_per_target_body(
          \x20                           let _candidate: u32 = spatial_grid_cells[_i];\n\
          \x20                           let _cand_pos: vec3<f32> = agent_pos[_candidate];\n\
          \x20                           let _dvec: vec3<f32> = _cand_pos - aoe_center;\n\
-         \x20                           if (dot(_dvec, _dvec) > radius_sq) { continue; }\n\
+         \x20                           // Cube gate (half-extent r per axis).\n\
+         \x20                           if (abs(_dvec.x) > radius) { continue; }\n\
+         \x20                           if (abs(_dvec.y) > radius) { continue; }\n\
+         \x20                           if (abs(_dvec.z) > radius) { continue; }\n\
+         \x20                           // Bevel sphere gate (radius r·√2).\n\
+         \x20                           if (dot(_dvec, _dvec) > bevel_sq) { continue; }\n\
          \x20                           let target_slot: u32 = _candidate;\n",
     );
     s.push_str(primary_arm_chain);

--- a/crates/engine/src/ability/apply.rs
+++ b/crates/engine/src/ability/apply.rs
@@ -846,9 +846,9 @@ pub fn apply_program_aoe(
                         || shape.kind == ShapeKind::Ring
                         || shape.kind == ShapeKind::Line
                         // #181 AOE Path B remaining shapes: Spread, Column,
-                        // Wall, Cylinder, Dome, Hull. Hull is a Sphere alias
-                        // (no separate filter helper today; see
-                        // `apply_program_aoe_sphere_filter` doc).
+                        // Wall, Cylinder, Dome, Hull. Hull semantics pinned
+                        // in Task #231 — castle-footprint (cube ∩ bevel
+                        // sphere); see `apply_program_aoe_hull_filter`.
                         || shape.kind == ShapeKind::Spread
                         || shape.kind == ShapeKind::Column
                         || shape.kind == ShapeKind::Wall
@@ -1438,34 +1438,61 @@ pub fn apply_program_aoe_dome_filter(
     hits
 }
 
-/// CPU-side hull-filter oracle for AOE Path B Hull (#181). The Hull
-/// shape's spec semantics are not nailed down today — the only place
-/// it's mentioned in the codebase is `ShapeKind::Hull = 11` in
-/// `program.rs` (no doc-comment, no spec text under
-/// `dataset/abilities/`). Without a spec, we ship Hull as an **alias to
-/// Sphere** (3D `dist² ≤ radius²`) so author intent matching the most
-/// common reading ("hull around me") works, and a future spec change
-/// can refine the gate without an API break (the args slot already
-/// reserves 4 f32, only `args[0]` is consumed today).
-///
-/// **NOTE: Hull is a Sphere alias.** When/if the spec defines Hull as
-/// a distinct shape (convex hull around an entity group? equipment-
-/// blob hitbox? something else), update both this filter and the GPU
-/// branch in `wgsl_body.rs` together.
+/// CPU-side hull-filter oracle for AOE Path B Hull (#181, semantics
+/// pinned in Task #231 — 2026-05-08). Hull is a **castle-footprint**
+/// per `docs/spec/ability.md` §9.2: a cube of half-extent `r` with its
+/// 8 corners chamfered off by a `r·√2` bevel sphere. Mirrors the GPU
+/// kernel's WGSL math bit-for-bit.
 ///
 /// Inputs:
 ///   * `center` — explicit cast target's position.
-///   * `radius` — `args[0]` (sphere radius).
+///   * `radius` — `args[0]` (cube half-extent; bevel sphere radius is
+///     `radius·√2`, derived — not a separate arg).
 ///   * `candidates` — slice of `(AgentId, position)` pairs.
 ///
 /// Output: in-hull `AgentId`s sorted ascending by raw id (P11).
+///
+/// In-hull predicate (per candidate, identical to the WGSL kernel):
+///   1. **Cube gate**: `|dx| ≤ r ∧ |dy| ≤ r ∧ |dz| ≤ r` (axis-aligned
+///      cube of half-extent `r`).
+///   2. **Bevel sphere gate**: `dx² + dy² + dz² ≤ 2·r²` (sphere of
+///      radius `r·√2` clips off the 8 cube corners). Uses `2.0 * r²`
+///      directly (avoids the `(r * sqrt2)²` round-trip — bit-equal
+///      across backends).
+///
+/// **Geometric distinctness from Sphere & Box.** Hull is a strict
+/// superset of `sphere(r)` (a candidate at `(r, 0, 0)` is in-hull —
+/// face-center, dist=r — but in-sphere only at the boundary), and a
+/// strict subset of `box(r, r, r)` (a candidate at `(r, r, r)` —
+/// corner, dist=r·√3 — is in-box but out-of-hull because the bevel
+/// gate `r·√3 > r·√2` clips it). Edge midpoints (e.g. `(r, r, 0)`,
+/// dist=r·√2) sit exactly on the bevel boundary (inclusive `≤`).
+///
+/// **P11.** Both backends evaluate the predicate identically (same f32
+/// ops in the same order: subtract, abs, dot, two compare branches).
+/// The final sort makes the post-filter set deterministic.
 pub fn apply_program_aoe_hull_filter(
     center:     glam::Vec3,
     radius:     f32,
     candidates: &[(AgentId, glam::Vec3)],
 ) -> Vec<AgentId> {
-    // Hull is a Sphere alias today (see doc-comment NOTE above).
-    apply_program_aoe_sphere_filter(center, radius, candidates)
+    let bevel_sq = 2.0 * radius * radius;
+    let mut hits: Vec<AgentId> = Vec::with_capacity(candidates.len());
+    for &(id, cand_pos) in candidates {
+        let dvec = cand_pos - center;
+        // Cube gate (half-extent r on each axis).
+        if dvec.x.abs() > radius || dvec.y.abs() > radius || dvec.z.abs() > radius {
+            continue;
+        }
+        // Bevel sphere gate (radius r·√2 — clips corners).
+        if dvec.dot(dvec) > bevel_sq {
+            continue;
+        }
+        hits.push(id);
+    }
+    // P11 reduction-determinism: sort ascending by raw AgentId.
+    hits.sort_by_key(|id| id.raw());
+    hits
 }
 
 /// One spawned summon: the freshly-allocated `agent_id` plus the
@@ -3199,20 +3226,45 @@ mod tests {
     }
 
     #[test]
-    fn aoe_hull_filter_aliases_sphere() {
-        // Hull is a Sphere alias today (see filter doc-comment NOTE).
-        // Pin equivalence so any future spec change surfaces.
+    fn aoe_hull_filter_castle_footprint_distinct_from_sphere_and_box() {
+        // Task #231: Hull = cube(half-extent r) ∩ sphere(r·√2). Pin the
+        // distinctness from both Sphere and Box so the alias regression
+        // never silently re-lands.
+        //
+        // r = 2.0 → bevel sphere radius = 2·√2 ≈ 2.828.
+        // - face center (2, 0, 0) dist=2.0  : in-cube, in-bevel → IN
+        // - edge mid    (2, 2, 0) dist=2·√2 : in-cube, on-bevel → IN (≤)
+        // - corner      (2, 2, 2) dist=2·√3 : in-cube, out-bevel → OUT (corner clipped)
+        // - sphere out  (3, 0, 0) dist=3.0  : OUT (cube fails on x)
+        // - bevel out   (1.5,1.5,1.5) d=√6.75≈2.598 : in-cube, in-bevel → IN
         let center = glam::Vec3::new(0.0, 0.0, 0.0);
         let candidates = vec![
-            (agent_n(1), glam::Vec3::new(0.0, 0.0, 0.0)),
-            (agent_n(2), glam::Vec3::new(1.0, 1.0, 1.0)),
-            (agent_n(3), glam::Vec3::new(0.0, 0.0, 2.001)),
+            (agent_n(1), glam::Vec3::new(2.0, 0.0, 0.0)),    // face center: IN
+            (agent_n(2), glam::Vec3::new(2.0, 2.0, 0.0)),    // edge mid (boundary): IN
+            (agent_n(3), glam::Vec3::new(2.0, 2.0, 2.0)),    // corner: OUT (bevel clip)
+            (agent_n(4), glam::Vec3::new(3.0, 0.0, 0.0)),    // outside cube: OUT
+            (agent_n(5), glam::Vec3::new(1.5, 1.5, 1.5)),    // interior: IN
         ];
         let hull_hits = apply_program_aoe_hull_filter(center, 2.0, &candidates);
-        let sphere_hits = apply_program_aoe_sphere_filter(center, 2.0, &candidates);
         assert_eq!(
+            hull_hits,
+            vec![agent_n(1), agent_n(2), agent_n(5)],
+            "hull(r=2) castle footprint: face/edge/interior IN; corner+outside OUT; got {hull_hits:?}"
+        );
+
+        // Distinctness pin: Hull must differ from BOTH Sphere(r) and
+        // Box(r,r,r) on this candidate set.
+        let sphere_hits = apply_program_aoe_sphere_filter(center, 2.0, &candidates);
+        // Sphere(r=2): face center (d=2.0) IN, edge mid (d=2·√2≈2.83) OUT, etc.
+        assert_ne!(
             hull_hits, sphere_hits,
-            "hull must alias sphere today; got hull={hull_hits:?} sphere={sphere_hits:?}"
+            "Hull must differ from Sphere — Hull is no longer a Sphere alias"
+        );
+        let box_hits = apply_program_aoe_box_filter(center, 2.0, 2.0, 2.0, &candidates);
+        // Box(r,r,r): includes corner (2,2,2) — Hull excludes it.
+        assert_ne!(
+            hull_hits, box_hits,
+            "Hull must differ from Box — bevel clips the corners"
         );
     }
 

--- a/crates/engine/tests/aoe_multi_agent_e2e.rs
+++ b/crates/engine/tests/aoe_multi_agent_e2e.rs
@@ -1023,9 +1023,13 @@ fn aoe_dome_above_plane_only_three_agent_fixture() {
 }
 
 #[test]
-fn aoe_hull_aliases_sphere_three_agent_fixture() {
-    // Hull(r=1.5) — Sphere alias today. Three agents in a row at x=0,
-    // 1, 2: hits ids[0] (d=0) + ids[1] (d=1); ids[2] (d=2 > 1.5) OUT.
+fn aoe_hull_castle_footprint_three_agent_fixture() {
+    // Task #231: Hull(r=1.5) is a castle-footprint — cube(half-extent
+    // 1.5) ∩ sphere(1.5·√2 ≈ 2.121). Three agents in a row at x=0, 1,
+    // 2: hits ids[0] (in cube + bevel) + ids[1] (d=1, in cube + bevel);
+    // ids[2] (x=2 > cube half-extent 1.5) OUT — same victim set as the
+    // prior Sphere alias for THIS axis-aligned row, but the hull and
+    // sphere filters are NOT identical (see distinctness pin below).
     let mut state = SimState::new(8, 0xCAFE);
     let ids = spawn_row(&mut state, 3);
 
@@ -1048,16 +1052,42 @@ fn aoe_hull_aliases_sphere_three_agent_fixture() {
     assert_eq!(
         aoe_targets,
         vec![ids[0], ids[1]],
-        "hull(r=1.5) aliases sphere — hits ids[0..=1]; got {aoe_targets:?}"
+        "hull(r=1.5) castle footprint — hits ids[0..=1]; got {aoe_targets:?}"
     );
 
-    // Also validate the alias against the sphere filter directly.
-    let sphere_targets = apply_program_aoe_sphere_filter(center, 1.5, &candidates);
-    assert_eq!(
-        sphere_targets, aoe_targets,
-        "hull must match sphere result today (alias semantics); \
-         hull={aoe_targets:?} sphere={sphere_targets:?}"
+    // Distinctness pin: synthetic candidate at the cube corner (1.5,
+    // 1.5, 1.5), dist=1.5·√3 ≈ 2.598 > bevel 1.5·√2 ≈ 2.121 — Hull
+    // OUT, Box IN. Exercises the bevel clip that distinguishes Hull
+    // from Box.
+    let synthetic_corner = (
+        AgentId::new(99).unwrap(),
+        center + glam::Vec3::new(1.5, 1.5, 1.5),
     );
+    let mut candidates_with_corner = candidates.clone();
+    candidates_with_corner.push(synthetic_corner);
+    let hull_with_corner = apply_program_aoe_hull_filter(center, 1.5, &candidates_with_corner);
+    let box_with_corner = apply_program_aoe_box_filter(center, 1.5, 1.5, 1.5, &candidates_with_corner);
+    assert!(!hull_with_corner.contains(&synthetic_corner.0),
+        "Hull must clip the cube corner (bevel sphere); got {hull_with_corner:?}");
+    assert!(box_with_corner.contains(&synthetic_corner.0),
+        "Box must include the cube corner; got {box_with_corner:?}");
+
+    // Distinctness pin: synthetic candidate at face-center (1.5, 0, 0),
+    // dist=1.5 — Hull IN (in cube + bevel), Sphere with the SAME radius
+    // also IN — but at edge midpoint (1.5, 1.5, 0), dist=1.5·√2 ≈ 2.121
+    // > sphere radius 1.5 — Hull IN (on bevel boundary), Sphere OUT.
+    let synthetic_edge = (
+        AgentId::new(98).unwrap(),
+        center + glam::Vec3::new(1.5, 1.5, 0.0),
+    );
+    let mut candidates_with_edge = candidates.clone();
+    candidates_with_edge.push(synthetic_edge);
+    let hull_with_edge = apply_program_aoe_hull_filter(center, 1.5, &candidates_with_edge);
+    let sphere_with_edge = apply_program_aoe_sphere_filter(center, 1.5, &candidates_with_edge);
+    assert!(hull_with_edge.contains(&synthetic_edge.0),
+        "Hull must include the edge midpoint (on bevel); got {hull_with_edge:?}");
+    assert!(!sphere_with_edge.contains(&synthetic_edge.0),
+        "Sphere(r=1.5) must exclude the edge midpoint (d=2.12 > 1.5); got {sphere_with_edge:?}");
 
     let events = apply_program_aoe(
         &prog, ids[0], ids[0], &aoe_targets, 0, 0xCAFE,

--- a/docs/spec/ability.md
+++ b/docs/spec/ability.md
@@ -1002,6 +1002,22 @@ Thickness override: `circle(3.0) thickness 2` → 2-voxel-thick disc.
 | `dome` | `dome(r)` | Hemisphere | `planned` |
 | `hull` | `hull(r)` | Castle-footprint (cuboid w/ beveled corners) | `planned` |
 
+**`hull(r)` predicate (pinned 2026-05-08, Task #231):** intersection of an
+axis-aligned cube of half-extent `r` with a sphere of radius `r·√2`. A
+candidate is in-hull when **both** gates hold:
+
+1. `|dx| ≤ r ∧ |dy| ≤ r ∧ |dz| ≤ r`  (cube of half-extent `r`)
+2. `dx² + dy² + dz² ≤ 2·r²`           (bevel sphere — `r·√2` radius)
+
+Geometric meaning: a cube with its 8 corners chamfered off. The face
+centers (`dist = r`) are in, the edge midpoints (`dist = r·√2`) are on
+the bevel boundary (inclusive), the corners (`dist = r·√3`) are clipped.
+This produces a victim set strictly between `sphere(r)` (smaller — only
+within `r`) and `box(r, r, r)` (larger — includes corners up to `r·√3`).
+Was previously aliased to Sphere; both backends now implement the
+distinct predicate (CPU oracle: `apply_program_aoe_hull_filter`; GPU:
+`area_kind == 11u` branch in `wgsl_body.rs`).
+
 ### 9.3 Orientation
 
 - Default: inferred from caster → cast direction. For `target: ground`,


### PR DESCRIPTION
## Summary

- Hull (`hull(r)`, `ShapeKind=11`) was silently aliased to Sphere on both backends. The spec text in `docs/spec/ability.md` §9.2 already defined Hull as **"Castle-footprint (cuboid w/ beveled corners)"** — this PR lands the predicate behind that text on both CPU oracle and GPU dispatcher.
- **In-hull predicate**: `cube(half-extent r) ∩ sphere(r·√2)`:
  1. `|dx| ≤ r ∧ |dy| ≤ r ∧ |dz| ≤ r`  (cube gate)
  2. `dx² + dy² + dz² ≤ 2·r²`           (bevel sphere — clips the 8 corners)
- Strict superset of `sphere(r)`, strict subset of `box(r,r,r)`. Edge midpoints (dist=r·√2) sit exactly on the bevel boundary (inclusive `≤`).
- Schema hash unchanged (no new variants, just the per-shape predicate body).

## Why this interpretation

The spec was not silent — `ability.md` §9.2 already said Hull = "Castle-footprint (cuboid w/ beveled corners)". The cube ∩ sphere intersection is the standard mathematical formulation of "cube with chamfered/beveled corners" and is the simplest reading that yields a victim set distinct from both Sphere and Box (the prerequisites for "this isn't an alias"). The bevel sphere radius `r·√2` is chosen so that face centers (`dist = r`) and edge midpoints (`dist = r·√2`) are in-hull while corners (`dist = r·√3`) are clipped.

## Files touched

- `docs/spec/ability.md` — added the predicate definition under the §9.2 table.
- `crates/engine/src/ability/apply.rs` — replaced `apply_program_aoe_hull_filter` body (was `apply_program_aoe_sphere_filter` delegate); updated dispatcher comment; replaced `aoe_hull_filter_aliases_sphere` unit test with `aoe_hull_filter_castle_footprint_distinct_from_sphere_and_box` that pins distinctness from both Sphere and Box.
- `crates/dsl_compiler/src/cg/emit/wgsl_body.rs` — replaced the `area_kind == 11u` branch (sphere-equivalent walk → cube + bevel-sphere walk). Uses `2.0 * radius * radius` to match the CPU oracle bit-for-bit (avoids `(r·√2)²` float round-trip — P3 + P11).
- `crates/engine/tests/aoe_multi_agent_e2e.rs` — renamed test to `aoe_hull_castle_footprint_three_agent_fixture`; added two synthetic-candidate distinctness pins (cube corner OUT vs Box IN; edge midpoint IN vs Sphere OUT).
- `crates/apply_ability_smoke_runtime/tests/aoe_chronicle_pin.rs` + `parity_apply_program_sweep.rs` — updated comments + assertion messages to reflect the new semantics. Existing GPU end-to-end pin and CPU↔GPU parity sweep both continue to pass byte-equal.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p engine --release --test schema_hash` — schema hash unchanged
- [x] `cargo test -p engine --release --lib aoe_hull` — both unit tests pass
- [x] `cargo test -p engine --release --test aoe_multi_agent_e2e` — 15 tests pass including new distinctness pins
- [x] `RUST_MIN_STACK=33554432 cargo test -p apply_ability_smoke_runtime --release --test aoe_chronicle_pin` — 17 tests pass including `aoe_hull_castle_footprint_on_gpu`
- [x] `RUST_MIN_STACK=33554432 cargo test -p apply_ability_smoke_runtime --release --test parity_apply_program_sweep` — CPU↔GPU byte-equal across the modifier matrix (entry #42 Bulwark exercises Hull)
- [x] `RUST_MIN_STACK=33554432 cargo test -p spy_network_runtime --release --lib` — pass
- [x] `RUST_MIN_STACK=33554432 cargo test -p village_economy_runtime --release --lib` — pass
- Note: 3 pre-existing failures in `dsl_compiler::when_condition_validation` (else-clause handling) — verified to fail on baseline before my changes; unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)