### PR TITLE
feat(dsl): compiler debug mode Phase 2 (DebugWgslFlags)

### DIFF
--- a/crates/dsl_compiler/src/cg/emit/kernel.rs
+++ b/crates/dsl_compiler/src/cg/emit/kernel.rs
@@ -96,6 +96,7 @@ use crate::cg::data_handle::{
     SpatialStorageKind, ViewStorageSlot,
 };
 use crate::cg::dispatch::DispatchShape;
+use crate::cg::lower::driver::DebugWgslFlags;
 use crate::cg::op::{
     ComputeOp, ComputeOpKind, OpId, PlumbingKind, ReplayabilityFlag, ScoringId, ScoringRowOp,
     SpatialQueryKind,
@@ -2965,11 +2966,13 @@ fn lower_op_body(
                     *mask,
                     &lets_prefix,
                     &predicate_wgsl,
+                    ctx.debug_wgsl,
                 )),
                 DispatchShape::PerPair { .. } => Ok(mask_predicate_per_pair_body_with_prefix(
                     *mask,
                     &lets_prefix,
                     &predicate_wgsl,
+                    ctx.debug_wgsl,
                 )),
                 DispatchShape::PerEvent { .. }
                 | DispatchShape::OneShot
@@ -3290,6 +3293,21 @@ fn lower_scoring_argmax_body(
                 )
             });
 
+        // Compiler debug mode Phase 2: per-agent scoring candidate
+        // count. Bumped once per row body entry — for pair-field rows
+        // this lands inside the inner candidate loop so each candidate
+        // visit increments the counter; for self-only rows it bumps
+        // once per agent per row (effectively a per-action visit
+        // count, which is what `score_kernel_visits` measures).
+        // Default `NONE` keeps the body unchanged.
+        let score_cand_bump = if ctx.debug_wgsl.score_kernel_visits {
+            "    // debug_wgsl.score_kernel_visits: per-agent histogram\n\
+             \x20   atomicAdd(&score_kernel_visits[agent_id], 1u);\n"
+                .to_string()
+        } else {
+            String::new()
+        };
+
         match row.guard {
             Some(guard_id) => {
                 let guard_wgsl = lower_cg_expr_to_wgsl(guard_id, ctx)?;
@@ -3299,6 +3317,7 @@ fn lower_scoring_argmax_body(
                     out.push_str(open);
                 }
                 out.push_str(&loop_open);
+                out.push_str(&score_cand_bump);
                 if let Some(gate) = &predicate_gate {
                     out.push_str(gate);
                 }
@@ -3327,6 +3346,7 @@ fn lower_scoring_argmax_body(
                     out.push_str(open);
                 }
                 out.push_str(&loop_open);
+                out.push_str(&score_cand_bump);
                 if let Some(gate) = &predicate_gate {
                     out.push_str(gate);
                 }
@@ -3602,6 +3622,23 @@ fn find_action_selected_kind(
 // ---------------------------------------------------------------------------
 
 /// PerAgent dispatch — `agent_id` is bound by the
+/// Compiler debug mode Phase 2 (`mask_hit_rate`): produce
+/// `(<total>, <passed>)` per-mask atomic-counter bumps. PerAgent and
+/// PerPair shapes share the increments verbatim — `mask_total[id]`
+/// pre-predicate, `mask_passed[id]` inside the if-true branch — so a
+/// shared helper keeps the two body templates from drifting on
+/// counter shape. Empty strings when the flag is off; the templates
+/// splice them as no-ops, preserving the existing emit shape.
+fn mask_hit_rate_bumps(mask: MaskId, debug_wgsl: DebugWgslFlags) -> (String, String) {
+    if !debug_wgsl.mask_hit_rate {
+        return (String::new(), String::new());
+    }
+    (
+        format!("    atomicAdd(&mask_total[{0}u], 1u);\n", mask.0),
+        format!("    atomicAdd(&mask_passed[{0}u], 1u);\n", mask.0),
+    )
+}
+
 /// `thread_indexing_preamble`. Each mask op uses per-id-suffixed
 /// locals (`mask_<ID>_word`, `mask_<ID>_bit`) so a Fused kernel with
 /// multiple `MaskPredicate` ops doesn't redeclare `word`/`bit`.
@@ -3617,11 +3654,15 @@ fn mask_predicate_per_agent_body_with_prefix(
     mask: MaskId,
     prefix: &str,
     predicate_wgsl: &str,
+    debug_wgsl: DebugWgslFlags,
 ) -> String {
+    let (total_bump, passed_bump) = mask_hit_rate_bumps(mask, debug_wgsl);
     format!(
         "{prefix}\
+         {total_bump}\
          let mask_{0}_value: bool = {1};\n\
          if (mask_{0}_value) {{\n\
+         {passed_bump}\
          \x20   let mask_{0}_word = agent_id >> 5u;\n\
          \x20   let mask_{0}_bit  = 1u << (agent_id & 31u);\n\
          \x20   atomicOr(&mask_{0}_bitmap[mask_{0}_word], mask_{0}_bit);\n\
@@ -3672,7 +3713,9 @@ fn mask_predicate_per_pair_body_with_prefix(
     mask: MaskId,
     prefix: &str,
     predicate_wgsl: &str,
+    debug_wgsl: DebugWgslFlags,
 ) -> String {
+    let (total_bump, passed_bump) = mask_hit_rate_bumps(mask, debug_wgsl);
     format!(
         "// PerPair MaskPredicate — derive (agent, cand) from `pair`.\n\
          let mask_{0}_k = cfg.agent_cap; // pair-field predicate: visit every (actor, candidate) pair.\n\
@@ -3683,8 +3726,10 @@ fn mask_predicate_per_pair_body_with_prefix(
          let per_pair_candidate = mask_{0}_cand;\n\
          \n\
          {prefix}\
+         {total_bump}\
          let mask_{0}_value: bool = {1};\n\
          if (mask_{0}_value) {{\n\
+         {passed_bump}\
          \x20   let mask_{0}_word = mask_{0}_agent >> 5u;\n\
          \x20   let mask_{0}_bit  = 1u << (mask_{0}_agent & 31u);\n\
          \x20   atomicOr(&mask_{0}_bitmap[mask_{0}_word], mask_{0}_bit);\n\
@@ -4564,6 +4609,93 @@ mod tests {
         );
     }
 
+    /// Compiler debug mode Phase 2: when `mask_hit_rate=true`, the
+    /// PerAgent body emits `atomicAdd(&mask_total[<id>], 1u)` before
+    /// the predicate evaluation and `atomicAdd(&mask_passed[<id>], 1u)`
+    /// inside the if-true branch. Default `NONE` does NOT emit them.
+    #[test]
+    fn mask_predicate_per_agent_body_emits_hit_rate_when_flag_set() {
+        let mut prog = CgProgram::default();
+        prog.debug_wgsl = DebugWgslFlags {
+            mask_hit_rate: true,
+            ..DebugWgslFlags::NONE
+        };
+        let lit_true = push_expr(&mut prog, CgExpr::Lit(LitValue::Bool(true)));
+        let kind = ComputeOpKind::MaskPredicate {
+            mask: MaskId(9),
+            predicate: lit_true,
+        };
+        let op = ComputeOp::new(
+            OpId(0),
+            kind,
+            DispatchShape::PerAgent,
+            Span::dummy(),
+            &prog,
+            &prog,
+            &prog,
+        );
+        let op_id = push_op(&mut prog, op);
+        let topology = KernelTopology::Split {
+            op: op_id,
+            dispatch: DispatchShape::PerAgent,
+        };
+        let ctx = EmitCtx::structural(&prog);
+        let (_spec, body) =
+            kernel_topology_to_spec_and_body(&topology, &prog, &ctx).unwrap();
+        assert!(
+            body.contains("atomicAdd(&mask_total[9u], 1u);"),
+            "mask_hit_rate=true must bump mask_total per visit;\nbody: {body}"
+        );
+        assert!(
+            body.contains("atomicAdd(&mask_passed[9u], 1u);"),
+            "mask_hit_rate=true must bump mask_passed on hit;\nbody: {body}"
+        );
+        // Still emits the existing atomicOr — flag is additive only.
+        assert!(
+            body.contains("atomicOr(&mask_9_bitmap[mask_9_word], mask_9_bit);"),
+            "existing atomicOr must remain;\nbody: {body}"
+        );
+    }
+
+    /// Default `NONE` keeps the body bit-for-bit free of any
+    /// `mask_total` / `mask_passed` references.
+    #[test]
+    fn mask_predicate_per_agent_body_omits_hit_rate_when_flag_not_set() {
+        let mut prog = CgProgram::default();
+        // Explicit NONE — equivalent to default but pinned for clarity.
+        prog.debug_wgsl = DebugWgslFlags::NONE;
+        let lit_true = push_expr(&mut prog, CgExpr::Lit(LitValue::Bool(true)));
+        let kind = ComputeOpKind::MaskPredicate {
+            mask: MaskId(11),
+            predicate: lit_true,
+        };
+        let op = ComputeOp::new(
+            OpId(0),
+            kind,
+            DispatchShape::PerAgent,
+            Span::dummy(),
+            &prog,
+            &prog,
+            &prog,
+        );
+        let op_id = push_op(&mut prog, op);
+        let topology = KernelTopology::Split {
+            op: op_id,
+            dispatch: DispatchShape::PerAgent,
+        };
+        let ctx = EmitCtx::structural(&prog);
+        let (_spec, body) =
+            kernel_topology_to_spec_and_body(&topology, &prog, &ctx).unwrap();
+        assert!(
+            !body.contains("mask_total"),
+            "DebugWgslFlags::NONE must not emit mask_total;\nbody: {body}"
+        );
+        assert!(
+            !body.contains("mask_passed"),
+            "DebugWgslFlags::NONE must not emit mask_passed;\nbody: {body}"
+        );
+    }
+
 
     #[test]
     fn mask_predicate_under_unsupported_dispatch_shape_errors() {
@@ -4715,6 +4847,89 @@ mod tests {
         assert!(
             !body.contains("TODO(task-4.x): scoring_argmax"),
             "body still has placeholder: {body}"
+        );
+    }
+
+    /// Compiler debug mode Phase 2: when
+    /// `score_kernel_visits=true`, the per-row body bumps
+    /// `score_kernel_visits[agent_id]` once per visit. Default `NONE`
+    /// does NOT emit it.
+    #[test]
+    fn scoring_argmax_emits_candidate_count_when_flag_set() {
+        let mut prog = CgProgram::default();
+        prog.debug_wgsl = DebugWgslFlags {
+            score_kernel_visits: true,
+            ..DebugWgslFlags::NONE
+        };
+        let utility = push_expr(&mut prog, CgExpr::Lit(LitValue::F32(2.5)));
+        let kind = ComputeOpKind::ScoringArgmax {
+            scoring: ScoringId(7),
+            rows: vec![ScoringRowOp {
+                action: ActionId(3),
+                utility,
+                target: None,
+                guard: None,
+            }],
+        };
+        let probe = ComputeOp::new(
+            OpId(0),
+            kind,
+            DispatchShape::PerAgent,
+            Span::dummy(),
+            &prog,
+            &prog,
+            &prog,
+        );
+        let op_id = push_op(&mut prog, probe);
+        let topology = KernelTopology::Split {
+            op: op_id,
+            dispatch: DispatchShape::PerAgent,
+        };
+        let ctx = EmitCtx::structural(&prog);
+        let (_spec, body) =
+            kernel_topology_to_spec_and_body(&topology, &prog, &ctx).unwrap();
+        assert!(
+            body.contains("atomicAdd(&score_kernel_visits[agent_id], 1u);"),
+            "score_kernel_visits=true must bump per-agent counter;\nbody: {body}"
+        );
+    }
+
+    /// Default `NONE` keeps the body free of any
+    /// `score_kernel_visits` references.
+    #[test]
+    fn scoring_argmax_omits_candidate_count_when_flag_not_set() {
+        let mut prog = CgProgram::default();
+        prog.debug_wgsl = DebugWgslFlags::NONE;
+        let utility = push_expr(&mut prog, CgExpr::Lit(LitValue::F32(2.5)));
+        let kind = ComputeOpKind::ScoringArgmax {
+            scoring: ScoringId(7),
+            rows: vec![ScoringRowOp {
+                action: ActionId(3),
+                utility,
+                target: None,
+                guard: None,
+            }],
+        };
+        let probe = ComputeOp::new(
+            OpId(0),
+            kind,
+            DispatchShape::PerAgent,
+            Span::dummy(),
+            &prog,
+            &prog,
+            &prog,
+        );
+        let op_id = push_op(&mut prog, probe);
+        let topology = KernelTopology::Split {
+            op: op_id,
+            dispatch: DispatchShape::PerAgent,
+        };
+        let ctx = EmitCtx::structural(&prog);
+        let (_spec, body) =
+            kernel_topology_to_spec_and_body(&topology, &prog, &ctx).unwrap();
+        assert!(
+            !body.contains("score_kernel_visits"),
+            "DebugWgslFlags::NONE must not emit score_kernel_visits;\nbody: {body}"
         );
     }
 

--- a/crates/dsl_compiler/src/cg/emit/program.rs
+++ b/crates/dsl_compiler/src/cg/emit/program.rs
@@ -353,6 +353,12 @@ pub fn emit_cg_program_with_debug(
         bound_target_exprs: std::cell::RefCell::new(std::collections::HashSet::new()),
         event_ring_atomic_loads: std::cell::Cell::new(false),
         alive_atomic_writes: std::cell::Cell::new(false),
+        // 2026-05-09 (Compiler debug mode Phase 2): mirror the
+        // program-level WGSL instrumentation bitset onto the emit
+        // context. Default `DebugWgslFlags::NONE` preserves the
+        // existing emit shape; per-runtime build.rs opt-in via
+        // `LowerOpts.debug_wgsl` flows through `CgProgram.debug_wgsl`.
+        debug_wgsl: prog.debug_wgsl,
     };
 
     for (stage_idx, stage) in schedule.stages.iter().enumerate() {

--- a/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
+++ b/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
@@ -73,6 +73,7 @@ use crate::cg::data_handle::{
     RngPurpose, SpatialStorageKind, ViewStorageSlot,
 };
 use crate::cg::expr::{BinaryOp, BuiltinId, CgExpr, CgTy, ExprArena, LitValue, NumericTy, UnaryOp};
+use crate::cg::lower::driver::DebugWgslFlags;
 use crate::cg::op::EventKindId;
 use crate::cg::program::CgProgram;
 use crate::cg::stmt::{
@@ -225,6 +226,24 @@ pub struct EmitCtx<'a> {
     /// `Assign(AgentField::Alive, _, Lit(Bool(false)))` pattern
     /// (detected by [`crate::cg::emit::kernel`]), restored on exit.
     pub alive_atomic_writes: std::cell::Cell<bool>,
+
+    /// 2026-05-09 (Compiler debug mode Phase 2): WGSL-side
+    /// atomic-counter instrumentation bitset, mirrored from
+    /// [`crate::cg::program::CgProgram::debug_wgsl`] at EmitCtx
+    /// construction time. When [`Self::debug_wgsl.event_kind_histogram`]
+    /// is set, the chronicle-append skeleton (and dispatcher arm
+    /// chain) bumps `event_kind_counts[<kind>]` alongside the existing
+    /// `atomicAdd(&event_tail[0], 1u)`. When `mask_hit_rate` is set,
+    /// every MaskPredicate body bumps `mask_total[<mask_id>]` per
+    /// candidate visit and `mask_passed[<mask_id>]` per pass. When
+    /// `score_kernel_visits` is set, every scoring argmax row
+    /// bumps `score_kernel_visits[agent_id]` per candidate considered.
+    /// Default [`crate::cg::lower::driver::DebugWgslFlags::NONE`]
+    /// preserves the existing emit shape verbatim.
+    ///
+    /// Read-only on `&EmitCtx` — the gate is checked in the same
+    /// emit functions that emit the chronicle/mask/scoring bodies.
+    pub debug_wgsl: DebugWgslFlags,
 }
 
 impl<'a> EmitCtx<'a> {
@@ -241,6 +260,13 @@ impl<'a> EmitCtx<'a> {
             bound_target_exprs: std::cell::RefCell::new(std::collections::HashSet::new()),
             event_ring_atomic_loads: std::cell::Cell::new(false),
             alive_atomic_writes: std::cell::Cell::new(false),
+            // 2026-05-09 (Compiler debug mode Phase 2): mirror the
+            // program-level WGSL instrumentation bitset so emit
+            // functions can gate their atomic-counter additions on
+            // a single pure read of `ctx.debug_wgsl`. Default
+            // `DebugWgslFlags::NONE` (when no opts threaded) leaves
+            // the existing emit shape unchanged.
+            debug_wgsl: prog.debug_wgsl,
         }
     }
 
@@ -1893,8 +1919,10 @@ fn lower_cg_stmt_body_to_wgsl(
             } else {
                 ("        ",         "            ")
             };
-            let primary_arm_chain = emit_chronicle_arm_chain(primary_indent, "scale_bonus");
-            let nested_arm_chain  = emit_chronicle_arm_chain(nested_indent,  "nested_scale_bonus");
+            let primary_arm_chain =
+                emit_chronicle_arm_chain(primary_indent, "scale_bonus", ctx.debug_wgsl);
+            let nested_arm_chain =
+                emit_chronicle_arm_chain(nested_indent, "nested_scale_bonus", ctx.debug_wgsl);
             // Engine pins MAX_EFFECTS_PER_PROGRAM = 6 + EFFECT_KIND_EMPTY = 0xFFu
             // (see crates/engine/src/ability/program.rs:28 +
             // crates/engine/src/ability/packed.rs). Inlining the
@@ -3131,6 +3159,7 @@ fn lower_emit_to_wgsl(
         stride,
         fields.len(),
         &field_writes,
+        ctx.debug_wgsl,
     ))
 }
 
@@ -3167,17 +3196,39 @@ fn lower_emit_to_wgsl(
 ///
 /// `field_count` is purely cosmetic — used in the header comment for
 /// frame-capture readability.
+///
+/// `debug_wgsl` (Compiler debug mode Phase 2): when
+/// [`crate::cg::lower::driver::DebugWgslFlags::event_kind_histogram`]
+/// is set, emits a parallel `atomicAdd(&event_kind_counts[<event_id>], 1u)`
+/// alongside the existing tail bump. The counter buffer must be
+/// declared by the kernel's BGL synthesis when any chronicle producer
+/// in the kernel body has the flag set; the BGL fanout is deferred to
+/// the per-runtime opt-in slice (no production runtime opts in
+/// today). Default [`crate::cg::lower::driver::DebugWgslFlags::NONE`]
+/// emits the existing skeleton verbatim — bit-for-bit identical to
+/// the prior shape.
 pub(crate) fn emit_chronicle_append_skeleton(
     event_id: u32,
     buf: &str,
     stride: u32,
     field_count: usize,
     field_writes: &[String],
+    debug_wgsl: DebugWgslFlags,
 ) -> String {
     let mut out = String::new();
     out.push_str(&format!("// emit event#{event_id} ({field_count} fields)\n"));
     out.push_str("{\n");
     out.push_str("    let slot = atomicAdd(&event_tail[0], 1u);\n");
+    if debug_wgsl.event_kind_histogram {
+        // Phase 2 debug instrumentation: bump the per-kind histogram
+        // alongside the ring's tail counter. The increment is
+        // observation-only (P5) and the atomic is commutative so
+        // counts remain deterministic across thread orderings (P11).
+        out.push_str(&format!(
+            "    // debug_wgsl.event_kind_histogram: per-kind chronicle counter\n\
+             \x20   atomicAdd(&event_kind_counts[{event_id}u], 1u);\n"
+        ));
+    }
     out.push_str(&format!(
         "    if (slot < {}u) {{\n",
         DEFAULT_EVENT_RING_CAP_SLOTS
@@ -3527,7 +3578,11 @@ pub(crate) fn event_kind_id_for_effect_kind(effect_kind: u32) -> Option<u32> {
 /// drift surfaces there. The chain is structurally identical to
 /// `pack_effect`'s variant ordering in
 /// `crates/engine/src/ability/packed.rs`.
-fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
+fn emit_chronicle_arm_chain(
+    indent: &str,
+    scale_bonus_var: &str,
+    debug_wgsl: DebugWgslFlags,
+) -> String {
     let damage_event_id = event_kind_id_for_effect_kind(0)
         .expect("EFFECT_KIND_TO_EVENT_KIND_ID must contain Damage=0");
     let heal_event_id = event_kind_id_for_effect_kind(1)
@@ -3626,6 +3681,27 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
 
     let mut s = String::new();
 
+    // Compiler debug mode Phase 2: per-arm helper that emits the
+    // event-kind histogram bump just below the slot acquisition. Empty
+    // when `event_kind_histogram=false` so the existing arm-chain
+    // shape is bit-for-bit unchanged for non-opt-in fixtures.
+    //
+    // Each arm's `<kind>_event_id` is statically known at emit time
+    // (resolved via `event_kind_id_for_effect_kind` above), so the
+    // bump targets a known index in `event_kind_counts`. The atomic
+    // is commutative + thread-order-independent (P11) so counts are
+    // deterministic across launches.
+    let hist_bump = |event_id: u32| -> String {
+        if debug_wgsl.event_kind_histogram {
+            format!(
+                "{i12}// debug_wgsl.event_kind_histogram: per-kind chronicle counter\n\
+                 {i12}atomicAdd(&event_kind_counts[{event_id}u], 1u);\n"
+            )
+        } else {
+            String::new()
+        }
+    };
+
     // Damage = 0 → 26
     s.push_str(&format!("{i4}// Damage = 0 → EventKindId::EffectDamageApplied = 26\n"));
     s.push_str(&format!("{i4}if (kind == 0u) {{\n"));
@@ -3633,6 +3709,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectDamageApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(damage_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {damage_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3649,6 +3726,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectHealApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(heal_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {heal_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3665,6 +3743,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectShieldApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(shield_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {shield_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3682,6 +3761,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectStunApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(stun_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {stun_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3701,6 +3781,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectSlowApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(slow_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {slow_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3724,6 +3805,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectRootApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(root_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {root_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3741,6 +3823,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectSilenceApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(silence_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {silence_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3758,6 +3841,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectFearApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(fear_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {fear_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3775,6 +3859,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectTauntApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(taunt_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {taunt_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3803,6 +3888,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectDashApplied (caster_slot + distance)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(dash_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {dash_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3819,6 +3905,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectBlinkApplied (caster_slot + distance)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(blink_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {blink_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3835,6 +3922,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectKnockbackApplied (caster_slot + target_slot + distance)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(knockback_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {knockback_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3852,6 +3940,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectPullApplied (caster_slot + target_slot + distance)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(pull_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {pull_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3885,6 +3974,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectStealthApplied (caster_slot + duration_ticks)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(stealth_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {stealth_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3900,6 +3990,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectCharmApplied (caster_slot + target_slot + duration_ticks)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(charm_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {charm_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3916,6 +4007,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectGroundedApplied (caster_slot + target_slot + duration_ticks)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(grounded_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {grounded_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3932,6 +4024,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectSuppressApplied (caster_slot + target_slot + duration_ticks)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(suppress_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {suppress_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3953,6 +4046,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectGoldTransfer (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(transfer_gold_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {transfer_gold_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3970,6 +4064,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectStandingDelta (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(modify_standing_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {modify_standing_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -3993,6 +4088,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectExecuteApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(execute_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {execute_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4013,6 +4109,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectSelfDamageApplied (caster_slot for both actor + target)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(self_damage_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {self_damage_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4034,6 +4131,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectLifeStealApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(life_steal_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {life_steal_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4056,6 +4154,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectDamageModifyApplied (caster_slot + target_slot)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(damage_modify_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {damage_modify_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4092,6 +4191,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectDamageOverTimeApplied (caster_slot + target_slot + amount + duration)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(damage_over_time_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {damage_over_time_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4111,6 +4211,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectHealOverTimeApplied (caster_slot + target_slot + amount + duration)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(heal_over_time_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {heal_over_time_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4130,6 +4231,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectTimedShieldApplied (caster_slot + target_slot + amount + duration)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(timed_shield_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {timed_shield_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4172,6 +4274,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectBuffApplied (caster_slot + target_slot + payload_a + payload_b)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(buff_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {buff_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4198,6 +4301,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectSummonApplied (caster_slot + template_hash + count + lifetime_ticks)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(summon_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {summon_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4217,6 +4321,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectHarvestApplied (caster_slot + kind_hash + amount)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(harvest_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {harvest_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4235,6 +4340,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectPlaceVoxelApplied (caster_slot + kind_hash)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(place_voxel_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {place_voxel_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4252,6 +4358,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectReflectApplied (caster_slot + target_slot + duration + fraction_q8)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(reflect_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {reflect_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4279,6 +4386,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectPlantBeliefApplied (caster_slot + target_slot + subject_idx + fact_bit_mask)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(plant_belief_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {plant_belief_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4303,6 +4411,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectObserveApplied (caster_slot + target_slot + target_observer)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(observe_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {observe_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4326,6 +4435,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectScryApplied (caster_slot + target_slot + target_observer + subject_idx)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(scry_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {scry_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4347,6 +4457,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectRevealApplied (caster_slot + target_slot + subject_idx)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(reveal_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {reveal_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4369,6 +4480,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectDisguiseApplied (caster_slot + target_slot + packed_payload_a)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(disguise_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {disguise_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4390,6 +4502,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectDecoyApplied (caster_slot + target_slot + subject_idx + fake_pos)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(decoy_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {decoy_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4411,6 +4524,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectEraseBeliefApplied (caster_slot + target_slot + subject_idx + fields)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(erase_belief_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {erase_belief_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4438,6 +4552,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectTravelToApplied (caster_slot + caster_slot + packed_dest + eta_ticks)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(travel_to_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {travel_to_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4463,6 +4578,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectRecipeApplied (caster_slot + caster_slot + packed_recipe + 0)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(recipe_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {recipe_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4488,6 +4604,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectWearToolApplied (caster_slot + caster_slot + packed_wear + 0)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(wear_tool_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {wear_tool_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4509,6 +4626,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectProposeApplied (caster_slot + target_slot + payload_a + payload_b)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(propose_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {propose_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4531,6 +4649,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectAnnounceApplied (caster_slot + caster_slot + payload_a + 0)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(announce_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {announce_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4552,6 +4671,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectGainSkillApplied (caster_slot + caster_slot + payload_a + 0)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(gain_skill_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {gain_skill_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -4574,6 +4694,7 @@ fn emit_chronicle_arm_chain(indent: &str, scale_bonus_var: &str) -> String {
     s.push_str(&format!("{i8}// chronicle: emit EffectCreateObligationApplied (caster_slot + target_slot + payload_a + 0)\n"));
     s.push_str(&format!("{i8}{{\n"));
     s.push_str(&format!("{i12}let _slot: u32 = atomicAdd(&event_tail[0], 1u);\n"));
+    s.push_str(&hist_bump(create_obligation_event_id));
     s.push_str(&format!("{i12}if (_slot < 1048576u) {{\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 0u], {create_obligation_event_id}u);\n"));
     s.push_str(&format!("{i16}atomicStore(&event_ring[_slot * 10u + 1u], tick);\n"));
@@ -7780,6 +7901,7 @@ mod tests {
             /*stride*/ 4,
             /*field_count*/ 2,
             &field_writes,
+            DebugWgslFlags::NONE,
         );
 
         // Header comment carries event id + field count for capture
@@ -7814,10 +7936,63 @@ mod tests {
         // the standard layout's header) have zero declared fields.
         // The skeleton must still emit the slot acquisition + tag/tick
         // header writes, just with no field-write lines.
-        let wgsl = emit_chronicle_append_skeleton(2, "ring", 2, 0, &[]);
+        let wgsl = emit_chronicle_append_skeleton(
+            2,
+            "ring",
+            2,
+            0,
+            &[],
+            DebugWgslFlags::NONE,
+        );
         assert!(wgsl.contains("atomicAdd(&event_tail[0], 1u);"));
         assert!(wgsl.contains("atomicStore(&ring[slot * 2u + 0u], 2u);"));
         assert!(wgsl.contains("atomicStore(&ring[slot * 2u + 1u], tick);"));
+    }
+
+    // ---- Compiler debug mode Phase 2 (DebugWgslFlags) ----
+
+    /// `event_kind_histogram=true` emits a parallel
+    /// `atomicAdd(&event_kind_counts[<kind>], 1u)` alongside the
+    /// existing `event_tail` bump. Default `NONE` does NOT emit it.
+    #[test]
+    fn chronicle_skeleton_emits_event_kind_histogram_when_flag_set() {
+        // Default `NONE` — the histogram increment must NOT appear.
+        let baseline = emit_chronicle_append_skeleton(
+            27,
+            "my_ring",
+            4,
+            0,
+            &[],
+            DebugWgslFlags::NONE,
+        );
+        assert!(
+            !baseline.contains("event_kind_counts"),
+            "DebugWgslFlags::NONE must not emit histogram counter;\n{baseline}"
+        );
+
+        // With the flag set — the per-kind atomicAdd must appear,
+        // referencing the same event_id (27) the rest of the skeleton
+        // bakes into the tag store.
+        let flagged = emit_chronicle_append_skeleton(
+            27,
+            "my_ring",
+            4,
+            0,
+            &[],
+            crate::cg::lower::driver::DebugWgslFlags {
+                event_kind_histogram: true,
+                ..crate::cg::lower::driver::DebugWgslFlags::NONE
+            },
+        );
+        assert!(
+            flagged.contains("atomicAdd(&event_kind_counts[27u], 1u);"),
+            "event_kind_histogram=true must emit per-kind atomicAdd;\n{flagged}"
+        );
+        // The existing `event_tail` bump is preserved verbatim.
+        assert!(
+            flagged.contains("let slot = atomicAdd(&event_tail[0], 1u);"),
+            "event_tail bump must remain;\n{flagged}"
+        );
     }
 
     // ---- EFFECT_KIND_TO_EVENT_KIND_ID — slice γ pre-fact pin.

--- a/crates/dsl_compiler/src/cg/lower/driver.rs
+++ b/crates/dsl_compiler/src/cg/lower/driver.rs
@@ -223,6 +223,26 @@ pub struct LowerOpts {
     /// schema-hash inputs. Toggling `debug` between runs leaves the
     /// schema hash unchanged.
     pub debug: DebugDepth,
+    /// 2026-05-09 (Compiler debug mode Phase 2): WGSL-side atomic
+    /// counter instrumentation. Independently selectable per axis
+    /// (event-kind histograms, mask hit-rate, scoring kernel visits).
+    /// When the bitset is `NONE`, the WGSL emit + BGL composer behave
+    /// exactly as before; when any flag is set, the affected emit
+    /// sites add parallel `atomicAdd` calls onto per-flag counter
+    /// buffers.
+    ///
+    /// Orthogonal to [`Self::debug`]: Phase 1 owns host-side
+    /// timestamps + memory traffic + DSL source mapping; Phase 2 owns
+    /// WGSL-side atomic counters. Two completely separate fields,
+    /// two completely separate code paths.
+    ///
+    /// Default `NONE` preserves the existing emit shape for every
+    /// non-opt-in fixture (every production runtime today). The
+    /// per-runtime BGL fanout (extra bindings on the ~11 runtimes
+    /// that bind agent SoA columns) is deferred to a follow-up
+    /// slice that lands an opt-in `*_debug_runtime` fixture; today
+    /// no runtime opts in.
+    pub debug_wgsl: DebugWgslFlags,
 }
 
 /// Compiler debug-mode level — graduated GPU + memory + DSL-source
@@ -309,6 +329,92 @@ impl DebugDepth {
     /// (D4 only).
     pub fn emits_source_map(self) -> bool {
         self >= DebugDepth::DslMapped
+    }
+}
+
+/// WGSL-side atomic-counter instrumentation bitset (Compiler debug
+/// mode Phase 2). Each axis is independently selectable; when an
+/// axis is set, the affected WGSL emit sites add a parallel
+/// `atomicAdd` call onto a per-axis counter buffer that the runtime
+/// reads back via the per-runtime debug API (deferred — needs
+/// opt-in `*_debug_runtime` fixture).
+///
+/// # Constitution alignment
+///
+/// - **P1 Compiler-First.** The atomic counters are emitted by the
+///   compiler, not hand-written in any `*.wgsl` file under
+///   `engine_gpu_rules/src/`.
+/// - **P2 Schema-Hash.** The bitset is compile-time configuration
+///   threaded through [`LowerOpts`]. The atomic counter buffers are
+///   extra GPU-side state, NOT part of the SoA / event contract —
+///   the schema hash stays unchanged.
+/// - **P3 Cross-Backend Parity.** GPU-only. The CPU backend can
+///   ignore [`Self`] entirely and return zero counters from the
+///   runtime API.
+/// - **P5 Determinism.** Atomic counters are observation-only and
+///   don't change RNG draws or sim state.
+/// - **P11 Reduction Determinism.** Atomic increments are
+///   commutative — order doesn't matter for COUNTS (only for sums of
+///   floats). Final values are deterministic regardless of work-item
+///   order.
+///
+/// Default [`Self::NONE`] preserves the existing emit shape.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct DebugWgslFlags {
+    /// Per-`EventKindId` histogram: at every chronicle producer
+    /// (`atomicAdd(&event_tail[0], 1u)` site emitted by the dispatcher
+    /// + emit lowerings), bump
+    /// `event_kind_counts[<statically-known kind>]` by 1. Total over
+    /// all entries equals the chronicle ring high-water mark for the
+    /// tick.
+    pub event_kind_histogram: bool,
+    /// Per-mask-kernel pass/total counter pair. Inside each
+    /// `MaskPredicate` body, `atomicAdd(&mask_total[<mask_id>], 1u)`
+    /// runs once per candidate visit; `atomicAdd(&mask_passed[<mask_id>], 1u)`
+    /// runs once per candidate that satisfies the predicate. Hit rate
+    /// = passed/total.
+    pub mask_hit_rate: bool,
+    /// Per-agent scoring kernel visit count. Bumps
+    /// `score_kernel_visits[agent_id]` per *kernel visit* — semantics
+    /// differ across row shapes:
+    ///
+    /// - **Pair-field rows** (target ≠ self): one increment per
+    ///   *candidate* considered in the inner loop. So for an agent
+    ///   that argmaxes over 200 in-radius candidates this tick, the
+    ///   counter rises by 200.
+    /// - **Self-only rows** (target = self): one increment per *row
+    ///   visit* — the kernel runs once per agent per row, so the
+    ///   counter rises by N for an agent visited across N rows.
+    ///
+    /// Renamed from `scoring_candidate_count` (2026-05-09 review): the
+    /// asymmetry across row types makes "candidates" misleading on
+    /// self-only rows where the kernel doesn't iterate. "Kernel visits"
+    /// matches the actual work counted.
+    pub score_kernel_visits: bool,
+}
+
+impl DebugWgslFlags {
+    /// All-axes-off bitset. Identical to [`Self::default()`] but
+    /// usable in `const` contexts.
+    pub const NONE: Self = Self {
+        event_kind_histogram: false,
+        mask_hit_rate: false,
+        score_kernel_visits: false,
+    };
+
+    /// All-axes-on bitset. Useful for top-down debugging and tests
+    /// that want to exercise every counter path.
+    pub const ALL: Self = Self {
+        event_kind_histogram: true,
+        mask_hit_rate: true,
+        score_kernel_visits: true,
+    };
+
+    /// `true` when at least one axis is enabled. Used by the BGL
+    /// composer follow-up (deferred) to decide whether to surface
+    /// the new instrumentation buffer bindings.
+    pub fn any(&self) -> bool {
+        self.event_kind_histogram || self.mask_hit_rate || self.score_kernel_visits
     }
 }
 
@@ -693,6 +799,12 @@ pub fn lower_compilation_to_cg_with_opts(
     // `view_signatures` was set on the builder's program BEFORE the
     // cycle gate (above); `finish()` preserves it. No re-snapshot
     // needed here.
+    // 2026-05-09 (Compiler debug mode Phase 2): persist the WGSL
+    // instrumentation bitset onto the program so the emit layer can
+    // read it via `EmitCtx::debug_wgsl`. This is the single channel
+    // by which a per-runtime build.rs opt-in (`LowerOpts {
+    // debug_wgsl: ... }`) reaches `wgsl_body.rs`.
+    prog.debug_wgsl = opts.debug_wgsl;
 
     if diagnostics.is_empty() {
         Ok(prog)
@@ -4189,5 +4301,53 @@ mod tests {
                 "agents.{method} should take (observer, subject, value)",
             );
         }
+    }
+
+    // ---- Compiler debug mode Phase 2 (DebugWgslFlags) plumbing ----
+
+    /// `DebugWgslFlags::NONE` is the default; `any()` is `false`.
+    /// `ALL` flips every axis; `any()` is `true`.
+    #[test]
+    fn debug_wgsl_flags_default_and_const_any() {
+        assert_eq!(DebugWgslFlags::default(), DebugWgslFlags::NONE);
+        assert!(!DebugWgslFlags::NONE.any());
+        assert!(DebugWgslFlags::ALL.any());
+        assert!(DebugWgslFlags::ALL.event_kind_histogram);
+        assert!(DebugWgslFlags::ALL.mask_hit_rate);
+        assert!(DebugWgslFlags::ALL.score_kernel_visits);
+    }
+
+    /// `LowerOpts::default()` carries `DebugWgslFlags::NONE` and
+    /// `DebugDepth::Off` — every existing fixture's
+    /// `lower_compilation_to_cg(comp)` call inherits the
+    /// zero-overhead shape.
+    #[test]
+    fn lower_opts_default_carries_off_and_none() {
+        let opts = LowerOpts::default();
+        assert_eq!(opts.debug, DebugDepth::Off);
+        assert_eq!(opts.debug_wgsl, DebugWgslFlags::NONE);
+        // Pre-existing fields preserve their defaults.
+        assert!(!opts.aoe_dispatch);
+        assert!(!opts.belief_state);
+    }
+
+    /// `LowerOpts.debug_wgsl` is plumbed through the driver onto
+    /// the resulting `CgProgram.debug_wgsl`. The emit layer reads
+    /// from the program's field via `EmitCtx::structural`.
+    #[test]
+    fn lower_opts_debug_wgsl_threads_to_cg_program() {
+        let comp = Compilation::default();
+        let opts = LowerOpts {
+            debug_wgsl: DebugWgslFlags {
+                event_kind_histogram: true,
+                ..DebugWgslFlags::NONE
+            },
+            ..LowerOpts::default()
+        };
+        let prog = lower_compilation_to_cg_with_opts(&comp, opts)
+            .expect("empty Compilation lowers cleanly");
+        assert!(prog.debug_wgsl.event_kind_histogram);
+        assert!(!prog.debug_wgsl.mask_hit_rate);
+        assert!(!prog.debug_wgsl.score_kernel_visits);
     }
 }

--- a/crates/dsl_compiler/src/cg/lower/mod.rs
+++ b/crates/dsl_compiler/src/cg/lower/mod.rs
@@ -39,8 +39,8 @@ pub mod verb_expand;
 pub mod view;
 
 pub use driver::{
-    lower_compilation_to_cg, lower_compilation_to_cg_with_opts, DebugDepth, DriverOutcome,
-    LowerOpts,
+    lower_compilation_to_cg, lower_compilation_to_cg_with_opts, DebugDepth, DebugWgslFlags,
+    DriverOutcome, LowerOpts,
 };
 pub use error::LoweringError;
 pub use expr::{lower_expr, LoweringCtx};

--- a/crates/dsl_compiler/src/cg/program.rs
+++ b/crates/dsl_compiler/src/cg/program.rs
@@ -996,6 +996,20 @@ pub struct CgProgram {
     /// table is a zero-cost surface for the P6 check that doesn't
     /// touch the fusion / emit pipeline.
     pub post_phase_physics_rules: std::collections::BTreeSet<u32>,
+    /// 2026-05-09 (Compiler debug mode Phase 2): WGSL-side atomic
+    /// counter instrumentation bitset, plumbed in from
+    /// [`super::lower::driver::LowerOpts::debug_wgsl`]. Read by the
+    /// emit layer ([`super::emit::wgsl_body::EmitCtx::debug_wgsl`])
+    /// to gate per-kernel atomic-counter `atomicAdd` calls. Default
+    /// [`super::lower::driver::DebugWgslFlags::NONE`] preserves the
+    /// existing emit shape for every non-opt-in fixture.
+    ///
+    /// `#[serde(skip)]`: this is build-time configuration, not part
+    /// of the program's logical contract. Round-tripping a CgProgram
+    /// through serde drops the flag back to `NONE` (i.e. the bake
+    /// channel always emits the production shape).
+    #[serde(skip)]
+    pub debug_wgsl: super::lower::driver::DebugWgslFlags,
 }
 
 impl CgProgram {

--- a/crates/dsl_compiler/tests/verb_emit.rs
+++ b/crates/dsl_compiler/tests/verb_emit.rs
@@ -169,6 +169,9 @@ fn scoring_kernel_emits_action_selected_when_verb_present() {
             bound_target_exprs: std::cell::RefCell::new(std::collections::HashSet::new()),
             event_ring_atomic_loads: std::cell::Cell::new(false),
             alive_atomic_writes: std::cell::Cell::new(false),
+            // Compiler debug mode Phase 2: mirror the program-level
+            // bitset (default `NONE`); test fixtures here don't opt in.
+            debug_wgsl: prog.debug_wgsl,
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 2 of the compiler debug mode plan (`docs/superpowers/plans/2026-05-09-compiler-debug-mode-gpu-timestamps.md`). Adds `LowerOpts.debug_wgsl: DebugWgslFlags` — a 3-axis bitset for WGSL-side atomic-counter instrumentation, orthogonal to Phase 1's `LowerOpts.debug: DebugDepth` (which lives on the host side).

The 3 axes:
- **`event_kind_histogram`** — at every chronicle producer site (47 sites in `wgsl_body.rs`), emit a parallel `atomicAdd(&event_kind_counts[<kind>], 1u)`. Total over all entries equals the per-tick chronicle ring high-water mark.
- **`mask_hit_rate`** — per-mask kernel `mask_total[<id>]` + `mask_passed[<id>]` counters. Hit rate = passed / total. Tells you whether a mask predicate is doing useful work.
- **`score_kernel_visits`** *(renamed from `scoring_candidate_count` per review)* — per-agent counter of scoring kernel visits. Asymmetric across row shapes (per-candidate on pair-field rows; per-row-visit on self-only rows), documented inline.

Default `DebugWgslFlags::NONE` preserves the existing emit shape bit-for-bit; no production runtime opts in. The per-runtime BGL fanout (extra bindings on the ~11 runtimes) is deferred to a follow-up slice that lands an opt-in `*_debug_runtime` fixture.

Design decisions applied per review:
1. **Fixed `event_kind_counts` array** sized from `EventKindId::ChronicleEntry+1` — simple, no per-fixture WGSL divergence (~516 B GPU mem, trivial).
2. **`cfg.agent_cap` convention** for `score_kernel_visits` — matches every other per-agent SoA column.
3. **Per-program mask counter sizing** via `prog.interner.masks.len()` at build.rs time — matches existing `mask_N_bitmap` pattern.
4. **Per-pair mask hit rate** — the per-actor coverage metric is already derivable from the existing `mask_N_bitmap` popcount.
5. **Renamed `scoring_candidate_count` → `score_kernel_visits`** to make the asymmetric semantics honest in the field name.
6. Phase 1's stub `DebugDepth` ripped (Phase 1 landed in PR #56 with the real one).

## Test plan
- [x] `cargo build --release` — clean
- [x] `cargo test -p dsl_compiler --release` — no FAILED (no `--lib` flag, runs integration tests)
- [x] `cargo test -p engine --release --test schema_hash` — schema unchanged
- [x] `cargo test -p spy_network_runtime --release --lib` — passes
- [ ] Per-runtime BGL fanout — DEFERRED to follow-up slice (no production runtime opts in today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)