### PR TITLE
feat(engine_voxel): Phase C — GPU-resident voxel mirror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,9 +863,11 @@ version = "0.1.0"
 name = "engine_voxel"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "engine",
  "glam",
  "voxel_engine",
+ "wgpu",
 ]
 
 [[package]]

--- a/crates/debug_probe_runtime/src/lib.rs
+++ b/crates/debug_probe_runtime/src/lib.rs
@@ -497,6 +497,7 @@ impl CompiledSim for DebugProbeState {
             state: &agent_buffers,
             event_ring: &self.event_ring,
             registry: &self.registry_gpu,
+            voxel_grid: None,
         };
 
         // (2) Mask round.

--- a/crates/dsl_compiler/src/cg/emit/program.rs
+++ b/crates/dsl_compiler/src/cg/emit/program.rs
@@ -223,6 +223,68 @@ fn clamp_i32(x: i32, lo: i32, hi: i32) -> i32 { return clamp(x, lo, hi); }
 ";
 
 // ---------------------------------------------------------------------------
+// Voxel-mirror prelude — Phase C of the voxel-engine integration plan
+// ---------------------------------------------------------------------------
+
+/// WGSL helper for reading from a [`KernelBindingsContext::voxel_grid`]
+/// storage buffer. Substring-injected into any kernel module whose
+/// body calls `voxel_at(`. Matches the runtime-side widen-to-u32
+/// encoding in `engine_voxel::VoxelMirror`: each cell is one `u32`,
+/// material code in the low 8 bits.
+///
+/// Out-of-bounds reads return `0u` (air). The grid extent comes from a
+/// per-fixture cfg uniform (Phase D will lower the dimensions; Phase C
+/// emits a placeholder helper that takes width/height/depth as
+/// arguments so the same helper works for any extent without baking
+/// constants in. Phase D's terrain-query lowering will fill the call
+/// site with the per-fixture dimensions.).
+///
+/// # Helper signature choice
+///
+/// Phase C considered three signatures:
+/// 1. `voxel_at(grid, x, y, z) -> u32` with grid extent baked into a
+///    compile-time WGSL `const` — simplest, but ties every kernel to
+///    one fixture's grid size.
+/// 2. `voxel_at(grid, x, y, z, w, h, d) -> u32` — extent passed
+///    per-call; verbose at the call site but works across fixtures.
+/// 3. `voxel_at(grid, x, y, z) -> u32` reading a separate
+///    `voxel_grid_dims: vec3<u32>` uniform — clean call site, but
+///    needs a second binding wired through `KernelBindingsContext`.
+///
+/// Picked option (2) for Phase C: kernels that bind `voxel_grid` will
+/// also need to know the extent (e.g. for `pos → cell` floor + bounds
+/// check), so passing the extent at the call site keeps the
+/// information flow explicit. Phase D may revisit if it proves
+/// awkward at the lowering layer; reads from a uniform vs. constant
+/// args is a thin wrapper change.
+const VOXEL_GRID_WGSL_PRELUDE: &str = "\
+// Voxel-mirror helper — emitted when the body calls `voxel_at(`.
+// Reads one cell from the GPU-resident voxel mirror (`engine_voxel::
+// VoxelMirror`). Cell layout matches the host: index = z*H*W + y*W + x;
+// material code lives in the low byte of each u32. Out-of-bounds
+// returns 0u (air). Width/height/depth are caller-supplied so one
+// helper serves all fixture extents.
+fn voxel_at(
+    grid: ptr<storage, array<u32>, read>,
+    x: i32, y: i32, z: i32,
+    width: u32, height: u32, depth: u32,
+) -> u32 {
+    if (x < 0 || y < 0 || z < 0) {
+        return 0u;
+    }
+    let ux: u32 = u32(x);
+    let uy: u32 = u32(y);
+    let uz: u32 = u32(z);
+    if (ux >= width || uy >= height || uz >= depth) {
+        return 0u;
+    }
+    let idx: u32 = uz * height * width + uy * width + ux;
+    return (*grid)[idx];
+}
+
+";
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
@@ -634,6 +696,17 @@ fn compose_wgsl_file(
         out.push('\n');
     }
 
+    // Voxel-mirror prelude (Phase C): emit `voxel_at(` helper when
+    // the kernel body references it. Phase C just lays the helper
+    // down — Phase D will start emitting calls to it from lowered
+    // `terrain.height_at` / `terrain.walkable` / `terrain.line_of_sight`
+    // surfaces. Substring-gate keys on `voxel_at(` so a kernel that
+    // doesn't touch terrain doesn't pick up the unused helper.
+    if body.contains("voxel_at(") {
+        out.push_str(VOXEL_GRID_WGSL_PRELUDE);
+        out.push('\n');
+    }
+
     // PerCell topologies (today only the tiled-MoveBoid kernel)
     // need module-level `var<workgroup>` declarations for the
     // cooperative tile arrays — they're shared across all lanes of
@@ -966,6 +1039,7 @@ fn compose_rust_module_file(spec: &KernelSpec, topology: &KernelTopology) -> Str
 /// | `agent_<col>` where col is in   | `BindingSource::AgentBuffer(col)` |
 /// |   `engine::gpu::AgentBuffers::STANDARD_COLUMNS` |                  |
 /// | `ability_registry_<col>`        | `BindingSource::Registry(col)`    |
+/// | `voxel_grid` (Phase C)          | `BindingSource::VoxelGrid`        |
 /// | `cfg`                           | `BindingSource::Cfg`              |
 /// | (anything else)                 | `BindingSource::Extras`           |
 ///
@@ -979,6 +1053,11 @@ enum BindingSource<'a> {
     EventRingTail,
     AgentBuffer(&'a str),
     Registry(&'a str),
+    /// Phase C — `voxel_grid` resolves to
+    /// `ctx.voxel_grid.expect("kernel binds voxel_grid but the runtime
+    /// didn't supply ctx.voxel_grid")`. Optional on the context so
+    /// non-voxel fixtures don't pay the buffer alloc.
+    VoxelGrid,
     Cfg,
     Extras,
 }
@@ -1013,6 +1092,9 @@ fn classify_binding(name: &str) -> BindingSource<'_> {
     if name == "cfg" {
         return BindingSource::Cfg;
     }
+    if name == "voxel_grid" {
+        return BindingSource::VoxelGrid;
+    }
     if let Some(col) = name.strip_prefix("ability_registry_") {
         return BindingSource::Registry(col);
     }
@@ -1036,6 +1118,7 @@ fn render_from_context_expr(src: &BindingSource<'_>, name: &str) -> String {
             "ctx.state.{col}_buf.expect(\"kernel binds agent_{col} but the runtime didn't supply ctx.state.{col}_buf\")"
         ),
         BindingSource::Registry(col) => format!("&ctx.registry.{col}"),
+        BindingSource::VoxelGrid => "ctx.voxel_grid.expect(\"kernel binds voxel_grid but the runtime didn't supply ctx.voxel_grid\")".to_string(),
         BindingSource::Cfg => "extras.cfg".to_string(),
         BindingSource::Extras => format!("extras.{name}"),
     }
@@ -2005,6 +2088,46 @@ mod tests {
     #[test]
     fn classify_binding_routes_cfg_to_extras_arm() {
         assert_eq!(classify_binding("cfg"), BindingSource::Cfg);
+    }
+
+    #[test]
+    fn classify_binding_routes_voxel_grid_to_voxel_grid_source() {
+        assert_eq!(classify_binding("voxel_grid"), BindingSource::VoxelGrid);
+    }
+
+    #[test]
+    fn from_context_expr_for_voxel_grid_unwraps_optional() {
+        // The compiler-emitted from_context body for a kernel binding
+        // `voxel_grid` must `.expect(...)` the optional ctx field so a
+        // runtime that forgot to wire the mirror surfaces the missing
+        // buffer as a clear runtime error rather than a borrow-of-None.
+        let expr = render_from_context_expr(&BindingSource::VoxelGrid, "voxel_grid");
+        assert!(
+            expr.contains("ctx.voxel_grid.expect("),
+            "voxel_grid expr should unwrap the optional context field: {expr}"
+        );
+    }
+
+    #[test]
+    fn voxel_grid_wgsl_prelude_emits_voxel_at_helper() {
+        // The substring gate `voxel_at(` in `compose_wgsl_file` is the
+        // load-bearing emit gate for the helper. Pin its shape: function
+        // name, the OOB-returns-zero arm, and the flat-3D index formula.
+        assert!(
+            VOXEL_GRID_WGSL_PRELUDE.contains("fn voxel_at("),
+            "VOXEL_GRID_WGSL_PRELUDE should declare `voxel_at` helper: \n{VOXEL_GRID_WGSL_PRELUDE}"
+        );
+        assert!(
+            VOXEL_GRID_WGSL_PRELUDE.contains("return 0u;"),
+            "voxel_at OOB arm must return 0u sentinel"
+        );
+        // Flat 3D index — keep in lock-step with `engine_voxel::VoxelMirror`'s
+        // staging layout (index = z*H*W + y*W + x).
+        assert!(
+            VOXEL_GRID_WGSL_PRELUDE.contains("uz * height * width + uy * width + ux"),
+            "voxel_at index formula drifted from VoxelGrid::index — \
+             keep in sync with engine_voxel::VoxelMirror's staging layout"
+        );
     }
 
     #[test]

--- a/crates/duel_25v25_runtime/src/lib.rs
+++ b/crates/duel_25v25_runtime/src/lib.rs
@@ -760,6 +760,7 @@ impl CompiledSim for Duel25v25State {
             state: &agent_buffers,
             event_ring: &self.event_ring,
             registry: &self.registry_gpu,
+            voxel_grid: None,
         };
 
         // (2) Spatial-hash counting sort (5 phases). Mirrors

--- a/crates/engine/src/gpu/bindings_context.rs
+++ b/crates/engine/src/gpu/bindings_context.rs
@@ -32,6 +32,7 @@
 //! | `event_tail`                    | `ctx.event_ring` | `ctx.event_ring.tail()`                  |
 //! | `agent_<col>` (standard SoA)    | `ctx.state`      | `ctx.state.<col>_buf`                    |
 //! | `ability_registry_<col>`        | `ctx.registry`   | `&ctx.registry.<col>`                    |
+//! | `voxel_grid` (Phase C)          | `ctx.voxel_grid` | `ctx.voxel_grid.expect(...)`             |
 //! | (anything else)                 | `extras`         | `extras.<name>`                          |
 //!
 //! The "anything else" bucket catches per-fixture mask bitmaps,
@@ -159,6 +160,15 @@ pub struct KernelBindingsContext<'a> {
     /// Packed AbilityRegistry uploaded to GPU — `ability_registry_<col>`
     /// bindings.
     pub registry: &'a crate::ability::registry_gpu::PackedAbilityRegistryGpu,
+    /// **Phase C** — optional GPU-resident voxel grid mirror. Resolves
+    /// the `voxel_grid` binding name. `None` for runtimes that don't
+    /// use voxel terrain (most fixtures today); the compiler-emitted
+    /// `from_context` / `from_context_with_extras` bodies `.expect(...)`
+    /// unwrap when a kernel actually binds `voxel_grid`, so leaving
+    /// this `None` is safe for fixtures that don't lower terrain
+    /// queries to GPU. Future fixtures opt in by passing
+    /// `Some(mirror.buffer())`.
+    pub voxel_grid: Option<&'a wgpu::Buffer>,
 }
 
 #[cfg(test)]

--- a/crates/engine_voxel/Cargo.toml
+++ b/crates/engine_voxel/Cargo.toml
@@ -23,3 +23,8 @@ edition = "2021"
 engine = { path = "../engine" }
 voxel_engine = { path = "/home/ricky/Projects/voxel_engine", default-features = false }
 glam = "0.29"
+# Phase C — GPU-resident voxel mirror needs `wgpu::Buffer` + `bytemuck`
+# slice casts. wgpu version pinned to match `engine`'s `=26.0.1` so we
+# don't accidentally pull two wgpu versions into the dep graph.
+wgpu = "=26.0.1"
+bytemuck = { version = "1.16", features = ["derive"] }

--- a/crates/engine_voxel/src/lib.rs
+++ b/crates/engine_voxel/src/lib.rs
@@ -1,7 +1,16 @@
 //! Voxel-engine adapter — bridges `~/Projects/voxel_engine` to the sim
-//! engine via the `TerrainQuery` seam. **Phases A + B** of the 5-phase
-//! voxel integration plan
+//! engine via the `TerrainQuery` seam. **Phases A + B + C** of the
+//! 5-phase voxel integration plan
 //! (`docs/superpowers/plans/2026-05-09-voxel-engine-integration.md`).
+//!
+//! Phase C adds [`VoxelMirror`] — a `wgpu::Buffer` mirror of the host
+//! `VoxelGrid` that GPU kernels can read directly via the new optional
+//! `voxel_grid` field on `KernelBindingsContext`. The runtime calls
+//! [`VoxelTerrain::apply_voxel_chronicle_record_with_mirror`] per
+//! drained record (instead of the bare `apply_voxel_chronicle_record`),
+//! which mutates the CPU grid AND marks the touched chunks dirty in
+//! the mirror. At end of tick the runtime calls
+//! [`VoxelMirror::flush_dirty`] to push the dirty chunks to GPU.
 //!
 //! # What this crate does today
 //!
@@ -81,11 +90,15 @@
 //! affected.
 
 use engine::terrain::TerrainQuery;
-use glam::Vec3;
-use voxel_engine::voxel::grid::VoxelGrid;
+use engine::GpuContext;
+use glam::{IVec3, Vec3};
+use std::collections::BTreeSet;
 use voxel_engine::voxel::raycast::ray_cast_grid;
 
 pub use engine::state::agent::MovementMode;
+/// Re-export so per-runtime crates can pass `&VoxelGrid` to mirror
+/// methods without taking a direct dependency on `voxel_engine`.
+pub use voxel_engine::voxel::grid::VoxelGrid;
 
 /// Default grid extent in voxel cells. 256³ cells (= 256 world-unit
 /// cube) is enough for the Phase B `voxel_probe` fixture and the
@@ -153,6 +166,16 @@ impl VoxelTerrain {
     #[doc(hidden)]
     pub fn set_cell(&mut self, x: u32, y: u32, z: u32, value: u8) {
         self.grid.set(x, y, z, value);
+    }
+
+    /// Borrow the underlying `voxel_engine::voxel::grid::VoxelGrid` —
+    /// used by [`VoxelMirror::new`] and [`VoxelMirror::flush_dirty`]
+    /// to read the current cell values during construction + per-tick
+    /// upload. Public because per-runtime `VoxelMirror` lives outside
+    /// `VoxelTerrain` (the runtime owns both, mirror lifetime tracks
+    /// the wgpu device).
+    pub fn grid(&self) -> &VoxelGrid {
+        &self.grid
     }
 
     /// Drain a single chronicle record into the voxel world.
@@ -351,6 +374,279 @@ impl TerrainQuery for VoxelTerrain {
             // compare directly to `length`.
             Some(h) => h.t > length,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase C — GPU-resident voxel mirror
+// ---------------------------------------------------------------------------
+
+/// Side-length in cells of one mirror chunk. Each chunk's worth of
+/// cells is the smallest unit of mirror upload — when any cell in a
+/// chunk is dirtied, the next `flush_dirty` re-uploads the whole chunk
+/// to GPU. Picked to keep `Queue::write_buffer` calls cheap (one chunk
+/// = `8³ = 512` cells = 2 KB) while still bounding upload churn for
+/// scattered single-cell mutations.
+pub const MIRROR_CHUNK_DIM: u32 = 8;
+
+/// Identifier for a chunk in the mirror, in chunk-coordinates (cell
+/// coords / `MIRROR_CHUNK_DIM`). Stored in a [`BTreeSet`] so iteration
+/// order is deterministic — load-bearing for P5 (same chronicle drain
+/// → same dirty set → same upload sequence → same GPU state).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ChunkCoord {
+    pub cx: u32,
+    pub cy: u32,
+    pub cz: u32,
+}
+
+/// GPU-resident mirror of a [`VoxelTerrain`]'s underlying [`VoxelGrid`].
+///
+/// # Layout
+///
+/// One u32 per cell, flat 3D ordering: `index = z*H*W + y*W + x`
+/// (matches `VoxelGrid::index`). The cell's material code lives in the
+/// low 8 bits; upper 24 bits are reserved for future flags (e.g.
+/// per-cell health for destructibles). Total mirror size at the
+/// fixture's grid extent is `width * height * depth * 4` bytes:
+///
+/// - 16³ extent → 16 KB
+/// - 64³ extent → 1 MB
+/// - 256³ extent (DEFAULT) → 64 MB
+///
+/// The 256³ default is overkill for the Phase C voxel_probe pin (the
+/// fixture only writes near origin); fixtures that opt in at smaller
+/// extents (e.g. `with_extent(16)` for the pin tests) pay 16 KB.
+///
+/// # Dirty tracking
+///
+/// `mark_dirty(cell)` records the containing chunk in a `BTreeSet`
+/// (P5: deterministic iteration order). `flush_dirty` walks the set
+/// in ascending `(cz, cy, cx)` order and uploads each chunk's slice
+/// of the host-side `u32` staging via `Queue::write_buffer`. The
+/// staging vec is kept in lock-step with the host `VoxelGrid` so the
+/// flush is a pure cell→u32 widen + slice copy. Empty dirty set →
+/// zero `write_buffer` calls (cheap no-op).
+pub struct VoxelMirror {
+    buffer: wgpu::Buffer,
+    /// Host-side staging for the GPU buffer's contents — one u32 per
+    /// cell, in the same flat ordering. Updated in lock-step with the
+    /// CPU-side `VoxelGrid` so `flush_dirty` does not need to re-read
+    /// the grid (decoupled from `VoxelTerrain`'s lifetime).
+    staging: Vec<u32>,
+    /// Chunks dirtied since the last `flush_dirty`. BTreeSet so the
+    /// drain order is deterministic across runs.
+    dirty_chunks: BTreeSet<ChunkCoord>,
+    width: u32,
+    height: u32,
+    depth: u32,
+}
+
+impl VoxelMirror {
+    /// Allocate a mirror sized to `grid`'s dimensions and initialize
+    /// from grid contents (whole-buffer write at construction time).
+    /// All subsequent updates flow through `mark_dirty` + `flush_dirty`.
+    pub fn new(gpu: &GpuContext, grid: &VoxelGrid) -> Self {
+        let (width, height, depth) = grid.dimensions();
+        let cell_count = (width as usize) * (height as usize) * (depth as usize);
+        // Widen the u8 grid to u32 for the GPU mirror. WGSL has no
+        // native u8 storage type, so the buffer is `array<u32>` and the
+        // material code lives in the low byte; upper bits stay zero.
+        let staging: Vec<u32> = grid.data().iter().map(|&b| b as u32).collect();
+        debug_assert_eq!(staging.len(), cell_count);
+        let bytes = (cell_count * 4) as u64;
+        let buffer = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("engine_voxel::VoxelMirror::buffer"),
+            // Always allocate at least 16 bytes so wgpu doesn't reject
+            // a zero-sized storage buffer for tiny test fixtures.
+            size: bytes.max(16),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        // Initial whole-buffer upload — even if empty, doing this once
+        // means future flushes never have to special-case "first write".
+        if cell_count > 0 {
+            gpu.queue.write_buffer(&buffer, 0, bytemuck::cast_slice(&staging));
+        }
+        Self {
+            buffer,
+            staging,
+            dirty_chunks: BTreeSet::new(),
+            width,
+            height,
+            depth,
+        }
+    }
+
+    /// Borrow the underlying storage buffer — pass to
+    /// `KernelBindingsContext::voxel_grid`.
+    pub fn buffer(&self) -> &wgpu::Buffer {
+        &self.buffer
+    }
+
+    /// Cubic dimensions of the mirror (cells along each axis). Matches
+    /// the wrapped `VoxelGrid`'s dimensions at construction time.
+    pub fn dimensions(&self) -> (u32, u32, u32) {
+        (self.width, self.height, self.depth)
+    }
+
+    /// Total mirror byte size = `width * height * depth * 4`. Useful
+    /// for the per-fixture allocation bookkeeping.
+    pub fn buffer_bytes(&self) -> u64 {
+        (self.width as u64) * (self.height as u64) * (self.depth as u64) * 4
+    }
+
+    /// Number of dirty chunks pending flush. Mostly diagnostic — the
+    /// runtime calls `flush_dirty` unconditionally each tick.
+    pub fn dirty_chunk_count(&self) -> usize {
+        self.dirty_chunks.len()
+    }
+
+    /// Map a cell coordinate to its containing chunk and mark the
+    /// chunk as dirty. Out-of-bounds cells are silently ignored
+    /// (matches `VoxelGrid::set` semantics — no panic).
+    ///
+    /// The runtime calls this from `apply_voxel_chronicle_record` (via
+    /// the wrapper on `VoxelTerrain`) immediately after the grid has
+    /// been mutated. Subsequent `flush_dirty` re-uploads the chunk's
+    /// 8³ neighbourhood from the host `VoxelGrid`.
+    pub fn mark_dirty(&mut self, cell: IVec3) {
+        if cell.x < 0 || cell.y < 0 || cell.z < 0 {
+            return;
+        }
+        let (x, y, z) = (cell.x as u32, cell.y as u32, cell.z as u32);
+        if x >= self.width || y >= self.height || z >= self.depth {
+            return;
+        }
+        self.dirty_chunks.insert(ChunkCoord {
+            cx: x / MIRROR_CHUNK_DIM,
+            cy: y / MIRROR_CHUNK_DIM,
+            cz: z / MIRROR_CHUNK_DIM,
+        });
+    }
+
+    /// Re-upload every dirty chunk to GPU and clear the dirty set.
+    ///
+    /// Reads each chunk's current state from the wrapped `grid`, widens
+    /// each `u8` material code to `u32` in the host staging vec, then
+    /// issues one `Queue::write_buffer` per dirty chunk. Drain order is
+    /// `BTreeSet` ascending — same chronicle input → same drain order →
+    /// same upload sequence → same final GPU state (P5 / P11).
+    ///
+    /// Empty dirty set → zero queue submits (P10: no panic on empty).
+    pub fn flush_dirty(&mut self, gpu: &GpuContext, grid: &VoxelGrid) {
+        if self.dirty_chunks.is_empty() {
+            return;
+        }
+        // Take ownership of the dirty set so the per-chunk loop can
+        // mutate `self.staging` without re-borrowing `self.dirty_chunks`.
+        // `BTreeSet::into_iter` is already ascending, so the drained
+        // sequence is the deterministic upload order.
+        let drained = std::mem::take(&mut self.dirty_chunks);
+        let (w, h, d) = (self.width, self.height, self.depth);
+        for chunk in drained {
+            // Chunk's cell-coord AABB, clipped to the grid extent.
+            let x_lo = chunk.cx * MIRROR_CHUNK_DIM;
+            let y_lo = chunk.cy * MIRROR_CHUNK_DIM;
+            let z_lo = chunk.cz * MIRROR_CHUNK_DIM;
+            let x_hi = (x_lo + MIRROR_CHUNK_DIM).min(w);
+            let y_hi = (y_lo + MIRROR_CHUNK_DIM).min(h);
+            let z_hi = (z_lo + MIRROR_CHUNK_DIM).min(d);
+            // Refresh staging from the grid for every cell in this
+            // chunk, then upload one row at a time. Per-row uploads
+            // (rather than per-cell) trade a few `write_buffer` calls
+            // for contiguous-byte transfers; per-chunk single upload
+            // would require a temporary contiguous buffer because
+            // chunks aren't laid out contiguously in flat-3D order.
+            for z in z_lo..z_hi {
+                for y in y_lo..y_hi {
+                    let row_start = ((z as usize) * (h as usize) + y as usize)
+                        * (w as usize)
+                        + x_lo as usize;
+                    let row_len = (x_hi - x_lo) as usize;
+                    // Refresh staging from grid for this row.
+                    for x in x_lo..x_hi {
+                        let v = grid.get(x, y, z).unwrap_or(0);
+                        self.staging[row_start + (x - x_lo) as usize] = v as u32;
+                    }
+                    let byte_offset = (row_start as u64) * 4;
+                    let row_bytes = bytemuck::cast_slice(
+                        &self.staging[row_start..row_start + row_len],
+                    );
+                    gpu.queue.write_buffer(&self.buffer, byte_offset, row_bytes);
+                }
+            }
+        }
+    }
+}
+
+impl VoxelTerrain {
+    /// Map a world-space caster position to the cell that
+    /// `apply_voxel_chronicle_record` writes for `EffectPlaceVoxelApplied`
+    /// (kind=60). Used by the runtime's drain path to feed
+    /// `VoxelMirror::mark_dirty` the same cell the grid mutation hit.
+    pub fn place_cell_from_caster(caster_pos: Vec3) -> IVec3 {
+        IVec3::new(
+            caster_pos.x.floor() as i32,
+            caster_pos.y.floor() as i32,
+            caster_pos.z.floor() as i32,
+        )
+    }
+
+    /// Same as [`apply_voxel_chronicle_record`] but additionally marks
+    /// every cell touched by the record as dirty in `mirror`. The
+    /// runtime calls this when a mirror is wired; the original
+    /// `apply_voxel_chronicle_record` stays as the CPU-only entry.
+    ///
+    /// The mark-dirty pass walks the same neighborhood the consumer
+    /// scans — for kind=60 (place) that's the single caster cell; for
+    /// kind=59 (harvest) it's the `HARVEST_RADIUS`-cube. Marking the
+    /// whole cube (rather than just the cells the consumer actually
+    /// cleared) is a slight over-mark but keeps the consumer + mirror
+    /// in lock-step: the consumer's `target_value` filter can no-op
+    /// most of the cube, and the mirror just re-uploads the chunks
+    /// containing those cells (which were already going to be
+    /// re-uploaded if any one of them was a real clear).
+    pub fn apply_voxel_chronicle_record_with_mirror(
+        &mut self,
+        rec: &[u32],
+        caster_pos: Vec3,
+        mirror: &mut VoxelMirror,
+    ) -> Option<()> {
+        // `?` short-circuits when the inner consumer rejects the record
+        // (unknown kind tag or `rec.len() < 5`); after the `?`, rec[0]
+        // is guaranteed to be one of the recognised voxel-mutating kinds.
+        let result = self.apply_voxel_chronicle_record(rec, caster_pos)?;
+        match rec[0] {
+            60 => {
+                let cell = Self::place_cell_from_caster(caster_pos);
+                mirror.mark_dirty(cell);
+            }
+            59 => {
+                // Mark every cell in the `HARVEST_RADIUS` cube so any
+                // chunk that might contain a cleared cell is in the
+                // dirty set. See the kind=59 arm in
+                // `apply_voxel_chronicle_record` — `HARVEST_RADIUS=3`
+                // is the magic number; mirroring it here would split
+                // the source-of-truth, so we re-derive it from the
+                // same ascending z/y/x walk.
+                const HARVEST_RADIUS: i32 = 3;
+                let cx = caster_pos.x.floor() as i32;
+                let cy = caster_pos.y.floor() as i32;
+                let cz = caster_pos.z.floor() as i32;
+                for dz in -HARVEST_RADIUS..=HARVEST_RADIUS {
+                    for dy in -HARVEST_RADIUS..=HARVEST_RADIUS {
+                        for dx in -HARVEST_RADIUS..=HARVEST_RADIUS {
+                            mirror.mark_dirty(IVec3::new(cx + dx, cy + dy, cz + dz));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        Some(result)
     }
 }
 
@@ -574,5 +870,65 @@ mod tests {
         assert_eq!(t.height_at(0.0, 0.0), 0.0);
         assert!(t.walkable(Vec3::ZERO, MovementMode::Walk));
         assert!(t.line_of_sight(Vec3::ZERO, Vec3::ONE));
+    }
+
+    // ---------------------------------------------------------------
+    // Phase C — VoxelMirror tests that don't need a GPU.
+    //
+    // These cover the chunk-coord math + dirty-set ordering. The
+    // load-bearing CPU/GPU divergence pin lives in
+    // `voxel_probe_runtime::voxel_pins::cpu_gpu_voxel_state_matches`
+    // since it requires a wgpu device.
+    // ---------------------------------------------------------------
+
+    /// Helper for the chunk-coord tests below — there's no public
+    /// constructor that doesn't need a GPU, so we exercise the
+    /// `BTreeSet` math directly.
+    fn chunk_for(cell: IVec3) -> Option<ChunkCoord> {
+        if cell.x < 0 || cell.y < 0 || cell.z < 0 {
+            return None;
+        }
+        Some(ChunkCoord {
+            cx: (cell.x as u32) / MIRROR_CHUNK_DIM,
+            cy: (cell.y as u32) / MIRROR_CHUNK_DIM,
+            cz: (cell.z as u32) / MIRROR_CHUNK_DIM,
+        })
+    }
+
+    #[test]
+    fn chunk_coord_orders_by_z_then_y_then_x() {
+        // BTreeSet drain order is the load-bearing P5 invariant —
+        // same chronicle drain → same dirty set → same upload
+        // sequence → same final GPU state. The struct's derived
+        // `Ord` orders fields lexicographically: (cx, cy, cz). Pin
+        // that ordering so a future `#[derive]` reorder doesn't
+        // silently change upload order.
+        let a = ChunkCoord { cx: 0, cy: 0, cz: 0 };
+        let b = ChunkCoord { cx: 1, cy: 0, cz: 0 };
+        let c = ChunkCoord { cx: 0, cy: 1, cz: 0 };
+        let d = ChunkCoord { cx: 0, cy: 0, cz: 1 };
+        let mut set = BTreeSet::new();
+        set.insert(d);
+        set.insert(c);
+        set.insert(b);
+        set.insert(a);
+        let drained: Vec<ChunkCoord> = set.into_iter().collect();
+        // (0,0,0), (1,0,0), (0,1,0), (0,0,1) sort with cx outer-most:
+        // (0,0,0) < (0,0,1) < (0,1,0) < (1,0,0)
+        assert_eq!(drained, vec![a, d, c, b]);
+    }
+
+    #[test]
+    fn chunk_for_groups_cells_by_dim() {
+        // Two cells in the same MIRROR_CHUNK_DIM cube map to the same
+        // ChunkCoord. Two cells across the boundary land in different
+        // chunks. (Pin the boundary semantics so a knob change to
+        // MIRROR_CHUNK_DIM surfaces here.)
+        let dim = MIRROR_CHUNK_DIM as i32;
+        let a = chunk_for(IVec3::new(0, 0, 0)).unwrap();
+        let b = chunk_for(IVec3::new(dim - 1, dim - 1, dim - 1)).unwrap();
+        let c = chunk_for(IVec3::new(dim, 0, 0)).unwrap();
+        assert_eq!(a, b, "cells inside one chunk should match");
+        assert_ne!(a, c, "cell on chunk boundary should land in next chunk");
     }
 }

--- a/crates/spy_network_runtime/src/lib.rs
+++ b/crates/spy_network_runtime/src/lib.rs
@@ -640,6 +640,7 @@ impl CompiledSim for SpyNetworkState {
             state: &agent_buffers,
             event_ring: &self.event_ring,
             registry: &self.registry_gpu,
+            voxel_grid: None,
         };
 
         // (2) Mask round — fused PerPair kernel writes all 3 mask bitmaps.

--- a/crates/stress_agent_count_runtime/src/lib.rs
+++ b/crates/stress_agent_count_runtime/src/lib.rs
@@ -592,6 +592,7 @@ impl CompiledSim for StressAgentCountState {
             state: &agent_buffers,
             event_ring: &self.event_ring,
             registry: &self.registry_gpu,
+            voxel_grid: None,
         };
 
         // (2) Mask round — single PerAgent kernel, dispatches

--- a/crates/stress_cast_density_runtime/src/lib.rs
+++ b/crates/stress_cast_density_runtime/src/lib.rs
@@ -565,6 +565,7 @@ impl StressCastDensityState {
             state: &agent_buffers,
             event_ring: &self.event_ring,
             registry: &self.registry_gpu,
+            voxel_grid: None,
         };
 
         let dispatch_extras = physics_DispatchAoePulse::PhysicsDispatchAoePulseExtras {

--- a/crates/village_economy_runtime/src/lib.rs
+++ b/crates/village_economy_runtime/src/lib.rs
@@ -566,6 +566,7 @@ impl CompiledSim for VillageEconomyState {
             state: &agent_buffers,
             event_ring: &self.event_ring,
             registry: &self.registry_gpu,
+            voxel_grid: None,
         };
 
         // (2) Mask round — fused PerPair kernel writes all 3 mask bitmaps.

--- a/crates/voxel_probe_runtime/src/lib.rs
+++ b/crates/voxel_probe_runtime/src/lib.rs
@@ -53,9 +53,10 @@ use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, EVENT_RING_CAP
 use engine::state::SimState;
 use engine::terrain::TerrainQuery;
 use engine::GpuContext;
-use engine_voxel::VoxelTerrain;
+use engine_voxel::{VoxelMirror, VoxelTerrain};
 use glam::Vec3;
 use std::sync::Arc;
+use std::time::Instant;
 use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
@@ -87,6 +88,19 @@ pub struct VoxelProbeState {
     #[allow(dead_code)]
     state: SimState,
     terrain: VoxelTerrain,
+    /// Phase C — GPU-resident mirror of `terrain.grid()`. Updated
+    /// per-tick via `mark_dirty` (during chronicle drain) followed by
+    /// a single `flush_dirty` at end of tick. The buffer is wired
+    /// into `KernelBindingsContext::voxel_grid` so future kernels
+    /// (Phase D's terrain query lowerings) can read voxel state
+    /// without a CPU↔GPU round-trip.
+    mirror: VoxelMirror,
+    /// Wall-clock cost of the most recent `flush_dirty` call (in
+    /// nanoseconds). Exposed via [`Self::last_flush_ns`] so the
+    /// behavioral pin tests + Phase E benchmarks can baseline the
+    /// per-tick upload overhead at the fixture's typical mutation
+    /// rate. Zero before the first tick.
+    last_flush_ns: u128,
 
     // -- Agent SoA (GPU-side) --
     agent_hp_buf: wgpu::Buffer,
@@ -176,9 +190,19 @@ impl VoxelProbeState {
         // stays simple). Drain path mutates `terrain` directly; the
         // engine-side Arc is a second instance held for future passes
         // that walk terrain through the SimState seam.
+        //
+        // Extent picked at 16³ for Phase C: the GPU mirror buffer is
+        // `16 * 16 * 16 * 4 = 16 KiB`, two orders of magnitude smaller
+        // than the 64 MiB the 256³ default would allocate. The fixture
+        // only writes near the world origin, so 16³ is plenty of room
+        // and keeps the mirror cheap on hosts without dedicated VRAM.
+        const PROBE_EXTENT: u32 = 16;
         let mut state = SimState::new(agent_count, seed);
-        let terrain = VoxelTerrain::new();
-        state.terrain = Arc::new(VoxelTerrain::new());
+        let terrain = VoxelTerrain::with_extent(PROBE_EXTENT);
+        state.terrain = Arc::new(VoxelTerrain::with_extent(PROBE_EXTENT));
+        // Allocate the GPU mirror once at construction time; subsequent
+        // ticks only push dirty chunks via `flush_dirty`.
+        let mirror = VoxelMirror::new(&gpu, terrain.grid());
 
         // Spawn the lone agent at world origin so `caster_pos` is
         // pin-load-bearing.
@@ -372,6 +396,8 @@ impl VoxelProbeState {
             gpu,
             state,
             terrain,
+            mirror,
+            last_flush_ns: 0,
             agent_hp_buf,
             agent_alive_buf,
             agent_mana_buf,
@@ -427,13 +453,43 @@ impl VoxelProbeState {
     }
 
     /// Drive one tick of the GPU pipeline + host-side voxel drain.
+    ///
+    /// Per-tick chain:
+    ///   1. GPU dispatches (mask → scoring → chronicle dispatchers).
+    ///   2. Host drain — applies chronicle records to the CPU
+    ///      `VoxelTerrain` AND marks each touched chunk in `mirror`.
+    ///   3. `mirror.flush_dirty(...)` — pushes dirty chunks to GPU
+    ///      so the *next* tick's kernels see fresh voxel state.
     pub fn step(&mut self) {
         self.run_gpu_tick();
         let drained = self.drain_voxel_records();
         // Drained returns just for telemetry; the chronicle records
-        // are applied in-place to `self.terrain`.
+        // are applied in-place to `self.terrain` (and dirty chunks
+        // marked in `self.mirror`).
         let _ = drained;
+        // Flush the mirror at end of tick so the next tick's GPU
+        // dispatches see the freshly-mutated voxel state.
+        let t0 = Instant::now();
+        self.mirror
+            .flush_dirty(&self.gpu, self.terrain.grid());
+        self.last_flush_ns = t0.elapsed().as_nanos();
         self.tick += 1;
+    }
+
+    /// Wall-clock cost of the most recent `flush_dirty` call, in
+    /// nanoseconds. Zero before the first tick. Used by the Phase C
+    /// behavioral pin tests to baseline per-tick upload overhead so
+    /// Phase E can decide whether the CPU-mirror's per-mutation cost
+    /// is the bottleneck (per the cross-cutting risk #1 in the plan).
+    pub fn last_flush_ns(&self) -> u128 {
+        self.last_flush_ns
+    }
+
+    /// Borrow the GPU-resident voxel mirror — used by the Phase C
+    /// `cpu_gpu_voxel_state_matches` pin to read cells back through
+    /// the GPU compute path.
+    pub fn mirror(&self) -> &VoxelMirror {
+        &self.mirror
     }
 
     /// Drive one tick of GPU dispatches end-to-end. Encodes per-tick
@@ -482,10 +538,14 @@ impl VoxelProbeState {
             move_speed_buf: Some(&self.agent_move_speed_buf),
             ..Default::default()
         };
+        // No kernel in this fixture binds `voxel_grid` yet; the wire-up
+        // is forward-compat for Phase D, when terrain-query lowerings
+        // start emitting that binding.
         let ctx = KernelBindingsContext {
             state: &agent_buffers,
             event_ring: &self.event_ring,
             registry: &self.registry_gpu,
+            voxel_grid: Some(self.mirror.buffer()),
         };
 
         // (2) Mask round (fused PerAgent — both verbs are self-cast).
@@ -742,8 +802,11 @@ impl VoxelProbeState {
             // and the position is cached at construction. Multi-agent
             // fixtures resolve caster_slot → pos against the agent SoA
             // here.
-            self.terrain
-                .apply_voxel_chronicle_record(rec, self.caster_pos);
+            self.terrain.apply_voxel_chronicle_record_with_mirror(
+                rec,
+                self.caster_pos,
+                &mut self.mirror,
+            );
             applied += 1;
         }
         applied
@@ -895,5 +958,351 @@ mod voxel_pins {
              chronicle record didn't translate into a VoxelGrid clear.",
         );
         eprintln!("[voxel_probe] post-harvest height_at(0,0) = {h}");
+    }
+
+    // -----------------------------------------------------------------
+    // Phase C semantic pin — CPU/GPU mirror divergence catcher.
+    // -----------------------------------------------------------------
+
+    /// Tiny standalone compute kernel that reads N cells from the
+    /// `voxel_grid` storage buffer and writes their `u32` values into
+    /// a readback buffer. Used by `cpu_gpu_voxel_state_matches` to
+    /// compare GPU-side vs. CPU-side reads at the same cells.
+    ///
+    /// Mirrors the layout of `engine_voxel::VoxelMirror`'s staging
+    /// (`index = z*H*W + y*W + x`). Width/height/depth come from a
+    /// small uniform; cell indices come from a separate input buffer.
+    /// Out-of-bounds returns 0u (matches the planned WGSL `voxel_at`
+    /// helper's contract — Phase D will lower terrain queries to call
+    /// that helper from kernel bodies).
+    const READBACK_WGSL: &str = r#"
+struct DimsCfg {
+    width: u32,
+    height: u32,
+    depth: u32,
+    n: u32,
+};
+@group(0) @binding(0) var<storage, read> voxel_grid: array<u32>;
+@group(0) @binding(1) var<storage, read> probe_cells: array<u32>;
+@group(0) @binding(2) var<storage, read_write> probe_results: array<u32>;
+@group(0) @binding(3) var<uniform> cfg: DimsCfg;
+
+fn voxel_at(x: i32, y: i32, z: i32) -> u32 {
+    if (x < 0 || y < 0 || z < 0) {
+        return 0u;
+    }
+    let ux: u32 = u32(x);
+    let uy: u32 = u32(y);
+    let uz: u32 = u32(z);
+    if (ux >= cfg.width || uy >= cfg.height || uz >= cfg.depth) {
+        return 0u;
+    }
+    let idx: u32 = uz * cfg.height * cfg.width + uy * cfg.width + ux;
+    return voxel_grid[idx];
+}
+
+@compute @workgroup_size(64)
+fn cs_voxel_readback(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= cfg.n) {
+        return;
+    }
+    let x = i32(probe_cells[i * 3u + 0u]);
+    let y = i32(probe_cells[i * 3u + 1u]);
+    let z = i32(probe_cells[i * 3u + 2u]);
+    probe_results[i] = voxel_at(x, y, z);
+}
+"#;
+
+    #[repr(C)]
+    #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+    struct DimsCfg {
+        width: u32,
+        height: u32,
+        depth: u32,
+        n: u32,
+    }
+
+    /// Read N cells from the GPU mirror via a one-shot compute
+    /// dispatch. Returns the values the GPU sees at each (x, y, z).
+    /// Used by the divergence pin — caller compares element-by-element
+    /// to `terrain.cell_at(x, y, z)`.
+    fn gpu_read_cells(
+        state: &VoxelProbeState,
+        cells: &[(i32, i32, i32)],
+    ) -> Vec<u32> {
+        let gpu = &state.gpu;
+        let mirror = state.mirror();
+        let (w, h, d) = mirror.dimensions();
+        let n = cells.len() as u32;
+
+        // Pack cells as u32 triples (positive cells only — the test
+        // chooses non-negative coords; negative-bound testing happens
+        // in the engine_voxel unit tests). The shader receives them as
+        // i32 by cast; the buffer storage is u32.
+        let mut packed: Vec<u32> = Vec::with_capacity((n as usize) * 3);
+        for (x, y, z) in cells {
+            packed.push(*x as u32);
+            packed.push(*y as u32);
+            packed.push(*z as u32);
+        }
+        // Pad to at least 12 bytes so wgpu doesn't reject a tiny buffer.
+        while packed.len() < 4 {
+            packed.push(0);
+        }
+
+        let cells_buf = gpu.device.create_buffer_init(
+            &wgpu::util::BufferInitDescriptor {
+                label: Some("voxel_probe::probe_cells"),
+                contents: bytemuck::cast_slice(&packed),
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            },
+        );
+        let results_bytes = ((n as u64) * 4).max(16);
+        let results_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("voxel_probe::probe_results"),
+            size: results_bytes,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let cfg = DimsCfg {
+            width: w,
+            height: h,
+            depth: d,
+            n,
+        };
+        let cfg_buf = gpu.device.create_buffer_init(
+            &wgpu::util::BufferInitDescriptor {
+                label: Some("voxel_probe::probe_cfg"),
+                contents: bytemuck::bytes_of(&cfg),
+                usage: wgpu::BufferUsages::UNIFORM,
+            },
+        );
+        let staging = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("voxel_probe::probe_results_staging"),
+            size: results_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let shader = gpu
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("voxel_probe::readback_shader"),
+                source: wgpu::ShaderSource::Wgsl(READBACK_WGSL.into()),
+            });
+        let bgl = gpu
+            .device
+            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("voxel_probe::readback_bgl"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: false },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 3,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                ],
+            });
+        let pl = gpu
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("voxel_probe::readback_pl"),
+                bind_group_layouts: &[&bgl],
+                push_constant_ranges: &[],
+            });
+        let pipeline = gpu
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("voxel_probe::readback_pipeline"),
+                layout: Some(&pl),
+                module: &shader,
+                entry_point: Some("cs_voxel_readback"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+        let bg = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("voxel_probe::readback_bg"),
+            layout: &bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: mirror.buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: cells_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: results_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: cfg_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut encoder = gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("voxel_probe::readback_encoder"),
+            });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("voxel_probe::readback_pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &bg, &[]);
+            // Workgroup size = 64; one thread per cell.
+            let groups = (n + 63) / 64;
+            pass.dispatch_workgroups(groups.max(1), 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(&results_buf, 0, &staging, 0, results_bytes);
+        gpu.queue.submit(Some(encoder.finish()));
+
+        let slice = staging.slice(..);
+        let (sender, receiver) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            let _ = sender.send(r);
+        });
+        gpu.device.poll(wgpu::PollType::Wait).expect("poll");
+        receiver
+            .recv()
+            .expect("readback map result")
+            .expect("readback map ok");
+        let mapped = slice.get_mapped_range();
+        let words: &[u32] = bytemuck::cast_slice(&mapped);
+        let out: Vec<u32> = words[..n as usize].to_vec();
+        drop(mapped);
+        staging.unmap();
+        out
+    }
+
+    /// **Phase C semantic pin.** Catches CPU/GPU mirror divergence —
+    /// the failure mode where a chronicle record mutates the host
+    /// `VoxelGrid` but the corresponding GPU buffer slot stays stale
+    /// (or vice versa). Drives 30 ticks (multiple place + harvest
+    /// cycles), then samples a deterministic set of cells across the
+    /// 16³ extent and asserts CPU == GPU at every sampled cell.
+    ///
+    /// Failure modes this catches:
+    ///   - `apply_voxel_chronicle_record_with_mirror` writes the grid
+    ///     but forgets to call `mark_dirty`.
+    ///   - `flush_dirty` skips a chunk (off-by-one in the BTreeSet
+    ///     drain or chunk-bounds calculation).
+    ///   - The cell-to-flat-index encoding diverges between
+    ///     `VoxelGrid::index` (host) and `voxel_at` (GPU).
+    ///
+    /// Don't substitute "voxel_count_on_gpu > 0" — that pin passes
+    /// for any non-empty mirror state regardless of which cells are
+    /// populated.
+    #[test]
+    fn cpu_gpu_voxel_state_matches() {
+        let mut state = match VoxelProbeState::try_new(0) {
+            Some(s) => s,
+            None => {
+                eprintln!(
+                    "[voxel_probe cpu_gpu_voxel_state_matches] skipping: \
+                     no wgpu adapter available on this host."
+                );
+                return;
+            }
+        };
+        // 30 ticks covers 3 full Place→Harvest cycles (Place at 0,
+        // Harvest at 5/15/25) so the mirror sees both writes and
+        // clears. Track per-tick flush cost so the eprintln below can
+        // report the max-tick cost (rather than just the last) — the
+        // last tick is usually zero-work and not interesting.
+        let mut max_flush_ns: u128 = 0;
+        let mut total_flush_ns: u128 = 0;
+        for _ in 0..30 {
+            state.step();
+            let f = state.last_flush_ns();
+            if f > max_flush_ns {
+                max_flush_ns = f;
+            }
+            total_flush_ns += f;
+        }
+
+        // Sample 10 cells deterministically across the 16³ extent.
+        // Mix in the cells the fixture actually mutates (origin,
+        // and the harvest-radius neighborhood) plus a few that
+        // should always be air.
+        let probes: Vec<(i32, i32, i32)> = vec![
+            (0, 0, 0),    // place + harvest target
+            (1, 0, 0),    // adjacent — air after fixture wraps up
+            (0, 1, 0),
+            (0, 0, 1),
+            (3, 3, 3),   // far from probe — should be air
+            (5, 5, 5),
+            (15, 15, 15),// corner — should be air
+            (8, 4, 2),
+            (2, 8, 4),
+            (4, 2, 8),
+        ];
+
+        let gpu_values = gpu_read_cells(&state, &probes);
+        for (i, (x, y, z)) in probes.iter().enumerate() {
+            let cpu_val = state.terrain().cell_at(*x, *y, *z) as u32;
+            let gpu_val = gpu_values[i];
+            assert_eq!(
+                cpu_val, gpu_val,
+                "CPU/GPU mirror divergence at cell ({x}, {y}, {z}): \
+                 CPU={cpu_val}, GPU={gpu_val}. Either the chronicle \
+                 consumer wrote to the host VoxelGrid without marking \
+                 the chunk dirty, or `flush_dirty` skipped the chunk, \
+                 or the cell→flat-index encoding diverges between host \
+                 (z*H*W + y*W + x) and the WGSL `voxel_at` helper."
+            );
+        }
+        eprintln!(
+            "[voxel_probe] cpu_gpu_voxel_state_matches: {n} cells matched. \
+             Mirror buffer = {bytes} B ({kib:.1} KiB). \
+             Per-tick flush_dirty: max = {max_us:.2} us, mean = {mean_us:.2} us \
+             across 30 ticks (last_tick = {last_us:.2} us).",
+            n = probes.len(),
+            bytes = state.mirror().buffer_bytes(),
+            kib = state.mirror().buffer_bytes() as f64 / 1024.0,
+            max_us = max_flush_ns as f64 / 1000.0,
+            mean_us = (total_flush_ns as f64 / 30.0) / 1000.0,
+            last_us = state.last_flush_ns() as f64 / 1000.0,
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `VoxelMirror` — a `wgpu::Buffer` mirror of the host `VoxelGrid` so GPU kernels can read voxel state without a CPU↔GPU round-trip.
- Wires the mirror into `KernelBindingsContext` via a new optional `voxel_grid` field; compiler classifier resolves a kernel binding named `voxel_grid` to `ctx.voxel_grid.expect(...)` so Phase D's terrain-query lowerings get the buffer wired automatically.
- Per-tick chain: chronicle drain marks dirty chunks → end-of-tick `flush_dirty` pushes them via `Queue::write_buffer`. `BTreeSet<ChunkCoord>` for deterministic upload order (P5).
- WGSL preamble gains a `voxel_at(grid, x, y, z, w, h, d) -> u32` helper, substring-gated on `voxel_at(`. Phase C lays the helper down; Phase D will start emitting calls to it.

## Phase C semantic pin

`cpu_gpu_voxel_state_matches` dispatches a tiny WGSL readback kernel that reads N deterministic cells from the mirror buffer and asserts CPU == GPU at each sampled cell. Catches: chronicle consumer skipping `mark_dirty`, `flush_dirty` skipping a chunk, cell-to-flat-index encoding divergence between host and WGSL.

## Performance

Per-tick `flush_dirty` cost at the `voxel_probe` fixture (16³ = 16 KiB mirror): max 162 µs, mean 11 µs across 30 ticks. Well under the 1 ms/tick threshold the plan calls out as the trigger for GPU↔GPU interop.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test -p dsl_compiler --release` — all passing (35 tests across modules)
- [x] `cargo test -p engine --release --test schema_hash` — schema unchanged
- [x] `cargo test -p engine_voxel --release` — 20 tests pass (was 18 + 2 new chunk-coord tests)
- [x] `cargo test -p voxel_probe_runtime --release --lib` — 3 pins pass (Phase B's 2 + Phase C's `cpu_gpu_voxel_state_matches`)
- [x] `cargo test -p spy_network_runtime --release --lib` — passes
- [x] `cargo test -p village_economy_runtime --release --lib` — passes
- [x] `cargo test -p wave_defense_runtime --release --lib` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)