### PR TITLE
feat(runtime): wire AbilityPower SoA into per-runtime GPU bindings

### DIFF
--- a/crates/apply_ability_chronicle_consumer_runtime/src/lib.rs
+++ b/crates/apply_ability_chronicle_consumer_runtime/src/lib.rs
@@ -98,6 +98,7 @@ pub struct ApplyAbilityChronicleConsumerState {
     // `caster_slot`, the consumer writes it via `target_id`; same
     // binding, distinct access patterns.)
     agent_attack_damage_buf: wgpu::Buffer,
+    agent_ability_power_buf: wgpu::Buffer,
     agent_max_hp_buf: wgpu::Buffer,
     agent_armor_buf: wgpu::Buffer,
     agent_magic_resist_buf: wgpu::Buffer,
@@ -240,6 +241,7 @@ impl ApplyAbilityChronicleConsumerState {
             })
         };
         let agent_attack_damage_buf = mk_stat("apply_ability_chronicle_consumer::agent_attack_damage");
+        let agent_ability_power_buf = mk_stat("apply_ability_chronicle_consumer::agent_ability_power");
         let agent_max_hp_buf        = mk_stat("apply_ability_chronicle_consumer::agent_max_hp");
         let agent_armor_buf         = mk_stat("apply_ability_chronicle_consumer::agent_armor");
         let agent_magic_resist_buf  = mk_stat("apply_ability_chronicle_consumer::agent_magic_resist");
@@ -340,6 +342,7 @@ impl ApplyAbilityChronicleConsumerState {
             agent_hp_buf,
             agent_hp_staging,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_max_hp_buf,
             agent_armor_buf,
             agent_magic_resist_buf,
@@ -428,6 +431,7 @@ impl ApplyAbilityChronicleConsumerState {
                 ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
                 ability_registry_chances:           &self.registry_gpu.chances,
                 agent_attack_damage: &self.agent_attack_damage_buf,
+                agent_ability_power: &self.agent_ability_power_buf,
                 agent_max_hp:        &self.agent_max_hp_buf,
                 agent_hp:            &self.agent_hp_buf,
                 agent_armor:         &self.agent_armor_buf,

--- a/crates/apply_ability_smoke_runtime/src/lib.rs
+++ b/crates/apply_ability_smoke_runtime/src/lib.rs
@@ -145,6 +145,7 @@ pub struct ApplyAbilitySmokeState {
     // (Damage 30 with no scaling slots) writes zero scale_bonus
     // regardless. Real fixtures (Bleed-style +5% MaxHp) populate these.
     agent_attack_damage_buf: wgpu::Buffer,
+    agent_ability_power_buf: wgpu::Buffer,
     agent_max_hp_buf: wgpu::Buffer,
     agent_hp_buf: wgpu::Buffer,
     agent_armor_buf: wgpu::Buffer,
@@ -379,6 +380,8 @@ impl ApplyAbilitySmokeState {
         };
         let agent_attack_damage_buf =
             mk_stat_col("apply_ability_smoke_runtime::agent_attack_damage", |s| s.attack_damage);
+        let agent_ability_power_buf =
+            mk_stat_col("apply_ability_smoke_runtime::agent_ability_power", |s| s.ability_power);
         let agent_max_hp_buf        =
             mk_stat_col("apply_ability_smoke_runtime::agent_max_hp",        |s| s.max_hp);
         let agent_hp_buf            =
@@ -408,17 +411,6 @@ impl ApplyAbilitySmokeState {
                 contents: bytemuck::cast_slice(&engaged_with_init),
                 usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             });
-        // NOTE: AbilityPower has no per-agent SoA column on the GPU
-        // (the dispatcher's `agent_stat()` switch returns 0.0 for
-        // ScalingStatRef::AbilityPower). The CPU oracle's
-        // `CasterStats::ability_power` field is therefore intentionally
-        // unread by the GPU side — sweep test pins this gap by including
-        // a Heal ability with `+ N% AbilityPower` scaling that must
-        // produce the same `scale_bonus = 0.0` on both backends (CPU
-        // multiplies by `caster_stats.ability_power = 0.0` from the
-        // PerAgentStats default; GPU returns 0.0 from the AbilityPower
-        // case unconditionally).
-
         // -- Event ring + tail. The kernel binds both as
         //    `array<atomic<u32>>` so we tag them STORAGE (the dispatcher
         //    writes via atomicAdd / atomicStore). COPY_SRC needed for
@@ -485,6 +477,7 @@ impl ApplyAbilitySmokeState {
             agent_level_buf,
             agent_pos_buf,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_max_hp_buf,
             agent_hp_buf,
             agent_armor_buf,
@@ -715,6 +708,7 @@ impl ApplyAbilitySmokeState {
             spatial_grid_cells:  &self.spatial_grid_cells_buf,
             spatial_grid_starts: &self.spatial_grid_starts_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,
@@ -801,6 +795,7 @@ impl ApplyAbilitySmokeState {
                 spatial_grid_cells:  &self.spatial_grid_cells_buf,
                 spatial_grid_starts: &self.spatial_grid_starts_buf,
                 agent_attack_damage: &self.agent_attack_damage_buf,
+                agent_ability_power: &self.agent_ability_power_buf,
                 agent_max_hp:        &self.agent_max_hp_buf,
                 agent_hp:            &self.agent_hp_buf,
                 agent_armor:         &self.agent_armor_buf,

--- a/crates/apply_ability_verb_chronicle_consumer_runtime/src/lib.rs
+++ b/crates/apply_ability_verb_chronicle_consumer_runtime/src/lib.rs
@@ -133,6 +133,7 @@ pub struct ApplyAbilityVerbChronicleConsumerState {
     // `scale_bonus` switch. All zero — verb-chronicle-consumer's
     // program (Damage 30) has no scaling slots.
     agent_attack_damage_buf: wgpu::Buffer,
+    agent_ability_power_buf: wgpu::Buffer,
     agent_max_hp_buf: wgpu::Buffer,
     agent_armor_buf: wgpu::Buffer,
     agent_magic_resist_buf: wgpu::Buffer,
@@ -243,6 +244,7 @@ impl ApplyAbilityVerbChronicleConsumerState {
             })
         };
         let agent_attack_damage_buf = mk_stat("apply_ability_verb_chronicle_consumer::agent_attack_damage");
+        let agent_ability_power_buf = mk_stat("apply_ability_verb_chronicle_consumer::agent_ability_power");
         let agent_max_hp_buf        = mk_stat("apply_ability_verb_chronicle_consumer::agent_max_hp");
         let agent_armor_buf         = mk_stat("apply_ability_verb_chronicle_consumer::agent_armor");
         let agent_magic_resist_buf  = mk_stat("apply_ability_verb_chronicle_consumer::agent_magic_resist");
@@ -312,6 +314,7 @@ impl ApplyAbilityVerbChronicleConsumerState {
             agent_hp_buf,
             agent_hp_staging,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_max_hp_buf,
             agent_armor_buf,
             agent_magic_resist_buf,
@@ -438,6 +441,7 @@ impl ApplyAbilityVerbChronicleConsumerState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,
@@ -528,6 +532,7 @@ impl ApplyAbilityVerbChronicleConsumerState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,

--- a/crates/apply_ability_verb_smoke_runtime/src/lib.rs
+++ b/crates/apply_ability_verb_smoke_runtime/src/lib.rs
@@ -128,6 +128,7 @@ pub struct ApplyAbilityVerbSmokeState {
     // `scale_bonus` switch. All zero — verb-smoke program has no
     // scaling slots so `scale_bonus = 0.0`.
     agent_attack_damage_buf: wgpu::Buffer,
+    agent_ability_power_buf: wgpu::Buffer,
     agent_max_hp_buf: wgpu::Buffer,
     agent_hp_buf: wgpu::Buffer,
     agent_armor_buf: wgpu::Buffer,
@@ -218,6 +219,7 @@ impl ApplyAbilityVerbSmokeState {
             })
         };
         let agent_attack_damage_buf = mk_stat("apply_ability_verb_smoke_runtime::agent_attack_damage");
+        let agent_ability_power_buf = mk_stat("apply_ability_verb_smoke_runtime::agent_ability_power");
         let agent_max_hp_buf        = mk_stat("apply_ability_verb_smoke_runtime::agent_max_hp");
         let agent_hp_buf            = mk_stat("apply_ability_verb_smoke_runtime::agent_hp");
         let agent_armor_buf         = mk_stat("apply_ability_verb_smoke_runtime::agent_armor");
@@ -286,6 +288,7 @@ impl ApplyAbilityVerbSmokeState {
             gpu,
             agent_level_buf,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_max_hp_buf,
             agent_hp_buf,
             agent_armor_buf,
@@ -382,6 +385,7 @@ impl ApplyAbilityVerbSmokeState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,

--- a/crates/boss_fight_runtime/src/lib.rs
+++ b/crates/boss_fight_runtime/src/lib.rs
@@ -54,6 +54,8 @@ pub struct BossFightState {
     /// exactly — the same five-column shape.
     #[allow(dead_code)]
     agent_attack_damage_buf: wgpu::Buffer,
+    #[allow(dead_code)]
+    agent_ability_power_buf: wgpu::Buffer,
     agent_max_hp_buf: wgpu::Buffer,
     #[allow(dead_code)]
     agent_armor_buf: wgpu::Buffer,
@@ -256,6 +258,8 @@ impl BossFightState {
         };
         let agent_attack_damage_buf =
             mk_zero_stat("boss_fight_runtime::agent_attack_damage");
+        let agent_ability_power_buf =
+            mk_zero_stat("boss_fight_runtime::agent_ability_power");
         let agent_armor_buf = mk_zero_stat("boss_fight_runtime::agent_armor");
         let agent_magic_resist_buf =
             mk_zero_stat("boss_fight_runtime::agent_magic_resist");
@@ -486,6 +490,7 @@ impl BossFightState {
             agent_alive_buf,
             agent_creature_type_buf,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_max_hp_buf,
             agent_armor_buf,
             agent_magic_resist_buf,
@@ -738,6 +743,7 @@ impl CompiledSim for BossFightState {
             ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,
@@ -779,6 +785,7 @@ impl CompiledSim for BossFightState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp: &self.agent_max_hp_buf,
             agent_hp: &self.agent_hp_buf,
             agent_armor: &self.agent_armor_buf,
@@ -838,6 +845,7 @@ impl CompiledSim for BossFightState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp: &self.agent_max_hp_buf,
             agent_hp: &self.agent_hp_buf,
             agent_armor: &self.agent_armor_buf,
@@ -888,6 +896,7 @@ impl CompiledSim for BossFightState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp: &self.agent_max_hp_buf,
             agent_hp: &self.agent_hp_buf,
             agent_armor: &self.agent_armor_buf,
@@ -940,6 +949,7 @@ impl CompiledSim for BossFightState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp: &self.agent_max_hp_buf,
             agent_hp: &self.agent_hp_buf,
             agent_armor: &self.agent_armor_buf,

--- a/crates/dsl_compiler/src/cg/data_handle.rs
+++ b/crates/dsl_compiler/src/cg/data_handle.rs
@@ -178,6 +178,7 @@ pub enum AgentFieldId {
     Armor,
     MagicResist,
     AttackDamage,
+    AbilityPower,
     AttackRange,
     Mana,
     MaxMana,
@@ -283,10 +284,10 @@ impl AgentFieldId {
         use AgentFieldId::*;
         match self {
             // f32 — vitals + scalar combat stats + needs + personality
-            Hp | MaxHp | ShieldHp | Armor | MagicResist | AttackDamage | AttackRange | Mana
-            | MaxMana | MoveSpeed | MoveSpeedMult | Hunger | Thirst | RestTimer | Safety
-            | Shelter | Social | Purpose | Esteem | RiskTolerance | SocialDrive | Ambition
-            | Altruism | Curiosity => AgentFieldTy::F32,
+            Hp | MaxHp | ShieldHp | Armor | MagicResist | AttackDamage | AbilityPower
+            | AttackRange | Mana | MaxMana | MoveSpeed | MoveSpeedMult | Hunger | Thirst
+            | RestTimer | Safety | Shelter | Social | Purpose | Esteem | RiskTolerance
+            | SocialDrive | Ambition | Altruism | Curiosity => AgentFieldTy::F32,
 
             // u32 — monotonic counters + tick stamps + level
             Level | StunExpiresAtTick | SlowExpiresAtTick | CooldownNextReadyTick
@@ -346,6 +347,7 @@ impl AgentFieldId {
             Armor => "armor",
             MagicResist => "magic_resist",
             AttackDamage => "attack_damage",
+            AbilityPower => "ability_power",
             AttackRange => "attack_range",
             Mana => "mana",
             MaxMana => "max_mana",
@@ -415,6 +417,7 @@ impl AgentFieldId {
             Armor,
             MagicResist,
             AttackDamage,
+            AbilityPower,
             AttackRange,
             Mana,
             MaxMana,
@@ -496,6 +499,7 @@ impl AgentFieldId {
             "armor" => Armor,
             "magic_resist" => MagicResist,
             "attack_damage" => AttackDamage,
+            "ability_power" => AbilityPower,
             "attack_range" => AttackRange,
             "mana" => Mana,
             "max_mana" => MaxMana,
@@ -1579,6 +1583,7 @@ mod tests {
             AgentFieldId::Armor,
             AgentFieldId::MagicResist,
             AgentFieldId::AttackDamage,
+            AgentFieldId::AbilityPower,
             AgentFieldId::AttackRange,
             AgentFieldId::Mana,
             AgentFieldId::MaxMana,
@@ -1642,6 +1647,7 @@ mod tests {
             AgentFieldId::Armor,
             AgentFieldId::MagicResist,
             AgentFieldId::AttackDamage,
+            AgentFieldId::AbilityPower,
             AgentFieldId::AttackRange,
             AgentFieldId::Mana,
             AgentFieldId::MaxMana,
@@ -1975,10 +1981,10 @@ mod tests {
         // + 4 control statuses Wave 2 piece 1 + 4 buff multipliers Wave
         // 2 piece 4 + 2 Disguise SoA columns Wave 3 ToM Phase 5 + 4
         // Lift A multi-tick procedure columns: BusyUntilTick +
-        // TravelDestX/Y/Z); if a new variant lands and `all_variants`
-        // isn't updated, this assertion fails before the round-trip loop
-        // above can.
-        assert_eq!(all.len(), 53);
+        // TravelDestX/Y/Z + AbilityPower); if a new variant lands and
+        // `all_variants` isn't updated, this assertion fails before the
+        // round-trip loop above can.
+        assert_eq!(all.len(), 54);
     }
 
     #[test]

--- a/crates/dsl_compiler/src/cg/emit/kernel.rs
+++ b/crates/dsl_compiler/src/cg/emit/kernel.rs
@@ -3262,7 +3262,7 @@ fn lower_scoring_argmax_body(
                      \x20               var pred_lhs_{i}: f32 = 0.0;\n\
                      \x20               switch (pred_field_{i}) {{\n\
                      \x20                   case 0u: {{ pred_lhs_{i} = agent_attack_damage[pred_agent_{i}]; }}\n\
-                     \x20                   case 1u: {{ pred_lhs_{i} = 0.0; }}\n\
+                     \x20                   case 1u: {{ pred_lhs_{i} = agent_ability_power[pred_agent_{i}]; }}\n\
                      \x20                   case 2u: {{ pred_lhs_{i} = agent_max_hp[pred_agent_{i}]; }}\n\
                      \x20                   case 3u: {{ pred_lhs_{i} = agent_hp[pred_agent_{i}]; }}\n\
                      \x20                   case 4u: {{ pred_lhs_{i} = agent_armor[pred_agent_{i}]; }}\n\

--- a/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
+++ b/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
@@ -1927,8 +1927,7 @@ fn lower_cg_stmt_body_to_wgsl(
                  // CPU oracle in `engine::ability::apply::apply_program`\n\
                  // (sums `inner.iter().map(|s| s.percent * stats.get(s.stat_ref))`\n\
                  // — same iteration order j=0 then j=1 per P11 reduction\n\
-                 // ordering). AbilityPower(tag=1) returns 0.0 — no agent\n\
-                 // SoA slot for it today (LoL-only stat).\n\
+                 // ordering).\n\
                  {{\n\
                  \x20\x20\x20\x20let ability_id__u32: u32 = u32({ability_wgsl});\n\
                  \x20\x20\x20\x20let caster_slot: u32 = u32({caster_wgsl});\n\
@@ -1973,7 +1972,7 @@ fn lower_cg_stmt_body_to_wgsl(
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20var stat_v: f32 = 0.0;\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20switch (s_tag) {{\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 0u: {{ stat_v = agent_attack_damage[caster_slot]; }}\n\
-                 \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 1u: {{ stat_v = 0.0; }} // AbilityPower — no agent SoA slot\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 1u: {{ stat_v = agent_ability_power[caster_slot]; }}\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 2u: {{ stat_v = agent_max_hp[caster_slot]; }}\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 3u: {{ stat_v = agent_hp[caster_slot]; }}\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 4u: {{ stat_v = agent_armor[caster_slot]; }}\n\
@@ -2023,7 +2022,7 @@ fn lower_cg_stmt_body_to_wgsl(
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20var pred_lhs: f32 = 0.0;\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20switch (pred_field) {{\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 0u: {{ pred_lhs = agent_attack_damage[pred_agent]; }}\n\
-                 \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 1u: {{ pred_lhs = 0.0; }} // AbilityPower — no agent SoA slot\n\
+                 \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 1u: {{ pred_lhs = agent_ability_power[pred_agent]; }}\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 2u: {{ pred_lhs = agent_max_hp[pred_agent]; }}\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 3u: {{ pred_lhs = agent_hp[pred_agent]; }}\n\
                  \x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20case 4u: {{ pred_lhs = agent_armor[pred_agent]; }}\n\

--- a/crates/dsl_compiler/src/cg/lower/driver.rs
+++ b/crates/dsl_compiler/src/cg/lower/driver.rs
@@ -2525,6 +2525,24 @@ fn apply_emit_destination_rings(ops: &mut [ComputeOp], pairs: &[(usize, EventRin
     }
 }
 
+/// Agent SoA stat columns the dispatcher's `agent_stat()` switch reads
+/// at `caster_slot` (or `pred_agent` for predicate eval) for the
+/// `scale_bonus` computation and per-effect predicate atoms. Mirrors
+/// the `ScalingStatRef` → `AgentFieldId` mapping in
+/// `engine::ability::program::CasterStats::get`:
+///   AttackDamage(0), AbilityPower(1), MaxHp(2), Hp(3), Armor(4),
+///   MagicResist(5), MoveSpeed(6), Mana(7).
+const APPLY_ABILITY_AGENT_STAT_FIELDS: &[crate::cg::data_handle::AgentFieldId] = &[
+    crate::cg::data_handle::AgentFieldId::AttackDamage,
+    crate::cg::data_handle::AgentFieldId::AbilityPower,
+    crate::cg::data_handle::AgentFieldId::MaxHp,
+    crate::cg::data_handle::AgentFieldId::Hp,
+    crate::cg::data_handle::AgentFieldId::Armor,
+    crate::cg::data_handle::AgentFieldId::MagicResist,
+    crate::cg::data_handle::AgentFieldId::MoveSpeed,
+    crate::cg::data_handle::AgentFieldId::Mana,
+];
+
 /// Walk every op's body for [`CgStmt::ApplyAbility`] and record reads
 /// on the three [`DataHandle::AbilityRegistryColumn`] handles the
 /// dispatcher accesses. Without this, the BGL composer never
@@ -2539,7 +2557,7 @@ fn apply_emit_destination_rings(ops: &mut [ComputeOp], pairs: &[(usize, EventRin
 /// surrounding kernel's binding set, but neither stmt carries the
 /// handles directly in its IR shape.
 fn wire_ability_registry_column_reads(prog: &CgProgram, ops: &mut [ComputeOp]) {
-    use crate::cg::data_handle::{AbilityRegistryColumn, AgentFieldId, AgentRef};
+    use crate::cg::data_handle::{AbilityRegistryColumn, AgentRef};
     use crate::cg::op::ComputeOpKind;
     // Mirror the dispatcher's emit (`cg::emit::wgsl_body`):
     // it reads `effect_kinds`, `effect_payload_a`, `effect_payload_b`
@@ -2572,24 +2590,6 @@ fn wire_ability_registry_column_reads(prog: &CgProgram, ops: &mut [ComputeOp]) {
         AbilityRegistryColumn::Chances,
     ];
 
-    // Agent SoA stat columns the dispatcher's `agent_stat()` switch
-    // reads at `caster_slot` for the scale_bonus computation. Mirrors
-    // `ScalingStatRef` → `AgentFieldId` mapping in the dispatcher's
-    // emit (and in `engine::ability::program::CasterStats::get`):
-    //   AttackDamage(0) → AttackDamage, AbilityPower(1) → no SoA slot
-    //   (returns 0.0 — LoL-only stat), MaxHp(2) → MaxHp, Hp(3) → Hp,
-    //   Armor(4) → Armor, MagicResist(5) → MagicResist, MoveSpeed(6)
-    //   → MoveSpeed, Mana(7) → Mana.
-    const AGENT_STAT_FIELDS: &[AgentFieldId] = &[
-        AgentFieldId::AttackDamage,
-        AgentFieldId::MaxHp,
-        AgentFieldId::Hp,
-        AgentFieldId::Armor,
-        AgentFieldId::MagicResist,
-        AgentFieldId::MoveSpeed,
-        AgentFieldId::Mana,
-    ];
-
     for (op_index, op) in ops.iter_mut().enumerate() {
         let snapshot_op = match prog.ops.get(op_index) {
             Some(o) => o,
@@ -2609,7 +2609,7 @@ fn wire_ability_registry_column_reads(prog: &CgProgram, ops: &mut [ComputeOp]) {
         for column in COLUMNS {
             op.record_read(DataHandle::AbilityRegistryColumn { column: *column });
         }
-        for field in AGENT_STAT_FIELDS {
+        for field in APPLY_ABILITY_AGENT_STAT_FIELDS {
             op.record_read(DataHandle::AgentField {
                 field:  *field,
                 target: AgentRef::Self_,
@@ -3206,26 +3206,13 @@ fn wire_scoring_mask_reads(prog: &CgProgram, ops: &mut [ComputeOp]) {
 /// closes the BGL composer gap created by the scoring kernel emit
 /// referencing identifiers not surfaced through any `CgExpr` node.
 fn wire_scoring_predicate_reads(prog: &CgProgram, ops: &mut [ComputeOp]) {
-    use crate::cg::data_handle::{AbilityRegistryColumn, AgentFieldId, AgentRef};
+    use crate::cg::data_handle::{AbilityRegistryColumn, AgentRef};
     // Same column set the dispatcher consumes for predicate eval.
-    // Agent stat fields mirror the seven slots
-    // `engine::ability::program::CasterStats::get` reads (AbilityPower
-    // returns 0.0 — no agent SoA slot, kept symmetric with the
-    // dispatcher emit).
     const COLUMNS: &[AbilityRegistryColumn] = &[
         AbilityRegistryColumn::WhenPredBinder,
         AbilityRegistryColumn::WhenPredField,
         AbilityRegistryColumn::WhenPredOp,
         AbilityRegistryColumn::WhenPredLiteral,
-    ];
-    const AGENT_STAT_FIELDS: &[AgentFieldId] = &[
-        AgentFieldId::AttackDamage,
-        AgentFieldId::MaxHp,
-        AgentFieldId::Hp,
-        AgentFieldId::Armor,
-        AgentFieldId::MagicResist,
-        AgentFieldId::MoveSpeed,
-        AgentFieldId::Mana,
     ];
 
     // Skip if no verb→ability mapping exists in the program (no
@@ -3262,7 +3249,7 @@ fn wire_scoring_predicate_reads(prog: &CgProgram, ops: &mut [ComputeOp]) {
         // where `pred_agent` is computed from caster_slot /
         // per_pair_candidate. Mirrors the dispatcher's `Self_`-only
         // recording in `wire_ability_registry_column_reads`.
-        for field in AGENT_STAT_FIELDS {
+        for field in APPLY_ABILITY_AGENT_STAT_FIELDS {
             op.record_read(DataHandle::AgentField {
                 field: *field,
                 target: AgentRef::Self_,

--- a/crates/duel_25v25_runtime/src/lib.rs
+++ b/crates/duel_25v25_runtime/src/lib.rs
@@ -83,6 +83,8 @@ pub struct Duel25v25State {
     /// + duel_abilities_runtime exactly — the same five-column shape.
     #[allow(dead_code)]
     agent_attack_damage_buf: wgpu::Buffer,
+    #[allow(dead_code)]
+    agent_ability_power_buf: wgpu::Buffer,
     agent_max_hp_buf: wgpu::Buffer,
     #[allow(dead_code)]
     agent_armor_buf: wgpu::Buffer,
@@ -301,6 +303,8 @@ impl Duel25v25State {
         };
         let agent_attack_damage_buf =
             mk_zero_stat("duel_25v25_runtime::agent_attack_damage");
+        let agent_ability_power_buf =
+            mk_zero_stat("duel_25v25_runtime::agent_ability_power");
         let agent_armor_buf = mk_zero_stat("duel_25v25_runtime::agent_armor");
         let agent_magic_resist_buf =
             mk_zero_stat("duel_25v25_runtime::agent_magic_resist");
@@ -525,6 +529,7 @@ impl Duel25v25State {
             agent_alive_buf,
             agent_creature_type_buf,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_max_hp_buf,
             agent_armor_buf,
             agent_magic_resist_buf,
@@ -831,6 +836,7 @@ impl CompiledSim for Duel25v25State {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             agent_creature_type: &self.agent_creature_type_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
@@ -902,6 +908,7 @@ impl CompiledSim for Duel25v25State {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             agent_creature_type: &self.agent_creature_type_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
@@ -973,6 +980,7 @@ impl CompiledSim for Duel25v25State {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             agent_creature_type: &self.agent_creature_type_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
@@ -1039,6 +1047,7 @@ impl CompiledSim for Duel25v25State {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             agent_creature_type: &self.agent_creature_type_buf,
             spatial_grid_cells: &self.spatial_grid_cells,

--- a/crates/duel_abilities_runtime/src/lib.rs
+++ b/crates/duel_abilities_runtime/src/lib.rs
@@ -149,6 +149,7 @@ pub struct DuelAbilitiesState {
     /// (attack_damage / armor / magic_resist / move_speed) are
     /// 0-initialized — duel_abilities verbs scale only on max_hp today.
     agent_attack_damage_buf: wgpu::Buffer,
+    agent_ability_power_buf: wgpu::Buffer,
     agent_max_hp_buf: wgpu::Buffer,
     agent_armor_buf: wgpu::Buffer,
     agent_magic_resist_buf: wgpu::Buffer,
@@ -426,6 +427,7 @@ impl DuelAbilitiesState {
             })
         };
         let agent_attack_damage_buf = mk_stat("duel_abilities_runtime::agent_attack_damage");
+        let agent_ability_power_buf = mk_stat("duel_abilities_runtime::agent_ability_power");
         let agent_armor_buf         = mk_stat("duel_abilities_runtime::agent_armor");
         let agent_magic_resist_buf  = mk_stat("duel_abilities_runtime::agent_magic_resist");
         let agent_move_speed_buf    = mk_stat("duel_abilities_runtime::agent_move_speed");
@@ -775,6 +777,7 @@ impl DuelAbilitiesState {
             agent_damage_taken_mult_expires_at_tick_buf,
             agent_stun_expires_at_tick_buf,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_max_hp_buf,
             agent_armor_buf,
             agent_magic_resist_buf,
@@ -1135,6 +1138,7 @@ impl CompiledSim for DuelAbilitiesState {
             ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,
@@ -1182,6 +1186,7 @@ impl CompiledSim for DuelAbilitiesState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,
@@ -1223,6 +1228,7 @@ impl CompiledSim for DuelAbilitiesState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,
@@ -1268,6 +1274,7 @@ impl CompiledSim for DuelAbilitiesState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,
@@ -1313,6 +1320,7 @@ impl CompiledSim for DuelAbilitiesState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,
@@ -1360,6 +1368,7 @@ impl CompiledSim for DuelAbilitiesState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,
@@ -1407,6 +1416,7 @@ impl CompiledSim for DuelAbilitiesState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,
@@ -1454,6 +1464,7 @@ impl CompiledSim for DuelAbilitiesState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_hp:            &self.agent_hp_buf,
             agent_armor:         &self.agent_armor_buf,
@@ -1766,6 +1777,7 @@ impl CompiledSim for DuelAbilitiesState {
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             ability_registry_chances:           &self.registry_gpu.chances,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,

--- a/crates/mass_battle_100v100_runtime/src/lib.rs
+++ b/crates/mass_battle_100v100_runtime/src/lib.rs
@@ -106,6 +106,8 @@ pub struct MassBattle100v100State {
     /// program actually scales. Mirrors duel_25v25_runtime exactly.
     #[allow(dead_code)]
     agent_attack_damage_buf: wgpu::Buffer,
+    #[allow(dead_code)]
+    agent_ability_power_buf: wgpu::Buffer,
     agent_max_hp_buf: wgpu::Buffer,
     #[allow(dead_code)]
     agent_armor_buf: wgpu::Buffer,
@@ -343,6 +345,8 @@ impl MassBattle100v100State {
         };
         let agent_attack_damage_buf =
             mk_zero_stat("mass_battle_100v100::agent_attack_damage");
+        let agent_ability_power_buf =
+            mk_zero_stat("mass_battle_100v100::agent_ability_power");
         let agent_armor_buf = mk_zero_stat("mass_battle_100v100::agent_armor");
         let agent_magic_resist_buf =
             mk_zero_stat("mass_battle_100v100::agent_magic_resist");
@@ -571,6 +575,7 @@ impl MassBattle100v100State {
             agent_alive_buf,
             agent_level_buf,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_max_hp_buf,
             agent_armor_buf,
             agent_magic_resist_buf,
@@ -812,6 +817,7 @@ impl CompiledSim for MassBattle100v100State {
             ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,
@@ -846,6 +852,7 @@ impl CompiledSim for MassBattle100v100State {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -887,6 +894,7 @@ impl CompiledSim for MassBattle100v100State {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -937,6 +945,7 @@ impl CompiledSim for MassBattle100v100State {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -988,6 +997,7 @@ impl CompiledSim for MassBattle100v100State {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,

--- a/crates/spy_network_runtime/src/lib.rs
+++ b/crates/spy_network_runtime/src/lib.rs
@@ -116,6 +116,7 @@ pub struct SpyNetworkState {
     // BGL contract demands the bindings exist.
     agent_max_hp_buf: wgpu::Buffer,
     agent_attack_damage_buf: wgpu::Buffer,
+    agent_ability_power_buf: wgpu::Buffer,
     agent_armor_buf: wgpu::Buffer,
     agent_magic_resist_buf: wgpu::Buffer,
     agent_move_speed_buf: wgpu::Buffer,
@@ -277,6 +278,8 @@ impl SpyNetworkState {
         };
         let agent_attack_damage_buf =
             mk_stat("spy_network_runtime::agent_attack_damage");
+        let agent_ability_power_buf =
+            mk_stat("spy_network_runtime::agent_ability_power");
         let agent_armor_buf = mk_stat("spy_network_runtime::agent_armor");
         let agent_magic_resist_buf = mk_stat("spy_network_runtime::agent_magic_resist");
         let agent_move_speed_buf = mk_stat("spy_network_runtime::agent_move_speed");
@@ -455,6 +458,7 @@ impl SpyNetworkState {
             agent_disguise_fake_type_buf,
             agent_max_hp_buf,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_armor_buf,
             agent_magic_resist_buf,
             agent_move_speed_buf,
@@ -670,6 +674,7 @@ impl CompiledSim for SpyNetworkState {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             agent_creature_type: &self.agent_creature_type_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
@@ -715,6 +720,7 @@ impl CompiledSim for SpyNetworkState {
                 agent_armor: &self.agent_armor_buf,
                 agent_magic_resist: &self.agent_magic_resist_buf,
                 agent_attack_damage: &self.agent_attack_damage_buf,
+                agent_ability_power: &self.agent_ability_power_buf,
                 agent_mana: &self.agent_mana_buf,
                 ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
                 ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -761,6 +767,7 @@ impl CompiledSim for SpyNetworkState {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -807,6 +814,7 @@ impl CompiledSim for SpyNetworkState {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,

--- a/crates/tactical_squad_5v5_runtime/src/lib.rs
+++ b/crates/tactical_squad_5v5_runtime/src/lib.rs
@@ -106,6 +106,8 @@ pub struct TacticalSquad5v5State {
     /// + duel_25v25_runtime exactly — the same five-column shape.
     #[allow(dead_code)]
     agent_attack_damage_buf: wgpu::Buffer,
+    #[allow(dead_code)]
+    agent_ability_power_buf: wgpu::Buffer,
     agent_max_hp_buf: wgpu::Buffer,
     #[allow(dead_code)]
     agent_armor_buf: wgpu::Buffer,
@@ -358,6 +360,8 @@ impl TacticalSquad5v5State {
         };
         let agent_attack_damage_buf =
             mk_zero_stat("tactical_squad_5v5_runtime::agent_attack_damage");
+        let agent_ability_power_buf =
+            mk_zero_stat("tactical_squad_5v5_runtime::agent_ability_power");
         let agent_armor_buf = mk_zero_stat("tactical_squad_5v5_runtime::agent_armor");
         let agent_magic_resist_buf =
             mk_zero_stat("tactical_squad_5v5_runtime::agent_magic_resist");
@@ -587,6 +591,7 @@ impl TacticalSquad5v5State {
             agent_creature_type_buf,
             agent_level_buf,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_max_hp_buf,
             agent_armor_buf,
             agent_magic_resist_buf,
@@ -895,6 +900,7 @@ impl CompiledSim for TacticalSquad5v5State {
             ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
             ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_max_hp:        &self.agent_max_hp_buf,
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,
@@ -930,6 +936,7 @@ impl CompiledSim for TacticalSquad5v5State {
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana:          &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -970,6 +977,7 @@ impl CompiledSim for TacticalSquad5v5State {
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana:          &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -1020,6 +1028,7 @@ impl CompiledSim for TacticalSquad5v5State {
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana:          &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -1092,6 +1101,7 @@ impl CompiledSim for TacticalSquad5v5State {
             agent_armor:         &self.agent_armor_buf,
             agent_magic_resist:  &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana:          &self.agent_mana_buf,
             ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
             ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,

--- a/crates/village_economy_runtime/src/lib.rs
+++ b/crates/village_economy_runtime/src/lib.rs
@@ -125,6 +125,7 @@ pub struct VillageEconomyState {
     // -- Stat columns (BGL contract requires; init zero) --
     agent_max_hp_buf: wgpu::Buffer,
     agent_attack_damage_buf: wgpu::Buffer,
+    agent_ability_power_buf: wgpu::Buffer,
     agent_armor_buf: wgpu::Buffer,
     agent_magic_resist_buf: wgpu::Buffer,
     agent_move_speed_buf: wgpu::Buffer,
@@ -233,6 +234,8 @@ impl VillageEconomyState {
         let agent_max_hp_buf = mk_storage_f32("village_economy::agent_max_hp", &zero_f32);
         let agent_attack_damage_buf =
             mk_storage_f32("village_economy::agent_attack_damage", &zero_f32);
+        let agent_ability_power_buf =
+            mk_storage_f32("village_economy::agent_ability_power", &zero_f32);
         let agent_armor_buf = mk_storage_f32("village_economy::agent_armor", &zero_f32);
         let agent_magic_resist_buf =
             mk_storage_f32("village_economy::agent_magic_resist", &zero_f32);
@@ -375,6 +378,7 @@ impl VillageEconomyState {
             agent_creature_type_buf,
             agent_max_hp_buf,
             agent_attack_damage_buf,
+            agent_ability_power_buf,
             agent_armor_buf,
             agent_magic_resist_buf,
             agent_move_speed_buf,
@@ -590,6 +594,7 @@ impl CompiledSim for VillageEconomyState {
             agent_armor: &self.agent_armor_buf,
             agent_magic_resist: &self.agent_magic_resist_buf,
             agent_attack_damage: &self.agent_attack_damage_buf,
+            agent_ability_power: &self.agent_ability_power_buf,
             agent_mana: &self.agent_mana_buf,
             agent_creature_type: &self.agent_creature_type_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
@@ -634,6 +639,7 @@ impl CompiledSim for VillageEconomyState {
                 agent_armor: &self.agent_armor_buf,
                 agent_magic_resist: &self.agent_magic_resist_buf,
                 agent_attack_damage: &self.agent_attack_damage_buf,
+                agent_ability_power: &self.agent_ability_power_buf,
                 agent_mana: &self.agent_mana_buf,
                 ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
                 ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -682,6 +688,7 @@ impl CompiledSim for VillageEconomyState {
                 agent_armor: &self.agent_armor_buf,
                 agent_magic_resist: &self.agent_magic_resist_buf,
                 agent_attack_damage: &self.agent_attack_damage_buf,
+                agent_ability_power: &self.agent_ability_power_buf,
                 agent_mana: &self.agent_mana_buf,
                 ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
                 ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
@@ -734,6 +741,7 @@ impl CompiledSim for VillageEconomyState {
                 agent_armor: &self.agent_armor_buf,
                 agent_magic_resist: &self.agent_magic_resist_buf,
                 agent_attack_damage: &self.agent_attack_damage_buf,
+                agent_ability_power: &self.agent_ability_power_buf,
                 agent_mana: &self.agent_mana_buf,
                 ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
                 ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,


### PR DESCRIPTION
## Summary

- Closes the parity gap left by PR #46: the dispatcher's `agent_stat()` switch was reading 0.0 for `ScalingStatRef::AbilityPower` because no per-runtime crate bound the new `agent_ability_power` SoA — so `+ N% AbilityPower` scalings silently collapsed to zero on the GPU side while the CPU oracle honored the per-agent value.
- Adds `AgentFieldId::AbilityPower` to the closed-set agent-field enum (snake/from_snake/all_variants/ty round-trip), extends the `APPLY_ABILITY_AGENT_STAT_FIELDS` set the dispatcher records reads against (deduped to a single module-level constant since dispatcher and scoring-predicate sites enumerate the same eight stats), and updates the WGSL emit's `case 1u` switch arms to read `agent_ability_power[caster_slot]` / `[pred_agent]` instead of the 0.0 stub.
- Adds the `agent_ability_power_buf` field + buffer init + binding pass-through to all 11 per-runtime crates that bind `agent_attack_damage`. Smoke fixture seeds the column from `PerAgentStats::ability_power`; production fixtures zero-init for now (future items/class slices will populate).

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p engine --release` — 0 failures
- [x] `cargo test -p dsl_compiler --release` — 0 failures (the `all_variants` count test was bumped 53 → 54)
- [x] `RUST_MIN_STACK=33554432 cargo test -p spy_network_runtime --release --lib` — 1 passed
- [x] `RUST_MIN_STACK=33554432 cargo test -p duel_25v25_runtime --release --lib` — 8 passed
- [x] `RUST_MIN_STACK=33554432 cargo test -p village_economy_runtime --release --lib` — 1 passed
- [x] `RUST_MIN_STACK=33554432 cargo test -p apply_ability_smoke_runtime --release` — parity sweep test (incl. HealAP arm) passes
- [x] Schema hash unchanged (the SoA column itself landed in PR #46; only per-runtime fanout here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)