### PR TITLE
refactor(debug_probe): migrate to compiler-emitted Bindings constructors (Phase 2 pilot)

### DIFF
--- a/crates/debug_probe_runtime/src/lib.rs
+++ b/crates/debug_probe_runtime/src/lib.rs
@@ -37,7 +37,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::EventRing;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 
 /// Slot count for the WGSL `event_kind_counts: array<atomic<u32>>`
 /// instrumentation buffer. Sized for `EventKindId::ChronicleEntry =
@@ -478,6 +478,27 @@ impl CompiledSim for DebugProbeState {
             (self.agent_count as u64) * 4,
         );
 
+        // Shared once per tick; each dispatch below adds only its
+        // fixture-specific `*Extras` (mask bitmap, scoring output,
+        // instrumentation buffers, indirect args).
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+        };
+
         // (2) Mask round.
         let mask_cfg = mask_verb_Pulse::MaskVerbPulseCfg {
             agent_cap: self.agent_count,
@@ -490,13 +511,17 @@ impl CompiledSim for DebugProbeState {
             0,
             bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = mask_verb_Pulse::MaskVerbPulseBindings {
-            agent_alive: &self.agent_alive_buf,
+        let mask_extras = mask_verb_Pulse::MaskVerbPulseExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_total: &self.mask_total_buf,
             mask_passed: &self.mask_passed_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            mask_verb_Pulse::MaskVerbPulseBindings::from_context_with_extras(
+                &ctx,
+                &mask_extras,
+            );
         dispatch::dispatch_mask_verb_pulse(
             &mut self.cache,
             &mask_bindings,
@@ -517,26 +542,14 @@ impl CompiledSim for DebugProbeState {
             0,
             bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             score_kernel_visits: &self.score_kernel_visits_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache,
             &scoring_bindings,
@@ -558,33 +571,14 @@ impl CompiledSim for DebugProbeState {
             0,
             bytemuck::bytes_of(&chronicle_cfg),
         );
-        let chronicle_bindings = physics_ApplyDamageFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyDamageFromChronicleAndVerbChroniclePulseBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_chances: &self.registry_gpu.chances,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
+        let chronicle_extras = physics_ApplyDamageFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyDamageFromChronicleAndVerbChroniclePulseExtras {
             event_kind_counts: &self.event_kind_counts_buf,
             cfg: &self.chronicle_cfg_buf,
         };
+        let chronicle_bindings = physics_ApplyDamageFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyDamageFromChronicleAndVerbChroniclePulseBindings::from_context_with_extras(
+            &ctx,
+            &chronicle_extras,
+        );
         dispatch::dispatch_physics_applydamagefromchronicle_and_verb_chronicle_pulse(
             &mut self.cache,
             &chronicle_bindings,
@@ -605,12 +599,15 @@ impl CompiledSim for DebugProbeState {
             0,
             bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx,
+                &seed_extras,
+            );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,


### PR DESCRIPTION
## Summary

Phase 2 pilot for [task #246](https://github.com/RPP1011/extensive-sim-game/issues/246) (plan `docs/superpowers/plans/2026-05-09-compiler-emitted-bindings-constructors.md`). Migrates the smallest runtime — `debug_probe_runtime` — to the compiler-emitted `Bindings::from_context_with_extras()` constructors that landed in Phase 1 (PR #60, commit `de1a611b`).

Builds one `KernelBindingsContext` + `AgentBuffers` aggregate per tick and threads it into all four kernel dispatches (`mask_verb_Pulse`, `scoring`, the fused chronicle dispatcher, `seed_indirect_0`). Per-kernel fixture-specific buffers (mask bitmap, scoring output, instrumentation buffers, indirect args) ride a small `*Extras` struct.

## LOC delta

`-3` net (45 removed, 42 added). The diff understates the savings because the new ~22-line one-time `ctx` + `agent_buffers` construction at the top of `step()` is amortized across all four dispatches; the per-site savings dominate at the chronicle dispatcher (where ~22 `agent_*` + `ability_registry_*` lines collapse into a single `from_context_with_extras` call). Across ~40 runtime crates this fanout will scale.

## Sample diff (chronicle dispatch site)

Before:
```rust
let chronicle_bindings = physics_ApplyDamageFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyDamageFromChronicleAndVerbChroniclePulseBindings {
    event_ring: self.event_ring.ring(),
    event_tail: self.event_ring.tail(),
    agent_hp: &self.agent_hp_buf,
    agent_max_hp: &self.agent_max_hp_buf,
    agent_move_speed: &self.agent_move_speed_buf,
    agent_armor: &self.agent_armor_buf,
    agent_magic_resist: &self.agent_magic_resist_buf,
    agent_attack_damage: &self.agent_attack_damage_buf,
    agent_ability_power: &self.agent_ability_power_buf,
    agent_mana: &self.agent_mana_buf,
    ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
    ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
    // ... 11 more ability_registry_* fields ...
    event_kind_counts: &self.event_kind_counts_buf,
    cfg: &self.chronicle_cfg_buf,
};
```

After:
```rust
let chronicle_extras = physics_ApplyDamageFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyDamageFromChronicleAndVerbChroniclePulseExtras {
    event_kind_counts: &self.event_kind_counts_buf,
    cfg: &self.chronicle_cfg_buf,
};
let chronicle_bindings = physics_ApplyDamageFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyDamageFromChronicleAndVerbChroniclePulseBindings::from_context_with_extras(
    &ctx,
    &chronicle_extras,
);
```

23 ability_registry/agent SoA lines disappear; only the 2 fixture-specific bindings (`event_kind_counts` instrumentation + `cfg` uniform) stay.

## API friction surfaced

The pilot ran cleanly. Notes for Phase 3 fanout:

1. **No lifetime issues with `AgentBuffers<'a>`** — building it as `let agent_buffers = AgentBuffers { hp_buf: Some(&self.agent_hp_buf), ..Default::default() };` worked out of the box.
2. **No buffer-classification surprises** — every standard SoA column resolved through `ctx.state` and every fixture-specific buffer (mask bitmap, scoring output, debug instrumentation counters, indirect args, cfg uniforms) ended up exactly where expected in `*Extras`.
3. **Per-tick boilerplate is small but does grow with column count.** The `agent_buffers` literal lists 9 of the 15 STANDARD_COLUMNS this fixture owns (`hp/max_hp/alive/mana/attack_damage/ability_power/armor/magic_resist/move_speed`). Runtimes that own ALL 15 columns will have a 15-line `agent_buffers` setup. Future thought: a `From<&SimState>` (when buffer ownership eventually moves onto `SimState` per the module docs) would erase even this.
4. **Generated long-name path noise.** Some fully-qualified type names are very long (`physics_ApplyDamageFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyDamageFromChronicleAndVerbChroniclePulseBindings::from_context_with_extras`). Not a friction the constructors introduced — pre-existing — but worth a per-runtime `use ... as Foo;` rename pattern to keep dispatch sites compact in larger runtimes.
5. **`cfg` uniform is always in `Extras`.** Every kernel here had `cfg: &self.<name>_cfg_buf` in its extras struct. That's correct (cfg is per-kernel, not shared infra), but it does mean every dispatch site keeps the cfg field in extras — no friction, just a confirmation that the convention table is correct.

## Test plan

- [x] Behavioral pin: `viz_tests::all_three_axes_record_nonzero_data` still passes after migration.
- [x] Schema hash unchanged: `cargo test -p engine --release --test schema_hash` passes (P2).
- [x] Workspace builds clean: `cargo build --release` finishes with no errors.
- [x] Smoke tests on adjacent runtimes (untouched by this PR — should still pass): `spy_network_runtime` + `village_economy_runtime` lib tests pass.

## Constitution alignment

- **P1 Compiler-First**: PASS — compiler-emitted constructors instead of hand-written ones.
- **P2 Schema-Hash**: PASS — unchanged.
- **P5 Determinism**: PASS — pure refactor; same buffer references just constructed differently.
- **P10 No Runtime Panic**: PASS — `from_context_with_extras` signature is type-checked at compile time. The `.expect()` paths in the constructor body would only fire if a runtime forgot to populate a column its kernel binds — surfaced as a clear error message naming the missing field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)