### PR TITLE
refactor(village_economy): migrate to compiler-emitted Bindings constructors

### DIFF
--- a/crates/village_economy_runtime/src/lib.rs
+++ b/crates/village_economy_runtime/src/lib.rs
@@ -93,7 +93,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::EventRing;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 
 mod binding_check;
 
@@ -545,6 +545,29 @@ impl CompiledSim for VillageEconomyState {
             scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each dispatch below adds only its
+        // fixture-specific `*Extras` (mask bitmaps, scoring output,
+        // creature_type / hunger / disguise_expires_at_tick repurposed
+        // SoA columns, indirect args).
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            shield_hp_buf: Some(&self.agent_shield_hp_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+        };
+
         // (2) Mask round — fused PerPair kernel writes all 3 mask bitmaps.
         let mask_cfg = fused_mask_verb_WalkToWorkshop::FusedMaskVerbWalkToWorkshopCfg {
             agent_cap: self.agent_count,
@@ -557,14 +580,18 @@ impl CompiledSim for VillageEconomyState {
             0,
             bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_WalkToWorkshop::FusedMaskVerbWalkToWorkshopBindings {
-            agent_alive: &self.agent_alive_buf,
+        let mask_extras = fused_mask_verb_WalkToWorkshop::FusedMaskVerbWalkToWorkshopExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_WalkToWorkshop::FusedMaskVerbWalkToWorkshopBindings::from_context_with_extras(
+                &ctx,
+                &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_walktoworkshop(
             &mut self.cache,
             &mask_bindings,
@@ -585,28 +612,16 @@ impl CompiledSim for VillageEconomyState {
             0,
             bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
+        let scoring_extras = scoring::ScoringExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache,
             &scoring_bindings,
@@ -629,33 +644,15 @@ impl CompiledSim for VillageEconomyState {
             0,
             bytemuck::bytes_of(&forge_cfg),
         );
-        let forge_bindings =
-            physics_verb_chronicle_ForgeIron::PhysicsVerbChronicleForgeIronBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_max_hp: &self.agent_max_hp_buf,
-                agent_move_speed: &self.agent_move_speed_buf,
-                agent_armor: &self.agent_armor_buf,
-                agent_magic_resist: &self.agent_magic_resist_buf,
-                agent_attack_damage: &self.agent_attack_damage_buf,
-                agent_ability_power: &self.agent_ability_power_buf,
-                agent_mana: &self.agent_mana_buf,
-                ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-                ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-                ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-                ability_registry_chances: &self.registry_gpu.chances,
-                ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-                ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-                ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-                ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-                ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-                ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-                ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-                ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-                ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
+        let forge_extras =
+            physics_verb_chronicle_ForgeIron::PhysicsVerbChronicleForgeIronExtras {
                 cfg: &self.chronicle_forge_cfg_buf,
             };
+        let forge_bindings =
+            physics_verb_chronicle_ForgeIron::PhysicsVerbChronicleForgeIronBindings::from_context_with_extras(
+                &ctx,
+                &forge_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_forgeiron(
             &mut self.cache,
             &forge_bindings,
@@ -678,33 +675,15 @@ impl CompiledSim for VillageEconomyState {
             0,
             bytemuck::bytes_of(&offer_cfg),
         );
-        let offer_bindings =
-            physics_verb_chronicle_OfferDeal::PhysicsVerbChronicleOfferDealBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_max_hp: &self.agent_max_hp_buf,
-                agent_move_speed: &self.agent_move_speed_buf,
-                agent_armor: &self.agent_armor_buf,
-                agent_magic_resist: &self.agent_magic_resist_buf,
-                agent_attack_damage: &self.agent_attack_damage_buf,
-                agent_ability_power: &self.agent_ability_power_buf,
-                agent_mana: &self.agent_mana_buf,
-                ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-                ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-                ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-                ability_registry_chances: &self.registry_gpu.chances,
-                ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-                ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-                ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-                ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-                ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-                ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-                ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-                ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-                ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
+        let offer_extras =
+            physics_verb_chronicle_OfferDeal::PhysicsVerbChronicleOfferDealExtras {
                 cfg: &self.chronicle_offer_cfg_buf,
             };
+        let offer_bindings =
+            physics_verb_chronicle_OfferDeal::PhysicsVerbChronicleOfferDealBindings::from_context_with_extras(
+                &ctx,
+                &offer_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_offerdeal(
             &mut self.cache,
             &offer_bindings,
@@ -731,33 +710,15 @@ impl CompiledSim for VillageEconomyState {
             0,
             bytemuck::bytes_of(&walk_cfg),
         );
-        let walk_bindings =
-            physics_verb_chronicle_WalkToWorkshop::PhysicsVerbChronicleWalkToWorkshopBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_max_hp: &self.agent_max_hp_buf,
-                agent_move_speed: &self.agent_move_speed_buf,
-                agent_armor: &self.agent_armor_buf,
-                agent_magic_resist: &self.agent_magic_resist_buf,
-                agent_attack_damage: &self.agent_attack_damage_buf,
-                agent_ability_power: &self.agent_ability_power_buf,
-                agent_mana: &self.agent_mana_buf,
-                ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-                ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-                ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-                ability_registry_chances: &self.registry_gpu.chances,
-                ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-                ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-                ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-                ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-                ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-                ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-                ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-                ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-                ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
+        let walk_extras =
+            physics_verb_chronicle_WalkToWorkshop::PhysicsVerbChronicleWalkToWorkshopExtras {
                 cfg: &self.chronicle_walk_cfg_buf,
             };
+        let walk_bindings =
+            physics_verb_chronicle_WalkToWorkshop::PhysicsVerbChronicleWalkToWorkshopBindings::from_context_with_extras(
+                &ctx,
+                &walk_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_walktoworkshop(
             &mut self.cache,
             &walk_bindings,
@@ -785,16 +746,15 @@ impl CompiledSim for VillageEconomyState {
             0,
             bytemuck::bytes_of(&fold_cfg),
         );
-        let fold_bindings = physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_FoldAnnounce_and_FoldSkill_and_FoldObligation::PhysicsFoldTravelAndFoldRecipeAndFoldWearAndFoldProposeAndFoldAnnounceAndFoldSkillAndFoldObligationBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_shield_hp: &self.agent_shield_hp_buf,
-            agent_mana: &self.agent_mana_buf,
+        let fold_extras = physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_FoldAnnounce_and_FoldSkill_and_FoldObligation::PhysicsFoldTravelAndFoldRecipeAndFoldWearAndFoldProposeAndFoldAnnounceAndFoldSkillAndFoldObligationExtras {
             agent_hunger: &self.agent_hunger_buf,
             agent_disguise_expires_at_tick: &self.agent_disguise_expires_at_tick_buf,
             cfg: &self.fold_cfg_buf,
         };
+        let fold_bindings = physics_FoldTravel_and_FoldRecipe_and_FoldWear_and_FoldPropose_and_FoldAnnounce_and_FoldSkill_and_FoldObligation::PhysicsFoldTravelAndFoldRecipeAndFoldWearAndFoldProposeAndFoldAnnounceAndFoldSkillAndFoldObligationBindings::from_context_with_extras(
+            &ctx,
+            &fold_extras,
+        );
         dispatch::dispatch_physics_foldtravel_and_foldrecipe_and_foldwear_and_foldpropose_and_foldannounce_and_foldskill_and_foldobligation(
             &mut self.cache,
             &fold_bindings,
@@ -815,12 +775,15 @@ impl CompiledSim for VillageEconomyState {
             0,
             bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx,
+                &seed_extras,
+            );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,


### PR DESCRIPTION
## Summary

- Migrates `village_economy_runtime` to the compiler-emitted `Bindings::from_context_with_extras()` API at all 7 dispatch sites (mask, scoring, ForgeIron / OfferDeal / WalkToWorkshop chronicle, fold, seed_indirect_0).
- Builds one `KernelBindingsContext` + `AgentBuffers` aggregate per tick, threaded into each kernel's generated constructor; fixture-specific buffers (mask bitmaps, creature_type, hunger, disguise_expires_at_tick, scoring output, indirect args, cfg uniforms) ride per-kernel `*Extras` structs.
- One of 5 parallel Phase 3 migrations following the debug_probe_runtime pilot (PR #61, commit bee1216d).

LOC delta: **-37 net** (102 deletions, 65 insertions). Each chronicle dispatch site collapses from ~26 ability_registry_* / agent_* lines into a 3-line `from_context_with_extras` call.

## Test plan

- [x] `cargo build --release` clean across the workspace.
- [x] `cargo test -p engine --release --test schema_hash` — passes (schema hash unchanged, P2).
- [x] `RUST_MIN_STACK=33554432 cargo test -p village_economy_runtime --release --lib` — `village_economy_acceptance` passes (all 7 lift primitive counters round-trip correctly through the migrated dispatch chain after 200 ticks).

Constitution alignment:
- P1 Compiler-First: PASS — using compiler-emitted constructors.
- P2 Schema-Hash: PASS — unchanged.
- P5 Determinism: PASS — pure refactor.
- P10 No Runtime Panic: PASS — type-checked at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)