### PR TITLE
feat(compiler): emit Bindings::from_context() constructors per kernel

### DIFF
--- a/crates/dsl_compiler/src/cg/emit/program.rs
+++ b/crates/dsl_compiler/src/cg/emit/program.rs
@@ -878,6 +878,14 @@ fn compose_rust_module_file(spec: &KernelSpec, topology: &KernelTopology) -> Str
     }
     out.push_str("}\n\n");
 
+    // ViewFold kernels skip the constructor — their custom
+    // anchor/ids/sim_cfg shape doesn't fit the standard naming
+    // convention; per-fixture runtimes construct them via the existing
+    // `view_storage` helpers.
+    if !matches!(spec.kind, KernelKind::ViewFold) {
+        out.push_str(&compose_bindings_from_context(spec));
+    }
+
     // Cfg struct decl — KernelSpec.cfg_struct_decl is the full
     // `#[repr(C)] ... pub struct <Cfg> { ... }` form.
     out.push_str(&spec.cfg_struct_decl);
@@ -930,6 +938,180 @@ fn compose_rust_module_file(spec: &KernelSpec, topology: &KernelTopology) -> Str
         // args at the dispatch call site (e.g.,
         // `PhysicsMoveBoidCfg { agent_cap: 16, _pad: [0; 3] }`).
     }
+
+    out
+}
+
+/// Classify an emitted Bindings field by name → which shared source
+/// the compiler-emitted `from_context()` constructor pulls it from.
+///
+/// The naming convention (kept in sync with the
+/// `engine::gpu::bindings_context` module docs):
+///
+/// | Field name pattern              | Classification                    |
+/// |---------------------------------|-----------------------------------|
+/// | `event_ring`                    | `BindingSource::EventRingRing`    |
+/// | `event_tail`                    | `BindingSource::EventRingTail`    |
+/// | `agent_<col>` where col is in   | `BindingSource::AgentBuffer(col)` |
+/// |   `engine::gpu::AgentBuffers::STANDARD_COLUMNS` |                  |
+/// | `ability_registry_<col>`        | `BindingSource::Registry(col)`    |
+/// | `cfg`                           | `BindingSource::Cfg`              |
+/// | (anything else)                 | `BindingSource::Extras`           |
+///
+/// The "anything else" bucket catches fixture-specific buffers — mask
+/// bitmaps, scoring output, fixture-specific SoA columns (e.g.,
+/// `agent_creature_type` in spy_network) — which ride a per-kernel
+/// `<Pascal>Extras` struct passed to `from_context_with_extras`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BindingSource<'a> {
+    EventRingRing,
+    EventRingTail,
+    AgentBuffer(&'a str),
+    Registry(&'a str),
+    Cfg,
+    Extras,
+}
+
+/// The compiler's mirror of `engine::gpu::AgentBuffers::STANDARD_COLUMNS`.
+/// Kept in sync by the `bindings_context_standard_columns_in_sync` test.
+const STANDARD_AGENT_COLUMNS: &[&str] = &[
+    "hp",
+    "max_hp",
+    "alive",
+    "pos",
+    "level",
+    "move_speed",
+    "move_speed_mult",
+    "shield_hp",
+    "armor",
+    "magic_resist",
+    "attack_damage",
+    "attack_range",
+    "mana",
+    "max_mana",
+    "ability_power",
+];
+
+fn classify_binding(name: &str) -> BindingSource<'_> {
+    if name == "event_ring" {
+        return BindingSource::EventRingRing;
+    }
+    if name == "event_tail" {
+        return BindingSource::EventRingTail;
+    }
+    if name == "cfg" {
+        return BindingSource::Cfg;
+    }
+    if let Some(col) = name.strip_prefix("ability_registry_") {
+        return BindingSource::Registry(col);
+    }
+    if let Some(col) = name.strip_prefix("agent_") {
+        if STANDARD_AGENT_COLUMNS.contains(&col) {
+            return BindingSource::AgentBuffer(col);
+        }
+    }
+    BindingSource::Extras
+}
+
+/// Render the Rust expression that yields the `&'a wgpu::Buffer` for
+/// a binding classified through [`classify_binding`]. `name` is the
+/// emitted Bindings field name (used for the extras-arm getter and for
+/// the AgentBuffer's `.expect()` message).
+fn render_from_context_expr(src: &BindingSource<'_>, name: &str) -> String {
+    match src {
+        BindingSource::EventRingRing => "ctx.event_ring.ring()".to_string(),
+        BindingSource::EventRingTail => "ctx.event_ring.tail()".to_string(),
+        BindingSource::AgentBuffer(col) => format!(
+            "ctx.state.{col}_buf.expect(\"kernel binds agent_{col} but the runtime didn't supply ctx.state.{col}_buf\")"
+        ),
+        BindingSource::Registry(col) => format!("&ctx.registry.{col}"),
+        BindingSource::Cfg => "extras.cfg".to_string(),
+        BindingSource::Extras => format!("extras.{name}"),
+    }
+}
+
+/// Compose the `from_context(ctx)` (or `from_context_with_extras(ctx,
+/// extras)` plus sibling `<Pascal>Extras` struct) impl block for a
+/// generic-kernel Bindings struct.
+///
+/// Walks the spec's bindings, classifies each via [`classify_binding`],
+/// and emits:
+///
+/// - When every binding routes through shared sources (state /
+///   event_ring / registry): a parameterless `from_context(ctx)` impl.
+/// - Otherwise (at least one binding falls through to extras OR a
+///   `cfg` binding exists — cfg always rides on extras since cfg
+///   buffers are per-fixture): a `<Pascal>Extras<'a>` struct holding
+///   the unclassified fields + a `from_context_with_extras(ctx, extras)`
+///   impl.
+///
+/// The Cfg binding is treated as "extras" because the cfg buffer is
+/// always a per-fixture per-kernel buffer the runtime owns and writes
+/// each tick. Routing it through extras keeps the constructor's
+/// shared-context narrow (no per-kernel cfg fanout in the context
+/// type).
+fn compose_bindings_from_context(spec: &KernelSpec) -> String {
+    // AliasOf bindings have no struct field (handled at BindGroupEntry
+    // time in lower_rust_bg_entries).
+    let classified: Vec<(&str, BindingSource<'_>)> = spec
+        .bindings
+        .iter()
+        .filter(|b| !matches!(b.bg_source, BgSource::AliasOf(_)))
+        .map(|b| (b.name.as_str(), classify_binding(&b.name)))
+        .collect();
+
+    let needs_extras = classified
+        .iter()
+        .any(|(_, src)| matches!(src, BindingSource::Cfg | BindingSource::Extras));
+
+    let pascal = &spec.pascal;
+    let mut out = String::new();
+
+    if needs_extras {
+        writeln!(out, "pub struct {pascal}Extras<'a> {{").expect("write");
+        for (name, _) in classified
+            .iter()
+            .filter(|(_, src)| matches!(src, BindingSource::Cfg | BindingSource::Extras))
+        {
+            writeln!(out, "    pub {name}: &'a wgpu::Buffer,").expect("write");
+        }
+        out.push_str("}\n\n");
+    }
+
+    writeln!(out, "impl<'a> {pascal}Bindings<'a> {{").expect("write");
+    out.push_str("    /// Construct from the shared [`engine::gpu::KernelBindingsContext`].\n");
+    if needs_extras {
+        writeln!(
+            out,
+            "    /// + per-kernel [`{pascal}Extras`] supplying fixture-specific buffers."
+        )
+        .expect("write");
+    }
+    out.push_str(
+        "    ///\n    \
+         /// Compiler-emitted; see the naming convention in\n    \
+         /// [`engine::gpu::bindings_context`].\n",
+    );
+    if needs_extras {
+        writeln!(
+            out,
+            "    pub fn from_context_with_extras(\n        \
+                 ctx: &engine::gpu::KernelBindingsContext<'a>,\n        \
+                 extras: &{pascal}Extras<'a>,\n    ) -> Self {{"
+        )
+        .expect("write");
+    } else {
+        out.push_str(
+            "    pub fn from_context(\n        \
+             ctx: &engine::gpu::KernelBindingsContext<'a>,\n    ) -> Self {\n",
+        );
+    }
+    out.push_str("        Self {\n");
+    for (name, src) in &classified {
+        let expr = render_from_context_expr(src, name);
+        writeln!(out, "            {name}: {expr},").expect("write");
+    }
+    out.push_str("        }\n    }\n}\n\n");
 
     out
 }
@@ -1726,4 +1908,262 @@ mod tests {
 
 
     // ---- 11. lib.rs synthesis (Task 5.2) ----
+
+    // ---- 12. Bindings::from_context() emit (Task #245) ------------------
+
+    use crate::kernel_binding_ir::{KernelBinding, KernelSpec};
+
+    fn make_spec_with_bindings(name: &str, fields: &[(&str, BgSource)]) -> KernelSpec {
+        let bindings = fields
+            .iter()
+            .enumerate()
+            .map(|(i, (n, src))| KernelBinding {
+                slot: i as u32,
+                name: (*n).to_string(),
+                access: AccessMode::ReadStorage,
+                wgsl_ty: "array<u32>".to_string(),
+                bg_source: src.clone(),
+            })
+            .collect();
+        KernelSpec {
+            name: name.to_string(),
+            pascal: snake_to_pascal(name),
+            entry_point: format!("cs_{name}"),
+            cfg_struct: format!("{}Cfg", snake_to_pascal(name)),
+            cfg_build_expr: "Default::default()".to_string(),
+            cfg_struct_decl: format!("pub struct {}Cfg;", snake_to_pascal(name)),
+            bindings,
+            kind: KernelKind::Generic,
+        }
+    }
+
+    #[test]
+    fn standard_agent_columns_match_engine_agent_buffers() {
+        // Drift guard: the compiler's classifier table must match the
+        // `engine::gpu::AgentBuffers::STANDARD_COLUMNS` const exposed
+        // to runtimes. If a column is added to one but not the other,
+        // generated `from_context` bodies reference fields that don't
+        // exist (or runtimes initialize fields the compiler never
+        // routes), surfacing as a build failure across every runtime.
+        // This test catches the drift in dsl_compiler's own test suite
+        // before the fanout.
+        let compiler_set: std::collections::BTreeSet<&str> =
+            STANDARD_AGENT_COLUMNS.iter().copied().collect();
+        let engine_set: std::collections::BTreeSet<&str> =
+            engine::gpu::AgentBuffers::STANDARD_COLUMNS
+                .iter()
+                .copied()
+                .collect();
+        assert_eq!(
+            compiler_set, engine_set,
+            "STANDARD_AGENT_COLUMNS in dsl_compiler::cg::emit::program drifted from engine::gpu::AgentBuffers::STANDARD_COLUMNS — keep both in sync"
+        );
+    }
+
+    #[test]
+    fn classify_binding_routes_event_ring_and_tail() {
+        assert_eq!(classify_binding("event_ring"), BindingSource::EventRingRing);
+        assert_eq!(classify_binding("event_tail"), BindingSource::EventRingTail);
+    }
+
+    #[test]
+    fn classify_binding_routes_standard_agent_columns() {
+        assert_eq!(classify_binding("agent_hp"), BindingSource::AgentBuffer("hp"));
+        assert_eq!(
+            classify_binding("agent_max_hp"),
+            BindingSource::AgentBuffer("max_hp")
+        );
+        assert_eq!(
+            classify_binding("agent_ability_power"),
+            BindingSource::AgentBuffer("ability_power")
+        );
+    }
+
+    #[test]
+    fn classify_binding_routes_registry_columns() {
+        assert_eq!(
+            classify_binding("ability_registry_effect_kinds"),
+            BindingSource::Registry("effect_kinds")
+        );
+        assert_eq!(
+            classify_binding("ability_registry_when_pred_field"),
+            BindingSource::Registry("when_pred_field")
+        );
+    }
+
+    #[test]
+    fn classify_binding_routes_cfg_to_extras_arm() {
+        assert_eq!(classify_binding("cfg"), BindingSource::Cfg);
+    }
+
+    #[test]
+    fn classify_binding_routes_unknown_to_extras() {
+        // Fixture-specific SoA columns fall through to extras.
+        assert_eq!(
+            classify_binding("agent_creature_type"),
+            BindingSource::Extras
+        );
+        assert_eq!(
+            classify_binding("agent_disguise_fake_type"),
+            BindingSource::Extras
+        );
+        // Per-fixture mask bitmaps fall through.
+        assert_eq!(classify_binding("mask_0_bitmap"), BindingSource::Extras);
+        // Scoring output buffer.
+        assert_eq!(classify_binding("scoring_output"), BindingSource::Extras);
+        // Indirect args (per-EventRing infrastructure but not the
+        // ring/tail pair).
+        assert_eq!(classify_binding("indirect_args_0"), BindingSource::Extras);
+    }
+
+    #[test]
+    fn bindings_from_context_emits_extras_when_unclassified_present() {
+        // Spec with one Cfg binding + one extras binding (mask
+        // bitmap-style name) → from_context_with_extras + Extras struct.
+        let spec = make_spec_with_bindings(
+            "demo_with_extras",
+            &[
+                ("agent_hp", BgSource::Cfg /* placeholder; not used */),
+                ("mask_0_bitmap", BgSource::Cfg),
+                ("cfg", BgSource::Cfg),
+            ],
+        );
+        let emitted = compose_bindings_from_context(&spec);
+        assert!(
+            emitted.contains("pub struct DemoWithExtrasExtras<'a>"),
+            "missing Extras struct decl in:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("pub mask_0_bitmap: &'a wgpu::Buffer,"),
+            "Extras struct missing mask_0_bitmap field:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("pub cfg: &'a wgpu::Buffer,"),
+            "Extras struct missing cfg field:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("pub fn from_context_with_extras("),
+            "missing from_context_with_extras impl:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("ctx.state.hp_buf.expect("),
+            "agent_hp should route through ctx.state.hp_buf:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("mask_0_bitmap: extras.mask_0_bitmap,"),
+            "mask_0_bitmap should route through extras:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("cfg: extras.cfg,"),
+            "cfg should route through extras:\n{emitted}"
+        );
+    }
+
+    #[test]
+    fn bindings_from_context_emits_no_extras_when_all_classified() {
+        // Spec where every binding routes through the shared sources
+        // (event_ring + ability_registry_*) — no cfg, no fixture-specific
+        // buffer → parameterless from_context, no Extras struct.
+        let spec = make_spec_with_bindings(
+            "demo_all_shared",
+            &[
+                ("event_ring", BgSource::Cfg),
+                ("event_tail", BgSource::Cfg),
+                ("agent_hp", BgSource::Cfg),
+                ("ability_registry_effect_kinds", BgSource::Cfg),
+            ],
+        );
+        let emitted = compose_bindings_from_context(&spec);
+        assert!(
+            !emitted.contains("Extras"),
+            "no Extras struct should emit when every binding classifies into shared sources:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("pub fn from_context("),
+            "missing parameterless from_context impl:\n{emitted}"
+        );
+        assert!(
+            !emitted.contains("from_context_with_extras"),
+            "should NOT emit from_context_with_extras when no extras needed:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("event_ring: ctx.event_ring.ring(),"),
+            "event_ring routing:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("event_tail: ctx.event_ring.tail(),"),
+            "event_tail routing:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("ability_registry_effect_kinds: &ctx.registry.effect_kinds,"),
+            "ability_registry_* routing:\n{emitted}"
+        );
+    }
+
+    #[test]
+    fn bindings_from_context_emits_for_every_kernel_in_a_real_program() {
+        // End-to-end smoke: drive an actual .sim through emit and
+        // confirm every emitted Bindings struct has a matching
+        // `from_context` or `from_context_with_extras` impl in the
+        // same module file.
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let workspace = manifest
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("workspace root");
+        let sim_path = workspace.join("assets/sim/spy_network.sim");
+        let src = std::fs::read_to_string(&sim_path).expect("read spy_network.sim");
+        let program = crate::parse(&src).expect("parse spy_network.sim");
+        let comp = dsl_ast::resolve::resolve(program).expect("resolve");
+        let cg = lower_compilation_to_cg(&comp).expect("CG lower");
+        let result = synthesize_schedule(&cg, ScheduleStrategy::Default);
+        let artifacts =
+            emit_cg_program(&result.schedule, &cg).expect("emit_cg_program");
+
+        // Walk every per-kernel rust file (exclude lib.rs, schedule.rs,
+        // dispatch.rs which have no Bindings structs).
+        let mut kernels_checked = 0;
+        for (filename, contents) in &artifacts.rust_files {
+            if filename == "lib.rs" || filename == "schedule.rs" || filename == "dispatch.rs"
+            {
+                continue;
+            }
+            // Find every "pub struct <X>Bindings<'a>" in the file.
+            for line in contents.lines() {
+                if let Some(rest) = line.strip_prefix("pub struct ") {
+                    if let Some(name_end) = rest.find("Bindings<'a>") {
+                        let pascal_with_bindings = &rest[..name_end];
+                        // Skip ViewFold kernels — their custom shape
+                        // doesn't fit the standard convention; the
+                        // emitter intentionally skips from_context for
+                        // them.
+                        if pascal_with_bindings.starts_with("Fold") {
+                            continue;
+                        }
+                        // Confirm the file has either a parameterless
+                        // `from_context(` or `from_context_with_extras(`
+                        // impl for this struct.
+                        let from_context_marker = format!(
+                            "impl<'a> {pascal_with_bindings}Bindings<'a> {{"
+                        );
+                        assert!(
+                            contents.contains(&from_context_marker),
+                            "kernel {filename} has Bindings struct '{pascal_with_bindings}Bindings' but no impl block found"
+                        );
+                        let has_from_context = contents.contains("pub fn from_context(")
+                            || contents.contains("pub fn from_context_with_extras(");
+                        assert!(
+                            has_from_context,
+                            "kernel {filename} Bindings struct '{pascal_with_bindings}Bindings' is missing from_context / from_context_with_extras"
+                        );
+                        kernels_checked += 1;
+                    }
+                }
+            }
+        }
+        assert!(
+            kernels_checked > 0,
+            "expected at least one non-ViewFold Bindings struct in spy_network's emit"
+        );
+    }
 }

--- a/crates/engine/src/gpu/bindings_context.rs
+++ b/crates/engine/src/gpu/bindings_context.rs
@@ -1,0 +1,176 @@
+//! `KernelBindingsContext` — the shared bundle of buffer sources the
+//! compiler-emitted `Bindings::from_context()` constructors pull from.
+//!
+//! # Why this exists
+//!
+//! Today every per-runtime `step()` writes ~30-line `Bindings { ... }`
+//! literals by hand for every kernel dispatch — repeating the
+//! `event_ring: self.event_ring.ring(), event_tail: self.event_ring.tail(),
+//! agent_pos: &self.agent_pos_buf, ...` plumbing across ~40 runtime
+//! crates. Every new SoA column or compiler-emitted buffer fans out
+//! through every dispatch site.
+//!
+//! The dsl_compiler already emits the `Bindings` struct definitions; it
+//! also emits a `from_context(&KernelBindingsContext)` constructor (and
+//! a sibling `from_context_with_extras(...)` for kernels that bind
+//! fixture-specific buffers) that pulls each buffer from the appropriate
+//! shared source by naming convention. Per-runtime dispatch becomes:
+//!
+//! ```ignore
+//! let ctx = KernelBindingsContext { state: &self.agent_buffers, event_ring: &self.event_ring, registry: &self.registry_gpu };
+//! let bindings = SomeKernelBindings::from_context(&ctx);
+//! ```
+//!
+//! # Naming convention (the constructor's getter table)
+//!
+//! The compiler classifies each emitted Bindings field name and routes
+//! it via:
+//!
+//! | Field name pattern              | Source           | Rust expression                          |
+//! |---------------------------------|------------------|------------------------------------------|
+//! | `event_ring`                    | `ctx.event_ring` | `ctx.event_ring.ring()`                  |
+//! | `event_tail`                    | `ctx.event_ring` | `ctx.event_ring.tail()`                  |
+//! | `agent_<col>` (standard SoA)    | `ctx.state`      | `ctx.state.<col>_buf`                    |
+//! | `ability_registry_<col>`        | `ctx.registry`   | `&ctx.registry.<col>`                    |
+//! | (anything else)                 | `extras`         | `extras.<name>`                          |
+//!
+//! The "anything else" bucket catches per-fixture mask bitmaps,
+//! fixture-specific SoA columns (e.g. `agent_creature_type` in
+//! spy_network), per-kernel cfg uniforms, scoring output buffers — all
+//! the buffers that aren't shared infrastructure. These ride a
+//! per-kernel `<KernelName>Extras` struct supplied as a trailing arg.
+//!
+//! # Phase 1 scope (this file)
+//!
+//! Phase 1 defines the context + the [`AgentBuffers`] aggregate the
+//! constructors pull standard agent-SoA buffers from. No runtime is
+//! migrated this slice — per-runtime hand-written `Bindings { ... }`
+//! literals continue to work alongside the new constructors. Migrations
+//! land in subsequent slices.
+//!
+//! # Why `AgentBuffers` instead of `&SimState`
+//!
+//! `SimState` (in [`crate::state`]) owns the host-side per-agent SoA
+//! (`Vec<f32>`, `Vec<u32>`, etc.) used by host-driven helpers. It does
+//! not own GPU buffer handles today — those live on per-runtime structs
+//! (e.g. `SpyNetworkState::agent_hp_buf`). Rather than restructure
+//! `SimState` to own `wgpu::Buffer`s as a precondition for this slice,
+//! [`AgentBuffers`] is a thin reference aggregate per-runtime structs
+//! populate at dispatch time. Phase 2 migrations will construct it
+//! inline when calling `from_context()`. If a future architectural
+//! change moves buffer ownership onto `SimState`, [`AgentBuffers`] can
+//! become a view returned by a `SimState` accessor without disturbing
+//! the constructor surface.
+
+/// Per-agent SoA buffer references the standard naming convention
+/// resolves through [`KernelBindingsContext::state`].
+///
+/// Every field corresponds to a known per-agent column the compiler
+/// emits as an `agent_<col>` binding. Fixture-specific columns
+/// (e.g. `agent_creature_type` in spy_network, `agent_disguise_*` in
+/// spy_network) are NOT here — they go through the per-kernel
+/// `<KernelName>Extras` struct instead.
+///
+/// Per-runtime construction at dispatch time:
+///
+/// ```ignore
+/// let agent_buffers = engine::gpu::AgentBuffers {
+///     hp_buf: Some(&self.agent_hp_buf),
+///     max_hp_buf: Some(&self.agent_max_hp_buf),
+///     // ... only the columns this runtime actually owns
+///     ..Default::default()
+/// };
+/// ```
+///
+/// Each field is `Option<&'a wgpu::Buffer>` so a runtime that doesn't
+/// own a particular column (e.g. a stress fixture with no mana stat)
+/// can leave it `None`. The compiler-emitted `from_context()` body
+/// `.expect("...")` unwraps the columns its kernel actually binds at
+/// dispatch time, surfacing missing buffers as a clear runtime error
+/// (`"kernel binds agent_mana but the runtime didn't supply
+/// ctx.state.mana_buf"`) rather than a confusing borrow-of-None.
+#[derive(Default)]
+pub struct AgentBuffers<'a> {
+    pub hp_buf: Option<&'a wgpu::Buffer>,
+    pub max_hp_buf: Option<&'a wgpu::Buffer>,
+    pub alive_buf: Option<&'a wgpu::Buffer>,
+    pub pos_buf: Option<&'a wgpu::Buffer>,
+    pub level_buf: Option<&'a wgpu::Buffer>,
+    pub move_speed_buf: Option<&'a wgpu::Buffer>,
+    pub move_speed_mult_buf: Option<&'a wgpu::Buffer>,
+    pub shield_hp_buf: Option<&'a wgpu::Buffer>,
+    pub armor_buf: Option<&'a wgpu::Buffer>,
+    pub magic_resist_buf: Option<&'a wgpu::Buffer>,
+    pub attack_damage_buf: Option<&'a wgpu::Buffer>,
+    pub attack_range_buf: Option<&'a wgpu::Buffer>,
+    pub mana_buf: Option<&'a wgpu::Buffer>,
+    pub max_mana_buf: Option<&'a wgpu::Buffer>,
+    pub ability_power_buf: Option<&'a wgpu::Buffer>,
+}
+
+impl<'a> AgentBuffers<'a> {
+    /// Standard agent SoA column names the compiler resolves as
+    /// `agent_<col>` → `ctx.state.<col>_buf`. The compiler matches an
+    /// emitted Bindings field name `agent_<col>` against this list to
+    /// decide whether the binding routes through `ctx.state` (returns
+    /// `true`) or falls through to extras (returns `false`).
+    ///
+    /// Mirrors the field set above. Adding a new standard SoA column
+    /// requires editing both the field list and this table — kept
+    /// adjacent so drift is mechanically obvious.
+    pub const STANDARD_COLUMNS: &'static [&'static str] = &[
+        "hp",
+        "max_hp",
+        "alive",
+        "pos",
+        "level",
+        "move_speed",
+        "move_speed_mult",
+        "shield_hp",
+        "armor",
+        "magic_resist",
+        "attack_damage",
+        "attack_range",
+        "mana",
+        "max_mana",
+        "ability_power",
+    ];
+
+    /// Returns `true` iff `col` (the suffix after `agent_`) is a
+    /// standard SoA column the compiler should route through `ctx.state`.
+    pub fn is_standard_column(col: &str) -> bool {
+        Self::STANDARD_COLUMNS.contains(&col)
+    }
+}
+
+/// The shared bundle of buffer sources the compiler-emitted
+/// `Bindings::from_context()` constructors pull from.
+///
+/// See module docs for the full naming-convention table. Per-runtime
+/// `step()` builds one of these per dispatch (or once per tick if all
+/// dispatches share the same context) and passes it to each kernel's
+/// generated constructor.
+pub struct KernelBindingsContext<'a> {
+    /// Per-agent SoA buffers — the `agent_<col>` family of bindings.
+    pub state: &'a AgentBuffers<'a>,
+    /// Per-fixture event ring infrastructure — `event_ring` /
+    /// `event_tail` bindings.
+    pub event_ring: &'a crate::gpu::EventRing,
+    /// Packed AbilityRegistry uploaded to GPU — `ability_registry_<col>`
+    /// bindings.
+    pub registry: &'a crate::ability::registry_gpu::PackedAbilityRegistryGpu,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifier_round_trips_standard_columns() {
+        for col in AgentBuffers::STANDARD_COLUMNS {
+            assert!(AgentBuffers::is_standard_column(col), "{col}");
+        }
+        assert!(!AgentBuffers::is_standard_column("creature_type"));
+        assert!(!AgentBuffers::is_standard_column("disguise_fake_type"));
+    }
+}

--- a/crates/engine/src/gpu/mod.rs
+++ b/crates/engine/src/gpu/mod.rs
@@ -22,11 +22,13 @@
 //! iteration layer.
 
 pub mod bgl;
+pub mod bindings_context;
 pub mod context;
 pub mod event_ring;
 pub mod kernel;
 
 pub use bgl::{bgl_storage, bgl_uniform};
+pub use bindings_context::{AgentBuffers, KernelBindingsContext};
 pub use context::{GpuContext, GpuContextError};
 pub use event_ring::{EventRing, ViewStorage, EVENT_RING_CAP_SLOTS, EVENT_STRIDE_U32};
 pub use kernel::Kernel;


### PR DESCRIPTION
## Summary

Phase 1 of the [bindings-constructors plan](docs/superpowers/plans/2026-05-09-compiler-emitted-bindings-constructors.md) (Task #245).

- **Compiler emits per-kernel constructors.** Every emitted `*Bindings` struct now has a sibling `from_context(ctx)` (or `from_context_with_extras(ctx, extras)` when fixture-specific buffers are involved) impl. The generated bodies pull each binding from the appropriate shared source via a naming convention.
- **New `engine::gpu::KernelBindingsContext<'a>` + `AgentBuffers<'a>`.** The shared bundle of `&EventRing`, `&PackedAbilityRegistryGpu`, and per-agent SoA buffer references the constructors target. `AgentBuffers` carries `Option<&wgpu::Buffer>` per standard SoA column with a `Default` impl so runtimes only fill the columns they own.
- **Drift guard.** A dsl_compiler test asserts `STANDARD_AGENT_COLUMNS` (compiler-side classifier table) stays in sync with `engine::gpu::AgentBuffers::STANDARD_COLUMNS`.

### Naming convention (compiler classifier)

| Field name pattern              | Source           | Rust expression                          |
|---------------------------------|------------------|------------------------------------------|
| `event_ring` / `event_tail`     | `ctx.event_ring` | `ctx.event_ring.ring()` / `.tail()`      |
| `agent_<col>` (standard SoA)    | `ctx.state`      | `ctx.state.<col>_buf.expect(...)`        |
| `ability_registry_<col>`        | `ctx.registry`   | `&ctx.registry.<col>`                    |
| `cfg` or unrecognized           | `extras`         | `extras.<name>`                          |

ViewFold kernels intentionally skip — their custom anchor/ids/sim_cfg shape doesn't fit the standard convention.

### Sample emitted output (spy_network's PhysicsVerbChronicleDisguise)

```rust
pub struct PhysicsVerbChronicleDisguiseExtras<'a> {
    pub cfg: &'a wgpu::Buffer,
}

impl<'a> PhysicsVerbChronicleDisguiseBindings<'a> {
    pub fn from_context_with_extras(
        ctx: &engine::gpu::KernelBindingsContext<'a>,
        extras: &PhysicsVerbChronicleDisguiseExtras<'a>,
    ) -> Self {
        Self {
            event_ring: ctx.event_ring.ring(),
            event_tail: ctx.event_ring.tail(),
            agent_hp: ctx.state.hp_buf.expect("kernel binds agent_hp but the runtime didn't supply ctx.state.hp_buf"),
            // ... 9 more SoA fields ...
            ability_registry_effect_kinds: &ctx.registry.effect_kinds,
            // ... 12 more registry fields ...
            cfg: extras.cfg,
        }
    }
}
```

The spy_network FusedMaskVerbDisguise kernel needs the most extras (4 mask bitmaps + cfg + the fixture-specific `agent_creature_type`) — its emitted Extras struct surfaces all five.

### Out of scope (this slice)

Per the plan, this is Phase 1 only — **no runtime migrations**. Existing per-runtime `Bindings { ... }` literals continue to work alongside the new constructors. Migration PRs (debug_probe pilot, then stress + production runtimes, then long-tail) land separately.

## Test plan

- [x] `cargo build --release` clean (full workspace).
- [x] `cargo test -p dsl_compiler --release` — 6 new tests pass:
  - `classify_binding_routes_event_ring_and_tail`
  - `classify_binding_routes_standard_agent_columns`
  - `classify_binding_routes_registry_columns`
  - `classify_binding_routes_cfg_to_extras_arm`
  - `classify_binding_routes_unknown_to_extras`
  - `bindings_from_context_emits_extras_when_unclassified_present`
  - `bindings_from_context_emits_no_extras_when_all_classified`
  - `bindings_from_context_emits_for_every_kernel_in_a_real_program` (drives spy_network end-to-end)
  - `standard_agent_columns_match_engine_agent_buffers` (drift guard)
- [x] `cargo test -p engine --release --test schema_hash` — unchanged.
- [x] Behavioral pins re-verified:
  - `spy_network::noble_dies_after_slander_cascade`
  - `village_economy::village_economy_acceptance`
  - `wave_defense::settlement_falls_within_budget` + `same_seed_same_death_tick`
  - `stress_cast_density::tick_advances_under_max_density`
  - `duel_25v25` (8 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)