### PR TITLE
refactor(spy_network): migrate to compiler-emitted Bindings constructors

### DIFF
--- a/crates/spy_network_runtime/src/lib.rs
+++ b/crates/spy_network_runtime/src/lib.rs
@@ -69,7 +69,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 mod binding_check;
 
@@ -621,6 +621,27 @@ impl CompiledSim for SpyNetworkState {
             scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each dispatch below adds only its
+        // fixture-specific `*Extras` (mask bitmaps, scoring output,
+        // creature-type / disguise SoA columns, indirect args, cfg uniforms).
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+        };
+
         // (2) Mask round — fused PerPair kernel writes all 3 mask bitmaps.
         let mask_cfg = fused_mask_verb_Disguise::FusedMaskVerbDisguiseCfg {
             agent_cap: self.agent_count,
@@ -633,15 +654,18 @@ impl CompiledSim for SpyNetworkState {
             0,
             bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_Disguise::FusedMaskVerbDisguiseBindings {
-            agent_alive: &self.agent_alive_buf,
-            agent_mana: &self.agent_mana_buf,
+        let mask_extras = fused_mask_verb_Disguise::FusedMaskVerbDisguiseExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_Disguise::FusedMaskVerbDisguiseBindings::from_context_with_extras(
+                &ctx,
+                &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_disguise(
             &mut self.cache,
             &mask_bindings,
@@ -665,28 +689,16 @@ impl CompiledSim for SpyNetworkState {
             0,
             bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
+        let scoring_extras = scoring::ScoringExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache,
             &scoring_bindings,
@@ -710,33 +722,15 @@ impl CompiledSim for SpyNetworkState {
             0,
             bytemuck::bytes_of(&disguise_cfg),
         );
-        let disguise_bindings =
-            physics_verb_chronicle_Disguise::PhysicsVerbChronicleDisguiseBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_max_hp: &self.agent_max_hp_buf,
-                agent_move_speed: &self.agent_move_speed_buf,
-                agent_armor: &self.agent_armor_buf,
-                agent_magic_resist: &self.agent_magic_resist_buf,
-                agent_attack_damage: &self.agent_attack_damage_buf,
-                agent_ability_power: &self.agent_ability_power_buf,
-                agent_mana: &self.agent_mana_buf,
-                ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-                ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-                ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-                ability_registry_chances: &self.registry_gpu.chances,
-                ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-                ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-                ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-                ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-                ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-                ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-                ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-                ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-                ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
+        let disguise_extras =
+            physics_verb_chronicle_Disguise::PhysicsVerbChronicleDisguiseExtras {
                 cfg: &self.chronicle_disguise_cfg_buf,
             };
+        let disguise_bindings =
+            physics_verb_chronicle_Disguise::PhysicsVerbChronicleDisguiseBindings::from_context_with_extras(
+                &ctx,
+                &disguise_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_disguise(
             &mut self.cache,
             &disguise_bindings,
@@ -758,32 +752,13 @@ impl CompiledSim for SpyNetworkState {
             0,
             bytemuck::bytes_of(&slander_cfg),
         );
-        let slander_bindings = physics_verb_chronicle_Slander::PhysicsVerbChronicleSlanderBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_chances: &self.registry_gpu.chances,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
+        let slander_extras = physics_verb_chronicle_Slander::PhysicsVerbChronicleSlanderExtras {
             cfg: &self.chronicle_slander_cfg_buf,
         };
+        let slander_bindings = physics_verb_chronicle_Slander::PhysicsVerbChronicleSlanderBindings::from_context_with_extras(
+            &ctx,
+            &slander_extras,
+        );
         dispatch::dispatch_physics_verb_chronicle_slander(
             &mut self.cache,
             &slander_bindings,
@@ -805,32 +780,13 @@ impl CompiledSim for SpyNetworkState {
             0,
             bytemuck::bytes_of(&strike_cfg),
         );
-        let strike_bindings = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_chances: &self.registry_gpu.chances,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
+        let strike_extras = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeExtras {
             cfg: &self.chronicle_strike_cfg_buf,
         };
+        let strike_bindings = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings::from_context_with_extras(
+            &ctx,
+            &strike_extras,
+        );
         dispatch::dispatch_physics_verb_chronicle_strike(
             &mut self.cache,
             &strike_bindings,
@@ -855,12 +811,13 @@ impl CompiledSim for SpyNetworkState {
             0,
             bytemuck::bytes_of(&dmgchron_slander_cfg),
         );
-        let dmgchron_slander_bindings = physics_ApplyDamageFromChronicle_and_ApplySlanderFromChronicle::PhysicsApplyDamageFromChronicleAndApplySlanderFromChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_mana: &self.agent_mana_buf,
+        let dmgchron_slander_extras = physics_ApplyDamageFromChronicle_and_ApplySlanderFromChronicle::PhysicsApplyDamageFromChronicleAndApplySlanderFromChronicleExtras {
             cfg: &self.apply_dmgchron_slander_cfg_buf,
         };
+        let dmgchron_slander_bindings = physics_ApplyDamageFromChronicle_and_ApplySlanderFromChronicle::PhysicsApplyDamageFromChronicleAndApplySlanderFromChronicleBindings::from_context_with_extras(
+            &ctx,
+            &dmgchron_slander_extras,
+        );
         dispatch::dispatch_physics_applydamagefromchronicle_and_applyslanderfromchronicle(
             &mut self.cache,
             &dmgchron_slander_bindings,
@@ -884,15 +841,15 @@ impl CompiledSim for SpyNetworkState {
             0,
             bytemuck::bytes_of(&dmg_disguise_cfg),
         );
-        let dmg_disguise_bindings = physics_ApplyDamage_and_ApplyDisguiseFromChronicle::PhysicsApplyDamageAndApplyDisguiseFromChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let dmg_disguise_extras = physics_ApplyDamage_and_ApplyDisguiseFromChronicle::PhysicsApplyDamageAndApplyDisguiseFromChronicleExtras {
             agent_disguise_expires_at_tick: &self.agent_disguise_expires_at_tick_buf,
             agent_disguise_fake_type: &self.agent_disguise_fake_type_buf,
             cfg: &self.apply_dmg_disguise_cfg_buf,
         };
+        let dmg_disguise_bindings = physics_ApplyDamage_and_ApplyDisguiseFromChronicle::PhysicsApplyDamageAndApplyDisguiseFromChronicleBindings::from_context_with_extras(
+            &ctx,
+            &dmg_disguise_extras,
+        );
         dispatch::dispatch_physics_applydamage_and_applydisguisefromchronicle(
             &mut self.cache,
             &dmg_disguise_bindings,
@@ -913,12 +870,15 @@ impl CompiledSim for SpyNetworkState {
             0,
             bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx,
+                &seed_extras,
+            );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,


### PR DESCRIPTION
## Summary

- Migrates all 8 hand-written `<KernelName>Bindings { ... }` literals in `spy_network_runtime::step()` to the compiler-emitted `from_context_with_extras()` API (Phase 1, PR #60).
- Builds one `KernelBindingsContext` + `AgentBuffers` aggregate per tick; per-kernel fixture-specific buffers (creature_type, mask bitmaps, disguise SoA, scoring output, indirect args, cfg uniforms) ride a small `*Extras` struct.
- Follows the pilot pattern from PR #61 (debug_probe_runtime, commit `bee1216d`). spy_network has the largest binding surface of any runtime — the three chronicle dispatchers each bind 24 fields (full SoA + 13 `ability_registry_*` columns + cfg), so collapsing those sites alone drives most of the savings.

LOC delta: **-40 net** (104 deleted, 64 added).

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test -p engine --release --test schema_hash` — both tests pass; schema hash unchanged (P2)
- [x] `RUST_MIN_STACK=33554432 cargo test -p spy_network_runtime --release --lib` — `viz_tests::noble_dies_after_slander_cascade` passes
- [x] No other runtime crates touched (parallel-PR isolation)

## Constitution alignment

- **P1 Compiler-First**: PASS — consuming compiler-emitted constructors.
- **P2 Schema-Hash**: PASS — unchanged.
- **P5 Determinism**: PASS — pure refactor; no semantics change.
- **P10 No Runtime Panic**: PASS — type-checked; `from_context_with_extras` `.expect`s on the standard SoA columns this kernel actually binds, surfacing missing buffers as a clear panic at dispatch time rather than a silent wrong-buffer bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)