### PR TITLE
refactor(stress_agent_count): migrate to compiler-emitted Bindings constructors

### DIFF
--- a/crates/stress_agent_count_runtime/src/lib.rs
+++ b/crates/stress_agent_count_runtime/src/lib.rs
@@ -44,7 +44,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::EventRing;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 
 /// Pre-built dispatcher kernel total size, captured at build time by
 /// build.rs (sum of all WGSL kernel byte counts). Read by the driver
@@ -573,6 +573,27 @@ impl CompiledSim for StressAgentCountState {
             (self.agent_count as u64) * 4,
         );
 
+        // Shared once per tick; each dispatch below adds only its
+        // fixture-specific `*Extras` (mask bitmap, scoring output,
+        // instrumentation buffers, indirect args).
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+        };
+
         // (2) Mask round — single PerAgent kernel, dispatches
         //     `agent_cap` threads (no per-pair fan-out — Pulse is
         //     self-target, so each agent only gates its own slot).
@@ -587,11 +608,15 @@ impl CompiledSim for StressAgentCountState {
             0,
             bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = mask_verb_Pulse::MaskVerbPulseBindings {
-            agent_alive: &self.agent_alive_buf,
+        let mask_extras = mask_verb_Pulse::MaskVerbPulseExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            mask_verb_Pulse::MaskVerbPulseBindings::from_context_with_extras(
+                &ctx,
+                &mask_extras,
+            );
         if let Some(t) = self.debug_timings.as_ref() {
             dispatch::record_mask_verb_pulse_timing(
                 &mut self.cache,
@@ -623,26 +648,14 @@ impl CompiledSim for StressAgentCountState {
             0,
             bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
             score_kernel_visits: &self.score_kernel_visits_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         if let Some(t) = self.debug_timings.as_ref() {
             dispatch::record_scoring_timing(
                 &mut self.cache,
@@ -679,33 +692,14 @@ impl CompiledSim for StressAgentCountState {
             0,
             bytemuck::bytes_of(&chronicle_cfg),
         );
-        let chronicle_bindings = physics_ApplyPulseFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyPulseFromChronicleAndVerbChroniclePulseBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_chances: &self.registry_gpu.chances,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
+        let chronicle_extras = physics_ApplyPulseFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyPulseFromChronicleAndVerbChroniclePulseExtras {
             event_kind_counts: &self.event_kind_counts_buf,
             cfg: &self.chronicle_cfg_buf,
         };
+        let chronicle_bindings = physics_ApplyPulseFromChronicle_and_verb_chronicle_Pulse::PhysicsApplyPulseFromChronicleAndVerbChroniclePulseBindings::from_context_with_extras(
+            &ctx,
+            &chronicle_extras,
+        );
         if let Some(t) = self.debug_timings.as_ref() {
             dispatch::record_physics_applypulsefromchronicle_and_verb_chronicle_pulse_timing(
                 &mut self.cache,
@@ -737,12 +731,15 @@ impl CompiledSim for StressAgentCountState {
             0,
             bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx,
+                &seed_extras,
+            );
         if let Some(t) = self.debug_timings.as_ref() {
             dispatch::record_seed_indirect_0_timing(
                 &mut self.cache,


### PR DESCRIPTION
## Summary

- Phase 3 migration of the compiler-emitted Bindings constructors plan; follows the Phase 2 pilot (PR #61, debug_probe_runtime).
- Replaces all four hand-written `Bindings { ... }` literals in `stress_agent_count_runtime::step()` with `from_context_with_extras()` calls.
- Builds one `KernelBindingsContext` + `AgentBuffers` aggregate per tick after the per-tick clears; per-kernel fixture-specific buffers (mask bitmap, scoring output, debug instrumentation counters, indirect args) ride a small `*Extras` struct.
- Preserves Phase 1 D3 timestamps + Phase 2 instrumentation (`event_kind_histogram` + `score_kernel_visits`) — the debug counter buffers are the only non-cfg fields each kernel's Extras still owns.
- LOC delta: -3 net (-45/+42). Big collapse at the chronicle dispatch site (~22 lines fold into one `from_context_with_extras` call); offset partly by the one-time ctx construction at top of step().

## Test plan

- [x] `cargo build --release` clean.
- [x] `cargo test -p engine --release --test schema_hash` PASS (P2 schema hash unchanged).
- [x] `RUST_MIN_STACK=33554432 cargo test -p stress_agent_count_runtime --release --lib` — `tick_advances_at_1k_agents` PASS.
- [x] `RUST_MIN_STACK=33554432 ./target/release/stress_agent_count_app 1000 5` NDJSON sanity:
  - per-kernel D3 `wall_ns` lines emit for all 4 kernels (mask_verb_Pulse, scoring, physics_ApplyPulseFromChronicle..., seed_indirect_0).
  - Phase 2 `event_kind_histogram` emits (kind=39 count=1000).
  - Phase 2 `score_kernel_visits` summary emits (agent_count=1000, sum=1000, nonzero_count=1000).

Constitution alignment: P1 Compiler-First PASS, P2 Schema-Hash PASS, P5 Determinism PASS (pure refactor), P10 No Runtime Panic PASS (type-checked at compile time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)