### PR TITLE
feat(wave_defense): Phase E — opt into VoxelTerrain (palisades) + determinism + perf baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ dependencies = [
  "engine_voxel",
  "glam",
  "pollster",
+ "sha2",
  "wgpu",
 ]
 
@@ -2858,6 +2859,7 @@ dependencies = [
  "dsl_ast",
  "dsl_compiler",
  "engine",
+ "engine_voxel",
  "glam",
  "pollster",
  "wgpu",

--- a/assets/ability_test/wave_defense/BuildPalisade.ability
+++ b/assets/ability_test/wave_defense/BuildPalisade.ability
@@ -1,0 +1,31 @@
+// wave_defense Phase E (voxel-engine integration) — settler self-cast
+// `place_voxel` ability driving the EffectPlaceVoxelApplied (kind=60)
+// chronicle producer.
+//
+// Lowers to:
+//   AbilityProgram {
+//     gate: { cooldown_ticks: 5 },
+//     effects: [EffectOp::PlaceVoxel { kind_hash: FxHash("palisade") }],
+//   }
+//
+// Settlers fire BuildPalisade every 50 ticks (gated by the verb's
+// `when` clause in wave_defense.sim) to deposit defensive palisade
+// voxels at their position. The runtime drains kind=60 chronicle
+// records into `engine_voxel::VoxelTerrain`, which both the host CPU
+// terrain queries AND the GPU mirror see — proving Phase E's "real
+// fixture uses voxel terrain" goal.
+//
+// `kind_hash = FxHash("palisade")`: distinct from voxel_probe's
+// "test_voxel" so the two fixtures' material codes don't collide
+// in any cross-fixture inspection.
+//
+// `cooldown: 500ms` (= 5 ticks) is informational only — the .sim
+// verb's `when` clause carries the load-bearing tick-window gate.
+
+ability BuildPalisade {
+    target: self
+    cooldown: 500ms
+    hint: utility
+
+    place_voxel "palisade"
+}

--- a/assets/sim/wave_defense.sim
+++ b/assets/sim/wave_defense.sim
@@ -119,6 +119,12 @@ config combat {
   // Wave spawning tuning.
   wave_period: u32 = 30,
 
+  // Phase E voxel-engine integration: settler BuildPalisade firing
+  // cadence. Set to 50 so settlers periodically reinforce the
+  // settlement during the early game without saturating the chronicle
+  // ring (25 settlers × 1 record / 50 ticks = 0.5 records/tick avg).
+  palisade_period: u32 = 50,
+
   // Wave-tier thresholds — in ticks. SpawnSmall fires while
   // `world.tick < small_to_medium`, SpawnMedium on
   // `[small_to_medium..medium_to_large)`, SpawnLarge on
@@ -195,12 +201,14 @@ verb Strike(self, target: Agent) =
 // ramping (Path B from Task #249) — no compiler extension; rides
 // the compound `world.tick >= L && world.tick < H` predicate.
 //
-// AbilityId binding (alphabetised registry slot order):
-//   MonsterCleave  → 1
-//   SpawnHorde     → 2
-//   SpawnLarge     → 3
-//   SpawnMedium    → 4
-//   SpawnSmall     → 5
+// AbilityId binding (alphabetised registry slot order — Phase E voxel
+// integration added BuildPalisade as slot 1):
+//   BuildPalisade  → 1   (settler self-cast; `place_voxel "palisade"`)
+//   MonsterCleave  → 2
+//   SpawnHorde     → 3
+//   SpawnLarge     → 4
+//   SpawnMedium    → 5
+//   SpawnSmall     → 6
 //
 // The dispatcher writes EffectSummonApplied chronicle records (kind=62)
 // into the event ring. The runtime drains those records after each
@@ -214,7 +222,7 @@ verb SpawnSmall(self, target: Agent) =
         && self.creature_type == config.combat.type_spawner
         && (world.tick < config.combat.small_to_medium)
         && (world.tick % config.combat.wave_period == 0))
-  apply_ability 5 by self target self
+  apply_ability 6 by self target self
   score 500.0
 
 verb SpawnMedium(self, target: Agent) =
@@ -225,7 +233,7 @@ verb SpawnMedium(self, target: Agent) =
         && (world.tick >= config.combat.small_to_medium)
         && (world.tick < config.combat.medium_to_large)
         && (world.tick % config.combat.wave_period == 0))
-  apply_ability 4 by self target self
+  apply_ability 5 by self target self
   score 500.0
 
 verb SpawnLarge(self, target: Agent) =
@@ -236,7 +244,7 @@ verb SpawnLarge(self, target: Agent) =
         && (world.tick >= config.combat.medium_to_large)
         && (world.tick < config.combat.large_to_horde)
         && (world.tick % config.combat.wave_period == 0))
-  apply_ability 3 by self target self
+  apply_ability 4 by self target self
   score 500.0
 
 verb SpawnHorde(self, target: Agent) =
@@ -246,8 +254,32 @@ verb SpawnHorde(self, target: Agent) =
         && self.creature_type == config.combat.type_spawner
         && (world.tick >= config.combat.large_to_horde)
         && (world.tick % config.combat.wave_period == 0))
-  apply_ability 2 by self target self
+  apply_ability 3 by self target self
   score 500.0
+
+// BuildPalisade — Phase E voxel-engine integration. Settlers self-cast
+// `place_voxel "palisade"` every `palisade_period` ticks (50) during
+// the early game so the wave_defense fixture exercises real voxel
+// terrain mutation (vs. the FlatPlane stub). The dispatcher writes
+// EffectPlaceVoxelApplied (kind=60) chronicle records; the runtime
+// drains them into `engine_voxel::VoxelTerrain`'s CPU grid AND marks
+// dirty chunks in the GPU mirror.
+//
+// `apply_ability 1 by self target self` resolves to the BuildPalisade
+// ability slot in the registry (alphabetised — BuildPalisade is the
+// first .ability file by name now). The verb's `when` clause limits
+// firing to settlers in the early game (tick < small_to_medium so
+// palisades land before the wave-pressure ramps); after the early
+// game settlers focus on Strike/Harvest as before.
+verb BuildPalisade(self, target: Agent) =
+  action BuildPalisadeAction
+  when (self.alive
+        && target == self
+        && self.creature_type == config.combat.type_settler
+        && (world.tick < config.combat.small_to_medium)
+        && (world.tick % config.combat.palisade_period == 0))
+  apply_ability 1 by self target self
+  score 1500.0
 
 // ---------------------------------------------------------------------
 // MonsterMarch — per_agent physics. Each alive monster steps toward

--- a/crates/voxel_probe_runtime/Cargo.toml
+++ b/crates/voxel_probe_runtime/Cargo.toml
@@ -27,6 +27,13 @@ pollster = "0.4"
 dsl_ast = { path = "../dsl_ast" }
 dsl_compiler = { path = "../dsl_compiler" }
 
+[dev-dependencies]
+# Phase E `same_seed_same_voxel_world` pin: SHA-256 the byte-cast
+# voxel grid contents to compare two same-seed runs at byte
+# granularity. sha2 is already a transitive dep through the engine
+# crate; pinning here makes the test's intent explicit.
+sha2 = "0.10"
+
 [build-dependencies]
 dsl_ast = { path = "../dsl_ast" }
 dsl_compiler = { path = "../dsl_compiler" }

--- a/crates/voxel_probe_runtime/src/lib.rs
+++ b/crates/voxel_probe_runtime/src/lib.rs
@@ -1337,6 +1337,114 @@ fn cs_voxel_readback(@builtin(global_invocation_id) gid: vec3<u32>) {
     // obstructions to traverse.
     // -----------------------------------------------------------------
 
+    // -----------------------------------------------------------------
+    // Phase E semantic pin — same_seed_same_voxel_world.
+    //
+    // The load-bearing P5 determinism pin for the voxel adapter: build
+    // two fixture instances with the same seed, drive each for N
+    // ticks, then hash the CPU-side VoxelGrid contents (every cell at
+    // every (x, y, z) in the 16³ extent — total 4096 bytes). The
+    // hashes MUST match. A failure means non-deterministic ordering
+    // crept in somewhere — most likely a HashMap iteration in the
+    // chronicle drain, or BTreeSet → HashSet substitution in the
+    // mirror's dirty tracking.
+    //
+    // This is the cross-cutting risk #2 from the plan
+    // (`docs/superpowers/plans/2026-05-09-voxel-engine-integration.md`):
+    // "voxel_engine's chunks may iterate by HashMap. Verify in Phase
+    // A; replace with BTreeMap or sort keys at boundary. P5 violation
+    // risk if missed. The same_seed_same_voxel_world pin in Phase E
+    // catches it."
+    //
+    // The hash is computed by walking cells in ascending (z, y, x)
+    // order — deterministic regardless of any internal storage
+    // ordering. Two same-seed runs with different internal iteration
+    // would still produce different VoxelGrid contents at the *same*
+    // (x, y, z) and the hash would diverge.
+    //
+    // Don't substitute "both runs return non-zero counts" — that's
+    // the probe-fooling pattern; same-seed runs that diverge in cell
+    // *placement* would still pass a counter-based pin.
+    // -----------------------------------------------------------------
+
+    /// Walk the voxel grid in ascending (z, y, x) order and SHA-256
+    /// the byte stream. Used by `same_seed_same_voxel_world` to
+    /// compare two same-seed runs at byte granularity. The walk
+    /// order is independent of the underlying storage's internal
+    /// iteration — a HashMap-backed grid that produces the same
+    /// cells at the same coordinates would still hash identically.
+    fn hash_voxel_world(state: &VoxelProbeState) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        let extent = state.terrain().extent() as i32;
+        let mut hasher = Sha256::new();
+        for z in 0..extent {
+            for y in 0..extent {
+                for x in 0..extent {
+                    let v = state.terrain().cell_at(x, y, z);
+                    hasher.update(&[v]);
+                }
+            }
+        }
+        hasher.finalize().into()
+    }
+
+    /// **Phase E semantic pin.** Two same-seed runs of the
+    /// voxel_probe fixture must produce byte-identical VoxelGrid
+    /// state after `N` ticks. Catches HashMap-derived non-determinism
+    /// in the chronicle drain or mirror, and any future RNG-keyed
+    /// voxel mutation that fails to use `per_agent_u32(...)` keying.
+    ///
+    /// The fixture's chronicle drain is purely a function of the
+    /// chronicle records (deterministic per the GPU dispatcher's
+    /// per-tick output) and the agent SoA (initialised
+    /// deterministically per seed). The voxel grid mutation order is
+    /// driven by the ring-slot ordering the dispatcher writes
+    /// (deterministic per GPU spec) → applied via
+    /// `apply_voxel_chronicle_record_with_mirror` in the order
+    /// records arrive. As long as every step of that pipeline is
+    /// deterministic, the final grid state hashes identically.
+    #[test]
+    fn same_seed_same_voxel_world() {
+        const N: u64 = 50;
+        let mut state_a = match VoxelProbeState::try_new(0xC0FFEE) {
+            Some(s) => s,
+            None => {
+                eprintln!(
+                    "[same_seed_same_voxel_world] skipping: no wgpu \
+                     adapter available on this host."
+                );
+                return;
+            }
+        };
+        let mut state_b = match VoxelProbeState::try_new(0xC0FFEE) {
+            Some(s) => s,
+            None => return,
+        };
+        for _ in 0..N {
+            state_a.step();
+        }
+        for _ in 0..N {
+            state_b.step();
+        }
+        let hash_a = hash_voxel_world(&state_a);
+        let hash_b = hash_voxel_world(&state_b);
+        assert_eq!(
+            hash_a, hash_b,
+            "same-seed runs produced different VoxelGrid hashes after \
+             {N} ticks: a={:02x?} b={:02x?}. Non-determinism crept in — \
+             most likely a HashMap iteration order leak in the \
+             chronicle drain, or BTreeSet → HashSet substitution in \
+             VoxelMirror::dirty_chunks. Re-audit voxel_engine \
+             dependencies for HashMap usage at the adapter boundary.",
+            hash_a, hash_b,
+        );
+        eprintln!(
+            "[voxel_probe] same_seed_same_voxel_world: hash={:02x?} \
+             (matched across two seed=0xC0FFEE runs of {N} ticks)",
+            &hash_a[..8]
+        );
+    }
+
     /// Verbatim copy of the `voxel_line_of_sight` helper body the
     /// compiler injects into kernels that call `terrain.line_of_sight`
     /// (see `dsl_compiler::cg::emit::program::VOXEL_GRID_WGSL_PRELUDE`).

--- a/crates/wave_defense_runtime/Cargo.toml
+++ b/crates/wave_defense_runtime/Cargo.toml
@@ -21,6 +21,7 @@ build = "build.rs"
 
 [dependencies]
 engine = { path = "../engine" }
+engine_voxel = { path = "../engine_voxel" }
 wgpu = "=26.0.1"
 bytemuck = { version = "1.16", features = ["derive"] }
 glam = "0.29"

--- a/crates/wave_defense_runtime/build.rs
+++ b/crates/wave_defense_runtime/build.rs
@@ -23,10 +23,18 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-// Task #249 polish slice: 5 abilities (was 2 in foundation slice).
-// MonsterCleave + 4 tier-keyed Spawn abilities for wave-size ramping.
-// Alphabetised — registry slot order matches.
+// Phase E voxel-engine integration: 6 abilities (was 5 in #249 polish).
+// BuildPalisade (settler `place_voxel "palisade"`) added at slot 1
+// (alphabetised filenames — `B` sorts before `M`).
+// Registry slots:
+//   BuildPalisade  → 1
+//   MonsterCleave  → 2
+//   SpawnHorde     → 3
+//   SpawnLarge     → 4
+//   SpawnMedium    → 5
+//   SpawnSmall     → 6
 const ABILITY_NAMES: &[&str] = &[
+    "BuildPalisade.ability",
     "MonsterCleave.ability",
     "SpawnHorde.ability",
     "SpawnLarge.ability",

--- a/crates/wave_defense_runtime/src/bin/wave_defense_app.rs
+++ b/crates/wave_defense_runtime/src/bin/wave_defense_app.rs
@@ -28,7 +28,9 @@
 use std::io::Write;
 use std::panic::AssertUnwindSafe;
 
-use wave_defense_runtime::{wave_size_at_tick, WaveDefenseState, DEFAULT_MAX_TICKS};
+use wave_defense_runtime::{
+    wave_size_at_tick, WaveDefenseState, DEFAULT_MAX_TICKS,
+};
 
 const TICK_SAMPLE_PERIOD: u64 = 50;
 
@@ -119,6 +121,21 @@ fn main() {
     let final_score = std::panic::catch_unwind(AssertUnwindSafe(|| state.read_score()))
         .unwrap_or(last_score);
     emit_summary(&mut stdout, died_at_tick, final_score, max_wave_size, panic_msg);
+
+    // Phase E voxel-engine integration — print the per-tick
+    // `flush_dirty` perf summary to stderr so the perf doc author
+    // can read it from `tail -10`'s combined stdout/stderr without
+    // polluting the NDJSON stdout stream. Mean cost = total / count.
+    let flush_calls = state.flush_call_count();
+    let max_us = state.max_flush_ns() as f64 / 1000.0;
+    let total_us = state.total_flush_ns() as f64 / 1000.0;
+    let mean_us = total_us / (flush_calls.max(1) as f64);
+    eprintln!(
+        "[wave_defense_app voxel-perf] palisade_records={} \
+         flush_call_count={flush_calls} flush_dirty: max={max_us:.2} us, \
+         mean={mean_us:.2} us, total={total_us:.2} us across {flush_calls} ticks",
+        state.total_palisade_records(),
+    );
 }
 
 fn emit_per_tick(

--- a/crates/wave_defense_runtime/src/binding_check.rs
+++ b/crates/wave_defense_runtime/src/binding_check.rs
@@ -4,14 +4,14 @@
 //! program landed at the expected AbilityId slot. Drift surfaces here
 //! at startup rather than as silent wrong-slot dispatch downstream.
 //!
-//! Slot pinning order (alphabetised filenames in `names`) — Task #249
-//! polish slice expanded the corpus from 2 → 5 abilities to support
-//! tick-windowed wave-size ramping (Path B):
-//!   MonsterCleave  → AbilityId(1)   (MonsterCleaveScan dispatches `apply_ability 1`)
-//!   SpawnHorde     → AbilityId(2)   (SpawnHorde verb dispatches `apply_ability 2`; count=64)
-//!   SpawnLarge     → AbilityId(3)   (SpawnLarge verb dispatches `apply_ability 3`; count=32)
-//!   SpawnMedium    → AbilityId(4)   (SpawnMedium verb dispatches `apply_ability 4`; count=16)
-//!   SpawnSmall     → AbilityId(5)   (SpawnSmall verb dispatches `apply_ability 5`; count=8)
+//! Slot pinning order (alphabetised filenames in `names`) — Phase E
+//! voxel-engine integration added BuildPalisade as a 6th ability:
+//!   BuildPalisade  → AbilityId(1)   (BuildPalisade verb dispatches `apply_ability 1`; place_voxel "palisade")
+//!   MonsterCleave  → AbilityId(2)   (MonsterCleaveScan dispatches `apply_ability 2`)
+//!   SpawnHorde     → AbilityId(3)   (SpawnHorde verb dispatches `apply_ability 3`; count=64)
+//!   SpawnLarge     → AbilityId(4)   (SpawnLarge verb dispatches `apply_ability 4`; count=32)
+//!   SpawnMedium    → AbilityId(5)   (SpawnMedium verb dispatches `apply_ability 5`; count=16)
+//!   SpawnSmall     → AbilityId(6)   (SpawnSmall verb dispatches `apply_ability 6`; count=8)
 //!
 //! Each .sim verb body's `apply_ability N by self target X` literal
 //! must agree with these constants — drift surfaces as silent
@@ -21,11 +21,12 @@ use std::path::PathBuf;
 
 use engine::ability::AbilityId;
 
-pub const MONSTER_CLEAVE_EXPECTED_ABILITY_ID: u32 = 1;
-pub const SPAWN_HORDE_EXPECTED_ABILITY_ID: u32 = 2;
-pub const SPAWN_LARGE_EXPECTED_ABILITY_ID: u32 = 3;
-pub const SPAWN_MEDIUM_EXPECTED_ABILITY_ID: u32 = 4;
-pub const SPAWN_SMALL_EXPECTED_ABILITY_ID: u32 = 5;
+pub const BUILD_PALISADE_EXPECTED_ABILITY_ID: u32 = 1;
+pub const MONSTER_CLEAVE_EXPECTED_ABILITY_ID: u32 = 2;
+pub const SPAWN_HORDE_EXPECTED_ABILITY_ID: u32 = 3;
+pub const SPAWN_LARGE_EXPECTED_ABILITY_ID: u32 = 4;
+pub const SPAWN_MEDIUM_EXPECTED_ABILITY_ID: u32 = 5;
+pub const SPAWN_SMALL_EXPECTED_ABILITY_ID: u32 = 6;
 
 /// Read + parse + build the AbilityRegistry over every .ability file
 /// under `assets/ability_test/wave_defense/`. Mirrors
@@ -52,9 +53,10 @@ pub(crate) fn build_wave_defense_registry()
     };
 
     // Source-order names list — also the registry's slot order.
-    // Alphabetised: MonsterCleave + SpawnHorde + SpawnLarge +
-    // SpawnMedium + SpawnSmall → AbilityIds (1, 2, 3, 4, 5).
+    // Alphabetised: BuildPalisade + MonsterCleave + SpawnHorde +
+    // SpawnLarge + SpawnMedium + SpawnSmall → AbilityIds (1, 2, 3, 4, 5, 6).
     let names = [
+        "BuildPalisade.ability",
         "MonsterCleave.ability",
         "SpawnHorde.ability",
         "SpawnLarge.ability",
@@ -91,6 +93,7 @@ pub fn assert_ability_registry_matches_sim_constants() {
         );
     };
 
+    assert_slot("BuildPalisade", BUILD_PALISADE_EXPECTED_ABILITY_ID);
     assert_slot("MonsterCleave", MONSTER_CLEAVE_EXPECTED_ABILITY_ID);
     assert_slot("SpawnHorde",    SPAWN_HORDE_EXPECTED_ABILITY_ID);
     assert_slot("SpawnLarge",    SPAWN_LARGE_EXPECTED_ABILITY_ID);

--- a/crates/wave_defense_runtime/src/lib.rs
+++ b/crates/wave_defense_runtime/src/lib.rs
@@ -122,7 +122,9 @@ use engine::gpu::{EVENT_RING_CAP_SLOTS, EVENT_STRIDE_U32};
 use engine::rng::per_agent_u32_pcg_with_extra;
 use engine::sim_trait::{AgentSnapshot, CompiledSim, VizGlyph};
 use engine::GpuContext;
+use engine_voxel::{VoxelMirror, VoxelTerrain};
 use glam::Vec3;
+use std::time::Instant;
 use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
@@ -130,9 +132,10 @@ include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 mod binding_check;
 
 pub use binding_check::{
-    assert_ability_registry_matches_sim_constants, MONSTER_CLEAVE_EXPECTED_ABILITY_ID,
-    SPAWN_HORDE_EXPECTED_ABILITY_ID, SPAWN_LARGE_EXPECTED_ABILITY_ID,
-    SPAWN_MEDIUM_EXPECTED_ABILITY_ID, SPAWN_SMALL_EXPECTED_ABILITY_ID,
+    assert_ability_registry_matches_sim_constants, BUILD_PALISADE_EXPECTED_ABILITY_ID,
+    MONSTER_CLEAVE_EXPECTED_ABILITY_ID, SPAWN_HORDE_EXPECTED_ABILITY_ID,
+    SPAWN_LARGE_EXPECTED_ABILITY_ID, SPAWN_MEDIUM_EXPECTED_ABILITY_ID,
+    SPAWN_SMALL_EXPECTED_ABILITY_ID,
 };
 
 /// Creature type discriminants — must match `assets/sim/wave_defense.sim`'s
@@ -211,6 +214,39 @@ pub fn wave_size_at_tick(tick: u64) -> u32 {
 /// `crates/engine/src/cascade/handler.rs` `EventKindId::EffectSummonApplied`).
 pub const KIND_EFFECT_SUMMON_APPLIED: u32 = 62;
 
+/// Engine event kind for EffectPlaceVoxelApplied chronicle records (Phase E
+/// voxel-engine integration). The dispatcher emits one record per
+/// successful BuildPalisade cast; the runtime drains them into the
+/// host-side VoxelTerrain via
+/// `engine_voxel::VoxelTerrain::apply_voxel_chronicle_record_with_mirror`.
+pub const KIND_EFFECT_PLACE_VOXEL_APPLIED: u32 = 60;
+
+/// Cubic extent of the voxel terrain in cells. 256³ at 1 world-unit
+/// per cell covers the entire `[-128, 128]³` simulation volume — well
+/// past the spawner ring at `±64`. Memory cost: 256³ × 4 B = 64 MiB
+/// for the GPU mirror, paid once at startup. The chunked dirty
+/// tracking keeps per-tick upload bounded by `dirty_chunks × 8³`.
+pub const VOXEL_GRID_EXTENT: u32 = 256;
+
+/// World→voxel translation. The voxel grid lives in `[0, EXTENT)` cell
+/// coordinates; the simulation lives around the origin in roughly
+/// `[-64, 64]³`. We shift by `(128, 128, 128)` so the world origin
+/// maps to cell `(128, 128, 128)` and the entire spawner ring sits
+/// within positive-cell territory.
+///
+/// Used by `caster_pos_to_voxel_world`: a caster at simulation pos
+/// `(x, y, z)` lands in voxel cell
+/// `(floor(x + 128), floor(y + 128), floor(z + 128))`. The chronicle
+/// drain receives the *shifted* position so out-of-bounds clamping in
+/// `apply_voxel_chronicle_record` works correctly.
+pub const VOXEL_WORLD_ORIGIN: Vec3 = Vec3::new(128.0, 128.0, 128.0);
+
+/// Map a simulation-space position to the voxel grid's coordinate
+/// system. See [`VOXEL_WORLD_ORIGIN`].
+pub fn caster_pos_to_voxel_world(sim_pos: Vec3) -> Vec3 {
+    sim_pos + VOXEL_WORLD_ORIGIN
+}
+
 /// Map a u32 PCG draw to an f32 in [-SPAWN_JITTER, +SPAWN_JITTER].
 /// P5 channel — deterministic, no host-side RNG state.
 fn perturb_axis(draw: u32) -> f32 {
@@ -259,9 +295,9 @@ pub struct WaveDefenseState {
     agent_magic_resist_buf: wgpu::Buffer,
     agent_move_speed_buf: wgpu::Buffer,
 
-    // -- Mask bitmaps (6 verbs) --
+    // -- Mask bitmaps (7 verbs after Phase E voxel integration) --
     //   Harvest=0, Strike=1, SpawnSmall=2, SpawnMedium=3,
-    //   SpawnLarge=4, SpawnHorde=5
+    //   SpawnLarge=4, SpawnHorde=5, BuildPalisade=6
     // (matches the verb declaration order in `wave_defense.sim`).
     mask_0_bitmap_buf: wgpu::Buffer,
     mask_1_bitmap_buf: wgpu::Buffer,
@@ -269,6 +305,7 @@ pub struct WaveDefenseState {
     mask_3_bitmap_buf: wgpu::Buffer,
     mask_4_bitmap_buf: wgpu::Buffer,
     mask_5_bitmap_buf: wgpu::Buffer,
+    mask_6_bitmap_buf: wgpu::Buffer,
     mask_bitmap_zero_buf: wgpu::Buffer,
     mask_bitmap_words: u32,
 
@@ -313,6 +350,7 @@ pub struct WaveDefenseState {
     chronicle_spawn_medium_cfg_buf: wgpu::Buffer,
     chronicle_spawn_large_cfg_buf: wgpu::Buffer,
     chronicle_spawn_horde_cfg_buf: wgpu::Buffer,
+    chronicle_build_palisade_cfg_buf: wgpu::Buffer,
     monster_phys_cfg_buf: wgpu::Buffer,
     fold_cfg_buf: wgpu::Buffer,
     apply_damage_cfg_buf: wgpu::Buffer,
@@ -331,6 +369,48 @@ pub struct WaveDefenseState {
     /// tick. Indexed [0..SPAWNER_COUNT); maps caster_slot →
     /// (caster_slot - SPAWNER_SLOT_START).
     spawner_positions: [Vec3; SPAWNER_COUNT as usize],
+
+    /// Cached settler positions in *voxel-space* (= sim pos +
+    /// `VOXEL_WORLD_ORIGIN`). Settlers are stationary in this fixture
+    /// (no MoveBy / SetPos rules touch them), so the host can resolve
+    /// `caster_slot → voxel_pos` without round-tripping `agent_pos`
+    /// per tick. Indexed `[0..SETTLER_COUNT)`; maps `caster_slot`
+    /// (= SETTLER_SLOT_START + i) to the i-th settler's pre-shifted
+    /// voxel position. Used by the BuildPalisade chronicle drain.
+    settler_voxel_positions: [Vec3; SETTLER_COUNT as usize],
+
+    // -- Phase E voxel-engine integration --
+    /// Host-side voxel terrain — Settlers' `BuildPalisade` ability
+    /// emits EffectPlaceVoxelApplied (kind=60) chronicle records;
+    /// `drain_voxel_records` mutates this grid via
+    /// `apply_voxel_chronicle_record_with_mirror`. The host-side
+    /// terrain query path (`monsters_blocked_by_palisade` pin) reads
+    /// `walkable(...)` against this grid.
+    voxel_terrain: VoxelTerrain,
+    /// GPU-resident mirror of `voxel_terrain.grid()`. Wired into
+    /// `KernelBindingsContext::voxel_grid` for forward-compat — no
+    /// kernel in this fixture currently reads from it (monster
+    /// pathfinding stays on `agent_pos` deltas), but the binding is
+    /// in place so future DSL extensions can call `terrain.walkable`
+    /// from MonsterMarch without runtime re-plumbing.
+    voxel_mirror: VoxelMirror,
+    /// Wall-clock cost of the most recent `flush_dirty` call (ns).
+    /// Drives the per-fixture perf baseline appended to
+    /// `docs/perf/2026-05-09-stress-ceilings.md`.
+    last_flush_ns: u128,
+    /// Maximum `flush_dirty` cost seen across the run (ns). Reset
+    /// once at construction; the per-tick step bumps it.
+    max_flush_ns: u128,
+    /// Cumulative `flush_dirty` cost across the run (ns). Combined
+    /// with `flush_call_count` gives the mean per-call cost.
+    total_flush_ns: u128,
+    /// Number of `flush_dirty` invocations across the run. Bumped
+    /// once per tick (even when the dirty set is empty — the cost
+    /// stays meaningful because it reflects the per-tick overhead).
+    flush_call_count: u64,
+    /// Number of `EffectPlaceVoxelApplied` chronicle records drained
+    /// across the run. > 0 confirms BuildPalisade fired at least once.
+    total_palisade_records: u64,
 
     // -- Host-side game state --
     /// Host-side count of alive monsters in the pool. Bumped on summon
@@ -359,6 +439,20 @@ pub struct WaveDefenseResult {
     /// counter) at termination. > 0 confirms gain_skill plumbed end-
     /// to-end.
     pub total_settler_skill: f32,
+    /// Phase E voxel-engine integration — total
+    /// EffectPlaceVoxelApplied chronicle records drained (= number of
+    /// successful BuildPalisade casts across the run).
+    pub total_palisade_records: u64,
+    /// Phase E voxel-engine integration — total `flush_dirty`
+    /// invocations (= ticks executed; one flush per tick regardless of
+    /// dirty count).
+    pub flush_call_count: u64,
+    /// Phase E voxel-engine integration — peak `flush_dirty`
+    /// wall-clock cost across the run (ns).
+    pub max_flush_ns: u128,
+    /// Phase E voxel-engine integration — cumulative `flush_dirty`
+    /// wall-clock cost across the run (ns).
+    pub total_flush_ns: u128,
 }
 
 impl WaveDefenseState {
@@ -396,6 +490,7 @@ impl WaveDefenseState {
         // exact same coordinate (which would make each settler's
         // spatial-walk loop see itself first and per-pair predicates
         // can collide). P5: deterministic per slot index, no RNG.
+        let mut settler_voxel_positions = [Vec3::ZERO; SETTLER_COUNT as usize];
         for i in 0..SETTLER_COUNT {
             let slot = (SETTLER_SLOT_START + i) as usize;
             let angle = (i as f32) * std::f32::consts::TAU
@@ -405,11 +500,17 @@ impl WaveDefenseState {
             // Add a small per-slot z so settlers occupy distinct
             // (x, y, z) but stay inside one origin spatial cell.
             let z = 0.05 * (i as f32 - 12.0);
-            pos_padded[slot] = Vec3::new(x, y, z).into();
+            let sim_pos = Vec3::new(x, y, z);
+            pos_padded[slot] = sim_pos.into();
             alive_init[slot] = 1;
             hp_init[slot] = SETTLER_HP;
             max_hp_init[slot] = SETTLER_MAX_HP;
             creature_init[slot] = CREATURE_TYPE_SETTLER;
+            // Phase E voxel-engine integration: cache the settler's
+            // *shifted* voxel-space position. The chronicle drain
+            // skips a per-tick agent_pos readback by indexing into
+            // this array.
+            settler_voxel_positions[i as usize] = caster_pos_to_voxel_world(sim_pos);
         }
 
         // Spawners — 6 face midpoints at ±SPAWNER_DISTANCE.
@@ -546,6 +647,7 @@ impl WaveDefenseState {
         let mask_3_bitmap_buf = mk_mask("wave_defense_runtime::mask_3_bitmap");
         let mask_4_bitmap_buf = mk_mask("wave_defense_runtime::mask_4_bitmap");
         let mask_5_bitmap_buf = mk_mask("wave_defense_runtime::mask_5_bitmap");
+        let mask_6_bitmap_buf = mk_mask("wave_defense_runtime::mask_6_bitmap");
         let zero_words: Vec<u32> = vec![0u32; mask_bitmap_words.max(4) as usize];
         let mask_bitmap_zero_buf = gpu.device.create_buffer_init(
             &wgpu::util::BufferInitDescriptor {
@@ -803,6 +905,22 @@ impl WaveDefenseState {
                 usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             },
         );
+        // Phase E voxel-engine integration: BuildPalisade chronicle
+        // dispatcher cfg uniform. Same Cfg shape as the Spawn dispatchers.
+        let chronicle_build_palisade_cfg_init =
+            physics_verb_chronicle_BuildPalisade::PhysicsVerbChronicleBuildPalisadeCfg {
+                event_count: 0,
+                tick: 0,
+                seed: 0,
+                agent_cap: 0,
+            };
+        let chronicle_build_palisade_cfg_buf = gpu.device.create_buffer_init(
+            &wgpu::util::BufferInitDescriptor {
+                label: Some("wave_defense_runtime::chronicle_build_palisade_cfg"),
+                contents: bytemuck::bytes_of(&chronicle_build_palisade_cfg_init),
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            },
+        );
         let monster_phys_cfg_init = physics_MonsterMarch_and_MonsterCleaveScan::PhysicsMonsterMarchAndMonsterCleaveScanCfg {
             agent_cap: agent_count,
             tick: 0,
@@ -872,6 +990,17 @@ impl WaveDefenseState {
             },
         );
 
+        // Phase E voxel-engine integration. Construct the host
+        // terrain + GPU mirror at fixture startup (extent = 256 ³,
+        // mirror = 64 MiB). Subsequent ticks only push dirty chunks
+        // via `flush_dirty`. Wave_defense doesn't currently have a
+        // kernel that reads `voxel_grid`, but the binding lives on
+        // `KernelBindingsContext` for forward-compat — future
+        // monster-pathfinding rules that call `terrain.walkable` from
+        // MonsterMarch can opt in by lowering through `from_context`.
+        let voxel_terrain = VoxelTerrain::with_extent(VOXEL_GRID_EXTENT);
+        let voxel_mirror = VoxelMirror::new(&gpu, voxel_terrain.grid());
+
         Self {
             gpu,
             agent_pos_buf,
@@ -892,6 +1021,7 @@ impl WaveDefenseState {
             mask_3_bitmap_buf,
             mask_4_bitmap_buf,
             mask_5_bitmap_buf,
+            mask_6_bitmap_buf,
             mask_bitmap_zero_buf,
             mask_bitmap_words,
             scoring_output_buf,
@@ -917,6 +1047,7 @@ impl WaveDefenseState {
             chronicle_spawn_medium_cfg_buf,
             chronicle_spawn_large_cfg_buf,
             chronicle_spawn_horde_cfg_buf,
+            chronicle_build_palisade_cfg_buf,
             monster_phys_cfg_buf,
             fold_cfg_buf,
             apply_damage_cfg_buf,
@@ -925,6 +1056,14 @@ impl WaveDefenseState {
             registry_gpu,
             cache: dispatch::KernelCache::default(),
             spawner_positions,
+            settler_voxel_positions,
+            voxel_terrain,
+            voxel_mirror,
+            last_flush_ns: 0,
+            max_flush_ns: 0,
+            total_flush_ns: 0,
+            flush_call_count: 0,
+            total_palisade_records: 0,
             monster_pool_cursor: 0,
             consecutive_dead_ticks: 0,
             tick: 0,
@@ -1409,6 +1548,34 @@ impl WaveDefenseState {
         // Drain summon chronicle records into actual monster slot
         // allocations.
         let _spawned = self.drain_summon_records();
+        // Phase E voxel-engine integration: drain
+        // EffectPlaceVoxelApplied (kind=60) chronicle records into the
+        // host VoxelTerrain + GPU mirror. NOTE: this re-reads the
+        // event ring — wave_defense's `drain_summon_records` already
+        // submits a copy_buffer_to_buffer of the ring into
+        // `event_ring_staging`, but it consumes that staging buffer
+        // (unmaps it) once finished. The voxel drain re-issues the
+        // copy + map to keep the two drains decoupled (they could be
+        // fused into a single readback in a future polish slice; the
+        // per-tick cost is dwarfed by the GPU dispatch wall-clock).
+        let palisade_records = self.drain_voxel_records();
+        self.total_palisade_records += palisade_records as u64;
+        // Flush dirty chunks at end of tick so the next tick's GPU
+        // dispatches see fresh voxel state (forward-compat for
+        // future MonsterMarch terrain-aware lowerings; today no
+        // kernel reads voxel_grid so this is bookkeeping). Always
+        // call flush_dirty (even if dirty set is empty) so
+        // `last_flush_ns` reflects the per-tick overhead, not just
+        // the cost on PlaceVoxel-active ticks.
+        let t0 = Instant::now();
+        self.voxel_mirror
+            .flush_dirty(&self.gpu, self.voxel_terrain.grid());
+        self.last_flush_ns = t0.elapsed().as_nanos();
+        if self.last_flush_ns > self.max_flush_ns {
+            self.max_flush_ns = self.last_flush_ns;
+        }
+        self.total_flush_ns += self.last_flush_ns;
+        self.flush_call_count += 1;
         // Termination check: count alive settlers; track consecutive
         // zero-tick streak.
         let alive_settlers = self.alive_settler_count();
@@ -1426,6 +1593,166 @@ impl WaveDefenseState {
             return true;
         }
         false
+    }
+
+    /// Borrow the host-side voxel terrain (Phase E). The
+    /// `monsters_blocked_by_palisade` pin queries `walkable(...)` here
+    /// to prove placed palisades show up in the CPU terrain query.
+    pub fn voxel_terrain(&self) -> &VoxelTerrain {
+        &self.voxel_terrain
+    }
+
+    /// Wall-clock cost of the most recent `flush_dirty` call (ns).
+    /// Phase E perf instrumentation — appended to
+    /// `docs/perf/2026-05-09-stress-ceilings.md`.
+    pub fn last_flush_ns(&self) -> u128 {
+        self.last_flush_ns
+    }
+
+    /// Number of EffectPlaceVoxelApplied chronicle records drained
+    /// across the run so far. > 0 confirms BuildPalisade fired at
+    /// least once (the verb's `when` clause + scoring picked it).
+    pub fn total_palisade_records(&self) -> u64 {
+        self.total_palisade_records
+    }
+
+    /// Peak `flush_dirty` wall-clock cost across the run (ns).
+    pub fn max_flush_ns(&self) -> u128 {
+        self.max_flush_ns
+    }
+
+    /// Cumulative `flush_dirty` wall-clock cost across the run (ns).
+    pub fn total_flush_ns(&self) -> u128 {
+        self.total_flush_ns
+    }
+
+    /// Number of `flush_dirty` invocations across the run.
+    pub fn flush_call_count(&self) -> u64 {
+        self.flush_call_count
+    }
+
+    /// Drain EffectPlaceVoxelApplied (kind=60) chronicle records and
+    /// apply them to the host VoxelTerrain + GPU mirror. Returns the
+    /// number of palisade records applied this tick.
+    ///
+    /// Mirrors `drain_summon_records`'s shape — re-reads the event
+    /// ring into the per-tick staging buffer, then walks the records
+    /// filtering for `kind == KIND_EFFECT_PLACE_VOXEL_APPLIED`.
+    fn drain_voxel_records(&mut self) -> u32 {
+        let mut encoder = self.gpu.device.create_command_encoder(
+            &wgpu::CommandEncoderDescriptor {
+                label: Some("wave_defense_runtime::drain_voxel"),
+            },
+        );
+        encoder.copy_buffer_to_buffer(
+            &self.event_tail_buf,
+            0,
+            &self.event_tail_staging,
+            0,
+            4,
+        );
+        let cap = self
+            .event_ring_readback_slots
+            .min(EVENT_RING_CAP_SLOTS);
+        let stage_ring_bytes = (cap as u64) * (EVENT_STRIDE_U32 as u64) * 4;
+        encoder.copy_buffer_to_buffer(
+            &self.event_ring_buf,
+            0,
+            &self.event_ring_staging,
+            0,
+            stage_ring_bytes,
+        );
+        self.gpu.queue.submit(Some(encoder.finish()));
+
+        // Map tail then ring (mirrors `drain_summon_records`).
+        let tail_value = {
+            let slice = self.event_tail_staging.slice(..);
+            let (sender, receiver) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |r| {
+                let _ = sender.send(r);
+            });
+            self.gpu.device.poll(wgpu::PollType::Wait).expect("poll");
+            let _ = receiver.recv().expect("map_async tail result");
+            let mapped = slice.get_mapped_range();
+            let v: u32 = bytemuck::cast_slice::<u8, u32>(&mapped)[0];
+            drop(mapped);
+            self.event_tail_staging.unmap();
+            v
+        };
+
+        let actual_records = tail_value.min(cap) as usize;
+        if actual_records == 0 {
+            // Force unmap + early return.
+            let slice = self.event_ring_staging.slice(..);
+            let (sender, receiver) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |r| {
+                let _ = sender.send(r);
+            });
+            self.gpu.device.poll(wgpu::PollType::Wait).expect("poll");
+            let _ = receiver.recv().expect("map_async ring result");
+            self.event_ring_staging.unmap();
+            return 0;
+        }
+
+        let records: Vec<[u32; 10]> = {
+            let slice = self.event_ring_staging.slice(..);
+            let (sender, receiver) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |r| {
+                let _ = sender.send(r);
+            });
+            self.gpu.device.poll(wgpu::PollType::Wait).expect("poll");
+            let _ = receiver.recv().expect("map_async ring result");
+            let mapped = slice.get_mapped_range();
+            let words: &[u32] = bytemuck::cast_slice(&mapped);
+            let mut out: Vec<[u32; 10]> = Vec::with_capacity(actual_records);
+            for r in 0..actual_records {
+                let base = r * (EVENT_STRIDE_U32 as usize);
+                let mut rec = [0u32; 10];
+                rec.copy_from_slice(&words[base..base + 10]);
+                out.push(rec);
+            }
+            drop(mapped);
+            self.event_ring_staging.unmap();
+            out
+        };
+
+        // Filter for kind=60 (EffectPlaceVoxelApplied). Slot layout:
+        //   [0] = 60
+        //   [1] = tick
+        //   [2] = caster_slot (= settler agent_id)
+        //   [3] = kind_hash   (= FxHash("palisade"))
+        // Walk records in ring order (deterministic per the chronicle
+        // emit ordering). For each record, resolve `caster_slot →
+        // voxel_pos` against the cached settler positions (settlers
+        // are stationary in this fixture) and call
+        // `apply_voxel_chronicle_record_with_mirror` which mutates
+        // the CPU grid AND marks dirty chunks in the GPU mirror.
+        let mut applied: u32 = 0;
+        for rec in &records {
+            if rec[0] != KIND_EFFECT_PLACE_VOXEL_APPLIED {
+                continue;
+            }
+            let caster_slot = rec[2];
+            // Map caster_slot → cached settler voxel-position. Out-of-
+            // range slots (a non-settler somehow firing the verb)
+            // get skipped — defensive against future verb-graph
+            // changes.
+            if caster_slot < SETTLER_SLOT_START
+                || caster_slot >= SETTLER_SLOT_START + SETTLER_COUNT
+            {
+                continue;
+            }
+            let voxel_pos =
+                self.settler_voxel_positions[(caster_slot - SETTLER_SLOT_START) as usize];
+            self.voxel_terrain
+                .apply_voxel_chronicle_record_with_mirror(
+                    rec,
+                    voxel_pos,
+                    &mut self.voxel_mirror,
+                );
+            applied += 1;
+        }
+        applied
     }
 }
 
@@ -1464,6 +1791,7 @@ impl CompiledSim for WaveDefenseState {
             &self.mask_3_bitmap_buf,
             &self.mask_4_bitmap_buf,
             &self.mask_5_bitmap_buf,
+            &self.mask_6_bitmap_buf,
         ] {
             encoder.copy_buffer_to_buffer(
                 &self.mask_bitmap_zero_buf,
@@ -1588,6 +1916,7 @@ impl CompiledSim for WaveDefenseState {
                 mask_3_bitmap: &self.mask_3_bitmap_buf,
                 mask_4_bitmap: &self.mask_4_bitmap_buf,
                 mask_5_bitmap: &self.mask_5_bitmap_buf,
+                mask_6_bitmap: &self.mask_6_bitmap_buf,
                 cfg: &self.mask_cfg_buf,
             },
             &self.gpu.device,
@@ -1628,6 +1957,7 @@ impl CompiledSim for WaveDefenseState {
                 mask_3_bitmap: &self.mask_3_bitmap_buf,
                 mask_4_bitmap: &self.mask_4_bitmap_buf,
                 mask_5_bitmap: &self.mask_5_bitmap_buf,
+                mask_6_bitmap: &self.mask_6_bitmap_buf,
                 scoring_output: &self.scoring_output_buf,
                 ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
                 ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
@@ -1774,6 +2104,23 @@ impl CompiledSim for WaveDefenseState {
             PhysicsVerbChronicleSpawnHordeBindings,
             chronicle_spawn_horde_cfg_buf,
             dispatch_physics_verb_chronicle_spawnhorde
+        );
+
+        // (7b) Phase E voxel-engine integration: BuildPalisade chronicle
+        // dispatcher. Settler self-cast verb gated by tick window
+        // (`world.tick < small_to_medium && world.tick % palisade_period
+        // == 0`). Same Bindings shape as the Spawn dispatchers — the
+        // dispatcher walks the BuildPalisade ability program (single
+        // `place_voxel "palisade"` effect), writing one
+        // EffectPlaceVoxelApplied (kind=60) record per cast into the
+        // event ring. The host drains those records in
+        // `drain_voxel_records` after `step_and_check_termination`.
+        spawn_dispatch!(
+            physics_verb_chronicle_BuildPalisade,
+            PhysicsVerbChronicleBuildPalisadeCfg,
+            PhysicsVerbChronicleBuildPalisadeBindings,
+            chronicle_build_palisade_cfg_buf,
+            dispatch_physics_verb_chronicle_buildpalisade
         );
 
         // (8) MonsterMarch + MonsterCleaveScan fused per_agent kernel.
@@ -2005,6 +2352,10 @@ pub fn run_until_death(seed: u64, max_ticks: u64) -> Option<WaveDefenseResult> {
                         total_monsters_spawned,
                         max_concurrent_monsters,
                         total_settler_skill,
+                        total_palisade_records: state.total_palisade_records,
+                        flush_call_count: state.flush_call_count,
+                        max_flush_ns: state.max_flush_ns,
+                        total_flush_ns: state.total_flush_ns,
                     });
                 }
                 total_monsters_spawned = total_monsters_spawned.max(ms);
@@ -2020,6 +2371,10 @@ pub fn run_until_death(seed: u64, max_ticks: u64) -> Option<WaveDefenseResult> {
                     total_monsters_spawned,
                     max_concurrent_monsters,
                     total_settler_skill,
+                    total_palisade_records: state.total_palisade_records,
+                    flush_call_count: state.flush_call_count,
+                    max_flush_ns: state.max_flush_ns,
+                    total_flush_ns: state.total_flush_ns,
                 });
             }
         }
@@ -2035,6 +2390,10 @@ pub fn run_until_death(seed: u64, max_ticks: u64) -> Option<WaveDefenseResult> {
         total_monsters_spawned,
         max_concurrent_monsters,
         total_settler_skill,
+        total_palisade_records: state.total_palisade_records,
+        flush_call_count: state.flush_call_count,
+        max_flush_ns: state.max_flush_ns,
+        total_flush_ns: state.total_flush_ns,
     })
 }
 
@@ -2045,6 +2404,10 @@ pub fn run_until_death(seed: u64, max_ticks: u64) -> Option<WaveDefenseResult> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Bring TerrainQuery into scope so the
+    // `monsters_blocked_by_palisade` pin can call `walkable(...)` on
+    // the VoxelTerrain instance.
+    use engine::terrain::TerrainQuery;
 
     /// Plan task 4: drive up to max_ticks=DEFAULT_MAX_TICKS; assert
     /// `result.died_at_tick < DEFAULT_MAX_TICKS` AND
@@ -2166,6 +2529,161 @@ mod tests {
              beyond that, the race is destabilising the score signal.",
             r1.score, r2.score,
         );
+    }
+
+    /// **Phase E voxel-engine integration semantic pin.** After a
+    /// short run, BuildPalisade must have fired at least 3 times AND
+    /// the placed cells must register as `walkable = false` against
+    /// the host VoxelTerrain. This is the "fixture-level proof
+    /// terrain matters" pin from the plan — settlers fire
+    /// `place_voxel "palisade"` per the verb's `when` gate; the
+    /// chronicle drain mutates the CPU grid; subsequent
+    /// `terrain.walkable(pos, Walk)` reads return false at the
+    /// placed cells.
+    ///
+    /// **Why this is the pin shape, not "monster-position
+    /// quantitative test".** Wave_defense's MonsterMarch is a GPU
+    /// kernel that today does NOT read `voxel_grid` (no DSL surface
+    /// for `terrain.walkable` in MonsterMarch yet — that's a future
+    /// slice). The chain is:
+    ///
+    ///   1. settlers cast BuildPalisade → chronicle records emitted
+    ///   2. host drain mutates VoxelTerrain → walkable() returns false
+    ///   3. (future) MonsterMarch lowering calls walkable() in WGSL
+    ///      and refuses the next-step delta when the cell is solid
+    ///
+    /// Steps 1-2 are this slice; step 3 is deferred. The pin
+    /// asserts steps 1+2 hold so future GPU lowering of step 3 lands
+    /// on a tested foundation. Don't substitute a counter-only pin
+    /// like "palisade_records > 0" — that's the probe-fooling
+    /// pattern (FlatPlane'd silently pass it). The walkable()
+    /// assertion is the load-bearing semantic check.
+    ///
+    /// Skips on hosts without a wgpu adapter.
+    #[test]
+    fn monsters_blocked_by_palisade() {
+        // Drive a short run (200 ticks) — long enough for several
+        // BuildPalisade casts (every 50 ticks: 0, 50, 100, 150) at
+        // multiple settler positions, but bounded so the test stays
+        // fast even on cold-cache hosts.
+        const TEST_TICKS: u64 = 200;
+        let result = match run_until_death(0, TEST_TICKS) {
+            Some(r) => r,
+            None => {
+                eprintln!(
+                    "[monsters_blocked_by_palisade] skipping: GPU init failed"
+                );
+                return;
+            }
+        };
+
+        // (1) BuildPalisade fired enough times. Chrome cadence: every
+        // 50 ticks (per palisade_period config), 25 settlers at
+        // origin → up to 25 records per cadence-tick. Bound: at
+        // tick=0 + tick=50 + tick=100 + tick=150 in our 200-tick
+        // run we expect 4 cadence-ticks; even with score-conflict
+        // suppression (Strike preempts when monsters near) we
+        // should land at least 3 records cumulatively.
+        assert!(
+            result.total_palisade_records >= 3,
+            "expected >= 3 BuildPalisade chronicle records across {} \
+             ticks (cadence every 50 ticks for {} settlers); got {}. \
+             Chronicle drain may not be wired, or BuildPalisade's \
+             score (1500) lost to Strike/Harvest more than expected.",
+            TEST_TICKS,
+            SETTLER_COUNT,
+            result.total_palisade_records,
+        );
+
+        // (2) Placed cells must register as walkable=false in the
+        // host VoxelTerrain. We rebuild a fresh fixture + drive the
+        // same number of ticks so we can introspect `voxel_terrain`
+        // (run_until_death consumes the state). Same-seed → same
+        // chronicle drain order → same cells placed (P5).
+        let state = match run_n_ticks_for_introspection(0, TEST_TICKS) {
+            Some(s) => s,
+            None => return,
+        };
+        // Walk the cached settler voxel-positions; for each settler
+        // that landed a palisade, the floor cell at its position
+        // should be solid (cell_at != 0) AND walkable() should
+        // return false there. We only assert for settlers in the
+        // positive-cell octant (some settlers' z's land at 127.4
+        // which still floors to 127 — well in-bounds at extent=256;
+        // shifted by VOXEL_WORLD_ORIGIN=(128,128,128) we're safely
+        // positive).
+        let mut blocked_count = 0_u32;
+        for i in 0..SETTLER_COUNT {
+            let pos = state.settler_voxel_positions[i as usize];
+            let cell_x = pos.x.floor() as i32;
+            let cell_y = pos.y.floor() as i32;
+            let cell_z = pos.z.floor() as i32;
+            let cell_value = state.voxel_terrain().cell_at(cell_x, cell_y, cell_z);
+            let walkable = state.voxel_terrain().walkable(
+                pos,
+                engine_voxel::MovementMode::Walk,
+            );
+            if cell_value != 0 {
+                assert!(
+                    !walkable,
+                    "settler {i} placed a palisade at cell ({cell_x}, \
+                     {cell_y}, {cell_z}) (value={cell_value}) but \
+                     walkable() returned true — terrain query and \
+                     voxel mutation disagree. Phase E plumbing broken: \
+                     either the chronicle drain wrote the wrong cell, \
+                     or walkable() reads a different grid.",
+                );
+                blocked_count += 1;
+            }
+        }
+        // At least one settler's path-cell should be blocked.
+        assert!(
+            blocked_count >= 1,
+            "expected >= 1 settler path-cell to be blocked by a placed \
+             palisade; got {blocked_count}. The chronicle drain landed \
+             {} records but none of the cached settler voxel-positions \
+             have non-zero cells — chronicle drain may be applying to \
+             wrong coordinates, or settler_voxel_positions is stale.",
+            result.total_palisade_records,
+        );
+        eprintln!(
+            "[monsters_blocked_by_palisade] palisade_records={} \
+             blocked_settler_cells={}/{} (proves CPU terrain query \
+             reflects mutations). flush_dirty: max={:.2} us, mean={:.2} us \
+             across {} ticks.",
+            result.total_palisade_records,
+            blocked_count,
+            SETTLER_COUNT,
+            result.max_flush_ns as f64 / 1000.0,
+            (result.total_flush_ns as f64 / result.flush_call_count.max(1) as f64) / 1000.0,
+            result.flush_call_count,
+        );
+    }
+
+    /// Helper for the `monsters_blocked_by_palisade` pin — re-runs
+    /// the fixture for `n` ticks and returns the live state so the
+    /// caller can introspect `voxel_terrain()` + the cached settler
+    /// voxel positions. `run_until_death` consumes its state; we
+    /// need a separate path that exposes the post-run state.
+    fn run_n_ticks_for_introspection(seed: u64, n: u64) -> Option<WaveDefenseState> {
+        let init = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            WaveDefenseState::new(seed)
+        }));
+        let mut state = match init {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
+        for _ in 0..n {
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                state.step_and_check_termination()
+            }));
+            match outcome {
+                Ok(true) => break,  // settlement fell early; pin runs anyway
+                Ok(false) => {}
+                Err(_) => break,
+            }
+        }
+        Some(state)
     }
 
     /// Plan task #249 piece 2: gain_skill behavioral pin. After a run

--- a/docs/engine/status.md
+++ b/docs/engine/status.md
@@ -28,13 +28,17 @@ files in `docs/superpowers/specs/` and the active plans in `docs/superpowers/pla
 | GPU cold-state replay umbrella (Subsystem 2) | `docs/superpowers/plans/2026-04-22-gpu-cold-state-replay.md` | ⚠️ Phase 1 done; Phases 2–4 are explicit future work |
 | Plan 4 — debug & trace runtime | _(to be written)_ | ❌ not yet written |
 | Ability DSL implementation | _(execution log in git history; LoL canary saturated 2026-05-06)_ | ✅ lowering 100% (172/172 LoL files) — apply handlers + GPU dispatch (`#125` family) in flight |
+| Voxel terrain integration | `docs/superpowers/plans/2026-05-09-voxel-engine-integration.md` | ✅ COMPLETE 2026-05-09 — `engine_voxel` adapter (CPU + GPU mirror), DSL `terrain.X(...)` lowers to WGSL helpers, `wave_defense_runtime` opts in via settler `BuildPalisade` casts; 6 semantic + 1 determinism + 1 fixture-level pin all green |
 | Economic depth implementation | _(to be planned from `docs/spec/economy.md`)_ | ❌ not yet planned |
 
 Deferred subsystems (factions, items, buildings, settlements, regions, personality
 utility, interior nav) are indexed in `docs/superpowers/roadmap.md`. Subsystems with
 DSL stub primitives partially landed (memberships, memory, relationships, groups,
-quests, theory-of-mind) and terrain (MVP `TerrainQuery` trait seam in `crates/engine/src/terrain.rs`)
-are partially in flight; full behaviour attachment is pending.
+quests, theory-of-mind) are partially in flight; full behaviour attachment is
+pending. Terrain is no longer in this category — Phase E of the voxel-engine
+integration plan (2026-05-09) shipped real `engine_voxel::VoxelTerrain` + GPU
+mirror; the `FlatPlane` default trait impl stays as the no-op fallback for
+fixtures that don't opt in.
 
 ## Subsystem table
 

--- a/docs/perf/2026-05-09-stress-ceilings.md
+++ b/docs/perf/2026-05-09-stress-ceilings.md
@@ -272,3 +272,94 @@ qualifies; the metric will become more interesting on fixtures with
 multi-faction predicates or per-pair candidate masks where the
 hit rate distinguishes "predicate filtered useful candidates" from
 "every candidate trivially passes."
+
+## Voxel mirror upload cost — wave_defense baseline
+
+Phase E of the voxel-engine integration plan
+(`docs/superpowers/plans/2026-05-09-voxel-engine-integration.md`)
+opted `wave_defense_runtime` into `engine_voxel::VoxelTerrain` +
+`VoxelMirror`. Settlers self-cast a new `BuildPalisade` ability
+(`place_voxel "palisade"`) every `palisade_period = 50` ticks during
+the early game (tick < 1000); the chronicle drain mutates the host
+VoxelTerrain AND marks dirty chunks in the GPU mirror; end-of-tick
+`flush_dirty(...)` re-uploads the dirty chunks.
+
+Run host: same as fixtures A/B above (Linux x86_64, wgpu adapter
+selected by `Backends::all`). Command:
+`RUST_MIN_STACK=33554432 cargo run --release --bin wave_defense_app -- 0`.
+
+| Metric                                          | Value                  |
+|-------------------------------------------------|------------------------|
+| Mirror buffer size (256³ × 4 B)                 | 64 MiB (alloc once)    |
+| Mirror chunk dim                                | 8³ cells = 2 KiB / chunk |
+| Run length                                      | 361 ticks              |
+| died_at_tick                                    | 360                    |
+| Score (= node mana)                             | 3350                   |
+| `BuildPalisade` chronicle records drained total | 175                    |
+| `flush_dirty` invocations                       | 361 (1 per tick)       |
+| `flush_dirty` median (per-tick)                 | 5.83 µs (mean, see below) |
+| `flush_dirty` p99 / max                         | 325.42 µs              |
+| `flush_dirty` total wall-clock                  | 2.10 ms across 361 ticks |
+| Per-tick mean overhead                          | 5.83 µs                |
+
+(Mean reported in lieu of true median because the per-tick perf is
+captured as `total_flush_ns / flush_call_count`; per-tick samples
+aren't streamed individually. The max captures the warmup tick where
+the host writes the first dirty chunks AND the once-only WGSL
+pipeline-cache cost on first dispatch — same artifact as cast_density
+fixture B's first-tick spike.)
+
+### Comparison vs. Phase C voxel_probe baseline
+
+Phase C's `voxel_probe_runtime::cpu_gpu_voxel_state_matches` pin
+reported `flush_dirty: max=162 µs, mean=11.46 µs` on the same host
+across 30 ticks (16³ extent). Wave_defense's numbers per the table:
+
+| Fixture                  | Extent   | Run length | Per-tick mean (µs) | Per-tick max (µs) |
+|--------------------------|----------|------------|--------------------|--------------------|
+| voxel_probe (Phase C)    | 16³      | 30 ticks   | 11.46              | 162                |
+| wave_defense (Phase E)   | 256³     | 361 ticks  | 5.83               | 325                |
+
+**Findings:**
+
+- **Per-tick mean dropped 50% (11.46 µs → 5.83 µs)** despite the 16×
+  extent jump (256³ vs 16³). The per-tick cost is dominated by the
+  empty-dirty-set fast-path (`if dirty_chunks.is_empty() { return; }`
+  in `VoxelMirror::flush_dirty`); wave_defense's BuildPalisade fires
+  only every 50 ticks, so 49/50 ticks return immediately. voxel_probe
+  fires every tick (PlaceTestVoxel at tick=0, Harvest at tick%10==5),
+  so the empty-dirty-set fast path engages less often.
+- **Per-tick max grew 2× (162 µs → 325 µs)** — expected from the
+  larger 64 MiB GPU buffer; first-tick allocation + initial whole-
+  buffer upload take longer at 256³ than 16³. Steady-state ticks
+  (where only the touched 8³ chunks re-upload) are unchanged in
+  cost regardless of total buffer size.
+- **Total per-run cost is 2.10 ms** across 361 ticks — well below the
+  plan's 1 ms/tick threshold for triggering a follow-up GPU↔GPU
+  interop investigation. CPU-mirror-then-upload is viable for
+  wave_defense's PlaceVoxel cadence (175 records over 360 ticks =
+  0.49 records/tick avg, 25 settlers × 1 record / 50 ticks =
+  0.5 records/tick theoretical).
+- **No GPU-interop follow-up filed.** The cross-cutting risk #1 in
+  the voxel-engine integration plan (`Phase E records the actual
+  cost; if it exceeds 1 ms/tick at the production-fixture rate,
+  that's the trigger to revisit GPU↔GPU interop`) does NOT trip at
+  wave_defense's cadence. A future PlaceVoxel-heavy fixture (e.g.
+  fire-spreads-every-tick at 1000+ records/tick) would re-trigger
+  the question — but the current fixture has plenty of headroom.
+
+### Next stride opportunities (not blocking this slice)
+
+- Stream per-tick `flush_dirty` samples to the existing NDJSON
+  output so the perf doc gets true median + p99 instead of mean
+  derived from totals.
+- Bench a hypothetical "every settler builds every tick" path
+  (palisade_period=1) to find the actual upper-bound on per-tick
+  mirror upload cost before GPU↔GPU interop becomes the obvious
+  next stride.
+- Wire `terrain.walkable(...)` lowering into `MonsterMarch` so
+  monsters actually pathfind around palisades — Phase E ships the
+  voxel terrain but doesn't yet make the GPU sim consume it
+  (the `monsters_blocked_by_palisade` pin proves the host CPU
+  query reflects mutations; the GPU sim consumption is the next
+  slice).

--- a/docs/superpowers/plans/2026-05-09-voxel-engine-integration.md
+++ b/docs/superpowers/plans/2026-05-09-voxel-engine-integration.md
@@ -1,0 +1,174 @@
+# Voxel-Engine Integration — Bridge `~/Projects/voxel_engine` to the Sim Engine
+
+> **Status: COMPLETE (2026-05-09)** — All 5 phases shipped. PR train: #69 (Phase A) → #70 (Phase B) → #71 (Phase C) → #72 (Phase D) → this PR (Phase E). After this slice `place_voxel` / `harvest` / terrain-aware queries do real work on both CPU and GPU; one production fixture (`wave_defense_runtime`) opts in via settler `BuildPalisade` casts; per-tick mirror upload cost baselined at 5.83 µs mean / 325 µs max in `docs/perf/2026-05-09-stress-ceilings.md`.
+
+> Goal: connect the Vulkan-based `voxel_engine` repo to this sim engine via the existing `TerrainQuery` seam + chronicle event consumers + a **GPU-resident voxel mirror** that sim kernels can read directly. After this slice `place_voxel` / `harvest` / terrain-aware queries do real work, AND the GPU dispatcher can ask terrain questions without a CPU round-trip.
+
+## Goal
+
+Today the sim engine has a 3-method `TerrainQuery` trait (`crates/engine/src/terrain.rs`) with one impl: `FlatPlane` returning yes-to-everything. The DSL surface for `place_voxel <kind_hash>` and `harvest <kind_hash> <amount>` lowers cleanly through the compiler and emits chronicle events `EffectPlaceVoxelApplied=60` / `EffectHarvestApplied=59`, but no runtime consumes them. Meanwhile `~/Projects/voxel_engine/` has a full Vulkan voxel world (chunks, spatial hash, GPU compute) that nothing in this project links to.
+
+**Today's terrain access pattern (verified):** ONE caller — `crates/engine/src/policy/utility.rs:358` invokes `state.terrain.line_of_sight(from, to)` from the CPU policy path. Zero WGSL emit sites lower terrain queries today; the DSL surface in `dsl_ast/src/resolve.rs` documents the methods but no kernel uses them. So a CPU-only `Arc<dyn TerrainQuery>` adapter would compile + work today.
+
+**Why a CPU-only adapter is the wrong stopping point:** the moment a sim kernel needs terrain (settlers checking line-of-sight to monsters during scoring; agents avoiding solid voxels in pathing), CPU-side trait dispatch becomes a per-tick × per-agent CPU↔GPU round-trip. At 200k agents × 10 Hz that's 2M trait-object calls/sec across the bus. Catastrophic. The slice has to land GPU-side voxel access in the same plan, not as an unbounded "future work."
+
+**After this slice:**
+- `Forager.ability` actually places palisades and harvests berries.
+- `TerrainQuery::height_at(x, y)` returns the highest occupied voxel in column (x, y) on CPU.
+- `walkable(pos, Walk)` returns `false` inside solid rock on CPU.
+- A wgpu storage-buffer mirror of the voxel grid is bound into kernels as a `KernelBindingsContext` source; WGSL emit lowers `terrain.line_of_sight(from, to)` to a function call that reads the buffer.
+- 4 behavioral pins (semantic, not threshold) catch the "FlatPlane silently passes" probe-fooling pattern. A 5th catches the CPU/GPU mirror divergence pattern.
+
+## Architectural Impact Statement
+
+- **Existing primitives searched:**
+  - `crates/engine/src/terrain.rs` — `TerrainQuery` trait + `FlatPlane` default impl + `Arc<dyn TerrainQuery>` field on `SimState` (line 234).
+  - `crates/engine/src/state/mod.rs:234` — `pub terrain: Arc<dyn TerrainQuery + Send + Sync>` already plumbed.
+  - `~/Projects/voxel_engine/src/{lib,world/{chunks,spatial,mod},terrain_compute}.rs` — concrete voxel world. Vulkan-based (ash/gpu-allocator deps); separate workspace.
+  - `crates/engine/src/ability/program.rs::EffectOp::PlaceVoxel` (variant 26) + `EffectOp::Harvest` (variant 25) — IR variants exist + dispatcher emits chronicle records.
+  - `EventKindId::EffectPlaceVoxelApplied = 60` + `EffectHarvestApplied = 59` — event ordinals reserved.
+  - `assets/ability_test/dsl_coverage/Forager.ability` — already-authored fixture exercising both verbs (ForageBerries, QuarryStrike, RaisePalisade, StockpileRun).
+  - `docs/superpowers/notes/2026-04-22-terrain-integration-gap.md` — the design doc that recommended Option B (separate adapter crate).
+
+  Search method: `rg` + `Read` + `find`.
+
+- **Decision:** new `crates/engine_voxel/` adapter crate. Wraps `~/Projects/voxel_engine` (added as a path dependency in workspace Cargo.toml). Implements `TerrainQuery` for a `VoxelTerrain` struct that owns a CPU-side voxel world (uses voxel_engine's `world::*` modules; deliberately skips `vulkan::*` to avoid pulling Vulkan deps into the sim engine's wgpu world). Per-fixture runtimes that want voxel terrain construct `Arc::new(VoxelTerrain::new())` and pass it to `SimState::with_terrain(...)` instead of accepting the `FlatPlane` default.
+
+  The adapter crate owns three responsibilities:
+  1. **CPU-side voxel world** — for the legacy CPU policy callers (line_of_sight at policy/utility.rs:358).
+  2. **Chronicle event consumer** — `apply_voxel_chronicle_record(&mut self, rec: &[u32; STRIDE])` drains `EffectPlaceVoxelApplied` / `EffectHarvestApplied` into voxel mutations.
+  3. **GPU-resident mirror** — a `wgpu::Buffer` that holds a flat encoding of the voxel grid (chunked or hashmap-of-chunks). Updated on every chronicle drain. Exposed as a `&'a wgpu::Buffer` field on `KernelBindingsContext` so compiler-emitted `from_context()` constructors pull it in just like `agent_pos_buf` etc.
+
+  **Why a new crate, not in-tree:** voxel_engine pulls Vulkan deps (`ash`, `gpu-allocator`, `shaderc` build dep) when its `vulkan::*` modules are used. We use only `world::*` here; even so, the adapter crate isolates the dep tree so engine consumers without voxel terrain don't pay the voxel_engine compile cost.
+
+  **Why CPU-mirror-then-upload, not GPU↔GPU interop:** voxel_engine and sim engine are both GPU-resident, but in different APIs (Vulkan via ash vs. wgpu). True interop options exist (shared `VkDevice` via `wgpu_hal::vulkan::Adapter::from_raw_device`, external memory FDs via `VK_KHR_external_memory_fd`, or flipping to a single-engine architecture where voxel_engine owns the device). All of them are bigger surface than the slice can absorb, and the per-mutation upload cost of the CPU mirror is bounded by chronicle event rate (PlaceVoxel + Harvest fire only on cast — single-digit kHz at most for the fixtures we're planning, vs. millions of GPU reads per tick). Pick the simpler architecture; revisit when measurement says it's the bottleneck.
+
+- **Rule-compiler touchpoints:**
+  - DSL inputs added: a new fixture `assets/sim/voxel_probe.sim` (small) + `assets/ability_test/voxel_probe/{PlaceTestVoxel,HarvestTestVoxel}.ability`. Existing `Forager.ability` stays as a corpus fixture; the probe fixture is the behavioral-pin testbed.
+  - Generated outputs emitted: per-runtime build.rs auto-regen for the new probe runtime; no other regen needed.
+  - **No compiler changes.** The chronicle events + WGSL emit already exist (Slice γ tail, May 7).
+
+- **Hand-written downstream code:**
+  - `crates/engine_voxel/src/lib.rs` — `VoxelTerrain` struct + `TerrainQuery` impl + `apply_voxel_chronicle_record()` consumer. Justified: the engine deliberately doesn't depend on voxel_engine; this adapter is the seam. NOT compiler-emittable (it's a host-side adapter, not a kernel).
+  - `crates/voxel_probe_runtime/src/lib.rs` — fixture runtime, follows the existing per-runtime pattern. Per-tick: dispatch the GPU kernels (compiler-emitted), then drain chronicle records into the voxel terrain via the adapter.
+
+- **Constitution check:**
+  - P1 (Compiler-First): PASS — chronicle event production is compiler-emitted; the consumer is a *host-side adapter*, not a hand-written `Rule`. The trait-object `Arc<dyn TerrainQuery>` pattern is already established (FlatPlane is a hand-written impl too — adapter is the same shape, just with a real backend).
+  - P2 (Schema-Hash): PASS — voxel state lives in the adapter crate, NOT in `SimState` SoA. The `Arc<dyn TerrainQuery>` field already exists on `SimState`; we're just supplying a different impl. Schema unchanged.
+  - P3 (Cross-Backend Parity): PASS — `TerrainQuery` is CPU-side; both `SerialBackend` and `GpuBackend` consult the same trait through the same Arc. Parity by construction.
+  - P4 (`EffectOp` Size Budget): N/A — no new variants.
+  - P5 (Determinism via Keyed PCG): PASS — voxel mutations are pure functions of chronicle records (which are themselves deterministic). Adapter must use deterministic data structures (BTreeMap, or sort keys before iterating Vec). voxel_engine's chunks may use HashMap — verify and either replace or sort-then-fold.
+  - P6 (Events Are the Mutation Channel): PASS — voxel state mutates *only* in response to drained chronicle records. No direct `&mut SimState` writes.
+  - P7 (Replayability Flagged): N/A — events already declared `@replayable`.
+  - P8 (AIS Required): PASS — this section.
+  - P9 (Tasks Close With Verified Commit): PASS — phase tasks each close with a commit.
+  - P10 (No Runtime Panic): PASS — `VoxelTerrain::new()` returns `Result`; queries return defaults on out-of-bounds (e.g. `height_at` on unloaded chunk returns 0).
+  - P11 (Reduction Determinism): PASS — chronicle record drain order is determined by ring slot order (deterministic by tick); voxel writes are commutative within a tick (last write per cell wins, but writes to *different* cells commute trivially). If a tick produces multiple writes to the *same* cell, sort by source AgentId then apply — same convention as the AOE bitonic sort (PR #39).
+
+- **Runtime gate:** the load-bearing test against probe-fooling. Three behavioral pins, each catching a class of FlatPlane-passes-trivially failure:
+  - `placed_voxel_changes_height_at` — start with empty terrain, fire `place_voxel` for a cell at (5, 5, 5), assert subsequent `terrain.height_at(5, 5)` returns ≥5 (FlatPlane returns 0 → fails).
+  - `solid_voxel_blocks_walkable` — place voxel at (10, 10, 10), assert `terrain.walkable(Vec3(10, 10, 10), Walk)` returns false (FlatPlane returns true → fails).
+  - `voxel_blocks_line_of_sight` — place voxel at (5, 5, 5), assert `terrain.line_of_sight(Vec3(0,0,5), Vec3(10,10,5))` returns false because the segment crosses the placed cell (FlatPlane returns true → fails).
+
+  Plus a determinism pin: `same_seed_same_voxel_world` — run the probe runtime twice with the same seed, assert the final voxel world hashes identically.
+
+- **Re-evaluation:** [x] AIS reviewed at design phase (initial fill).  [ ] AIS reviewed post-design.
+
+---
+
+## Phasing — 5 PRs
+
+The slice is too large for one PR. Each phase ships a viable end state. Phases A+B prove the CPU side; phase C is the perf-fix that makes the slice viable for real fixtures; phase D wires GPU emit; phase E proves it on a production fixture.
+
+### Phase A — Adapter crate skeleton + CPU-side `VoxelTerrain` (~400 LOC)
+
+Goal: prove the wiring without changing any behavior. CPU-only; GPU mirror comes in phase C.
+
+- New `crates/engine_voxel/{Cargo.toml, src/lib.rs}`. Add to workspace members. `voxel_engine = { path = "/home/ricky/Projects/voxel_engine" }` as path dep, restricted to `world::*` modules (no `vulkan::*` — verify Cargo features can isolate this; if not, document the dep cost).
+- `pub struct VoxelTerrain { world: voxel_engine::world::VoxelWorld /* or equivalent */ }`. Implement `TerrainQuery` for it: `height_at` walks the column at (x, y); `walkable(pos, mode)` checks the cell at `floor(pos)`; `line_of_sight(from, to)` raycasts via voxel_engine's terrain_compute or a CPU port.
+- Add `pub fn apply_voxel_chronicle_record(&mut self, rec: &[u32; STRIDE]) -> Option<()>` returning `None` (no-op) — to be filled in phase B.
+- **Determinism audit**: voxel_engine's chunk storage may use HashMap. Verify in this phase. If yes, replace with `BTreeMap<ChunkCoord, Chunk>` at the adapter boundary or sort keys before any iteration. P5 / P11 violation risk if missed.
+- Tests: `VoxelTerrain::new()` constructs cleanly; the 3 trait methods on an empty world produce sensible defaults (height 0, walkable true, LOS true — same as FlatPlane initially).
+
+**Behavioral pin:** existing fixtures still pass (no runtime opts in yet). Schema unchanged.
+
+### Phase B — Voxel probe runtime + chronicle event consumer (~700 LOC)
+
+Goal: PlaceVoxel + Harvest events actually mutate the voxel world. CPU-side only; GPU access still pending.
+
+- New `crates/voxel_probe_runtime/{Cargo.toml, build.rs, src/lib.rs}` mirroring `debug_probe_runtime`'s shape. Constructs `Arc::new(VoxelTerrain::new())` and passes to `SimState::with_terrain(...)`. After each tick, drains chronicle records via `apply_voxel_chronicle_record()` (drain ordering deterministic per the chronicle ring's tick-relative slot order).
+- New fixtures `assets/sim/voxel_probe.sim` + `assets/ability_test/voxel_probe/{PlaceTestVoxel,HarvestTestVoxel}.ability`. One agent fires `place_voxel` then `harvest` over a 3-tick sequence.
+- Adapter fills in `apply_voxel_chronicle_record` for both kind=60 (`EffectPlaceVoxelApplied`) and kind=59 (`EffectHarvestApplied`).
+- **Two semantic behavioral pins** (the FlatPlane-killers):
+  - `placed_voxel_changes_height_at` — fire `place_voxel` for cell (5, 5, 5); subsequent `terrain.height_at(5, 5)` ≥ 5. FlatPlane returns 0 → fails. Catches "events fire into a void."
+  - `harvested_voxel_disappears` — place voxel, harvest it, assert `terrain.height_at` returns to ground. Catches "harvest emits an event but doesn't actually remove anything."
+
+### Phase C — GPU-resident voxel mirror (the perf fix) (~700 LOC)
+
+Goal: voxel state lives in a wgpu storage buffer, available to GPU kernels via the existing `KernelBindingsContext`. **This phase is what makes the slice viable for real fixtures.**
+
+- Adapter holds a `VoxelMirror` struct: a `wgpu::Buffer` whose layout encodes the voxel grid (flat 3D array for small worlds; chunked for larger). Plus per-chunk dirty flags so per-tick uploads only touch changed chunks.
+- On `apply_voxel_chronicle_record`: write to BOTH the CPU-side `VoxelWorld` AND the matching cell in the GPU mirror's host-side staging. At end of drain, single `Queue::write_buffer` flushes the dirty chunks to GPU.
+- Extend `KernelBindingsContext<'a>` with an optional `pub voxel_grid: Option<&'a wgpu::Buffer>` field (analogous to the optional `debug` field). Compiler's classifier table (from the Bindings constructors plan) gets a new entry: `voxel_grid` field name → `ctx.voxel_grid.expect(...)`.
+- WGSL helper functions for terrain queries that consume the buffer: `voxel_at(grid: ptr<storage, ...>, x: i32, y: i32, z: i32) -> u32`. Lives in the WGSL preamble emit.
+- **Behavioral pin (catches mirror divergence)**: `cpu_gpu_voxel_state_matches` — after a sequence of place/harvest, read N random cells via the GPU mirror (compute kernel that writes the cell value to a readback buffer) and assert each equals the CPU-side `VoxelWorld.cell_at(...)`. Catches "host wrote to CPU but forgot to write to GPU."
+
+### Phase D — DSL → WGSL emit for terrain queries (~600 LOC)
+
+Goal: a `.sim` rule can write `if (terrain.line_of_sight(self.pos, target.pos)) { ... }` and the compiler lowers it to a WGSL function call against the voxel mirror.
+
+- Today the DSL surface for `terrain.line_of_sight(from, to)` exists in `dsl_ast/src/resolve.rs` but no WGSL lowering. Implement the lowering in `crates/dsl_compiler/src/cg/emit/wgsl_body.rs`: the resolved IR call becomes a WGSL `voxel_line_of_sight(&voxel_grid, from, to)` invocation. Same for `terrain.height_at(x, y)` and `terrain.walkable(pos, mode)`.
+- Helper functions emitted into the WGSL preamble for any kernel whose body references them.
+- Two semantic behavioral pins:
+  - `solid_voxel_blocks_walkable` — place voxel at (10, 10, 10), assert `terrain.walkable(Vec3(10, 10, 10), Walk)` returns false (FlatPlane returns true → fails). Test the CPU side.
+  - `voxel_blocks_line_of_sight` — place voxel at (5, 5, 5), assert `terrain.line_of_sight(Vec3(0,0,5), Vec3(10,10,5))` returns false. Test the CPU side.
+  - `gpu_terrain_query_matches_cpu` — same scenario via a tiny GPU compute kernel that calls the new WGSL helper; assert it returns the same answer as the CPU oracle. Catches CPU/GPU semantic divergence.
+
+### Phase E — Production fixture opts in + determinism (~400 LOC)
+
+Goal: prove the slice doesn't regress determinism + one real fixture uses voxel terrain.
+
+- Determinism pin: `same_seed_same_voxel_world` — probe runtime, two runs, hash the voxel world's flat byte array, assert equal.
+- Opt `wave_defense_runtime` into VoxelTerrain. Use case: monsters can't pathfind through walls, settlers can place defensive walls (the deferred wave_defense polish item lands here). The wave defense `same_seed_same_death_tick` pin must still hold.
+- Update `docs/perf/2026-05-09-stress-ceilings.md` with measured per-tick voxel mirror upload cost at the wave_defense fixture's typical place/harvest rate. Establishes a baseline so future PlaceVoxel-heavy fixtures know what they're paying.
+
+---
+
+## Cross-cutting risks
+
+1. **Per-mutation GPU upload cost (Phase C's load-bearing question).** Each chronicle drain does a `Queue::write_buffer` for every dirty chunk. At `wave_defense` cast rates (a handful of place_voxel events per tick from settlers) this is trivial. At a hypothetical "fire-spreads-every-tick" rate (thousands of voxels mutating per tick) it could become a bottleneck. Phase E records the actual cost; if it exceeds 1 ms/tick at the production-fixture rate, that's the trigger to revisit GPU↔GPU interop.
+
+2. **HashMap ordering = nondeterminism.** voxel_engine's chunks may iterate by HashMap. Verify in Phase A; replace with `BTreeMap<ChunkCoord, Chunk>` or sort keys at boundary. P5 violation risk if missed. The `same_seed_same_voxel_world` pin in Phase E catches it.
+
+3. **Coordinate system mismatch.** Sim engine uses `Vec3` in arbitrary R³. voxel_engine uses chunk-relative `IVec3` per cell. Adapter handles the conversion (floor for placement, exact for queries). Check that voxel_engine's chunks have consistent cell-size + chunk-extent constants. Document the chosen world-units-per-cell at the adapter boundary so DSL authors know what `place_voxel` granularity actually means.
+
+4. **CPU/GPU mirror divergence.** Phase C's mirror-as-buffer pattern has the same drift risk as any cache-coherence problem: a mutation might land on CPU but not GPU (or vice versa). The `cpu_gpu_voxel_state_matches` pin (Phase C) and `gpu_terrain_query_matches_cpu` pin (Phase D) directly attack this. Don't substitute "both readbacks return non-zero" for "both readbacks return the SAME value at the same cell."
+
+5. **Behavioral pin coverage.** Per the prior probe-fooling discussion: the 5 behavioral pins listed (placed_voxel_changes_height_at, harvested_voxel_disappears, solid_voxel_blocks_walkable, voxel_blocks_line_of_sight, same_seed_same_voxel_world) are deliberately *semantic*, not threshold-based. Each catches a class of "FlatPlane silently passes" failure. Plus the two divergence pins (cpu_gpu_voxel_state_matches, gpu_terrain_query_matches_cpu) catch the new mirror-shape failures Phase C introduces. **Don't substitute counter-based pins.**
+
+6. **Voxel_engine's API stability.** It's a separate repo at edition=2024 with its own evolution path. Pinning to a specific commit (or vendoring a snapshot into a workspace member) trades update friction for stability. Phase A picks one; document the choice.
+
+## Out of scope (deferred)
+
+- **True GPU↔GPU interop (zero-copy voxel access).** Three real architectures exist beyond the CPU-mirror approach this slice ships:
+  1. **Shared `VkDevice`** — `wgpu_hal::vulkan::Adapter::from_raw_device(...)` wraps the same device voxel_engine creates; both engines reference each other's `VkBuffer` handles directly. Raw-hal API surface (unstable); manual Vulkan semaphores for cross-API sync.
+  2. **External memory FDs** — `VK_KHR_external_memory_fd` lets voxel_engine export buffers as Linux FDs that wgpu (via raw-hal) imports. Linux-only; manual FD lifetime; cross-device sync.
+  3. **Flip the relationship** — voxel_engine owns the Vulkan device; sim engine becomes ash-native and runs as compute passes scheduled into voxel_engine's frame loop. Massive port; biggest perf ceiling.
+
+  Defer until the CPU-mirror's per-mutation upload cost is the measured bottleneck. The phase E findings doc will record the actual cost so we can decide.
+- **Voxel rendering / visualization.** voxel_engine has full Vulkan rendering; we don't expose it here. A future viz slice (separate crate, like the deleted wolf-sim viz was) can connect.
+- **Destructible terrain damage propagation.** PlaceVoxel + Harvest cover the basic mutate-by-cast surface; richer effects (explosion AOE breaks all voxels in radius, fire spreads through solid material) are per-fixture follow-ups.
+- **Cover bonuses on attack scoring** (mentioned in the original gap doc as a "future feature hangs off this seam"). Not in scope here, but Phase D's WGSL emit work means it's a small follow-up — scoring can call `terrain.line_of_sight` directly.
+- **Migrating Forager.ability from `dsl_coverage` to a real fixture.** It stays in dsl_coverage as a parser-corpus fixture; voxel_probe runs the new minimal probe fixture for behavioral pins.
+- **Voxel-aware pathfinding for monsters** in wave_defense. Phase E opts the fixture in but only uses voxels for static walls + `walkable` queries. Real navmesh-style pathfinding is a separate slice.
+
+## Why this slice now
+
+Four reasons:
+
+1. **The seam exists** — TerrainQuery + Arc<dyn> + FlatPlane default. The adapter crate is exactly the planned next step (per the design doc from April 22). No re-architecting.
+2. **The voxel_engine repo is real and self-contained** — not a stub. Bridging is mechanical, not exploratory.
+3. **The probe-fooling concern is concrete here.** Every existing TerrainQuery test passes against FlatPlane. Voxel ops emit chronicle events into a void. The 7 semantic behavioral pins designed above (5 across phases A/B/D/E + 2 divergence pins in C/D) directly attack the false-pass pattern. Shipping this slice without the pins would just deepen the same bug class; with the pins, the slice models the right way to extend the engine.
+4. **GPU access lands in the same plan, not as future work.** The original draft of this plan stopped at CPU-only adapter; the user flagged it would perform terribly at scale (per-tick × per-agent CPU↔GPU round-trip is unworkable). Phase C is the perf-fix that makes the slice viable for real fixtures. Without Phase C the slice would be performative — looks integrated, dies under load.
+
+This is also a natural place to demo the **invariant-based probe pattern** from the meta-discussion — every behavioral pin is an algebraic property (place→height changes, harvest→cell empty, solid→walkable false, voxel→LOS blocked, CPU mirror == GPU mirror, GPU query == CPU oracle, same seed → same world) rather than a counter threshold.


### PR DESCRIPTION
## Summary

Final phase of the voxel-engine integration plan (`docs/superpowers/plans/2026-05-09-voxel-engine-integration.md`). Closes the 5-PR train (#69 → #70 → #71 → #72 → this PR).

- **Determinism pin** in `voxel_probe_runtime`: `same_seed_same_voxel_world` SHA-256s the VoxelGrid byte stream after 50 ticks across two same-seed runs and asserts equality (P5).
- **Wave_defense opts in** to `engine_voxel::VoxelTerrain` + `VoxelMirror`. Settlers self-cast a new `BuildPalisade` ability (`place_voxel \"palisade\"`) every 50 ticks during the early game; the chronicle drain mutates the host VoxelTerrain AND marks dirty chunks in the GPU mirror; end-of-tick `flush_dirty` re-uploads dirty chunks.
- **`monsters_blocked_by_palisade` semantic pin**: drives 200 ticks, asserts ≥ 3 BuildPalisade chronicle records drained AND ≥ 1 settler's path cell registers as `walkable = false` (proves CPU terrain query reflects mutations end-to-end).
- **Existing `same_seed_same_death_tick` pin still passes** — P5 determinism unaffected by the voxel opt-in.
- **Perf baseline** appended to `docs/perf/2026-05-09-stress-ceilings.md`: `flush_dirty` mean 5.83 µs / max 325 µs across 361 ticks. Well below the plan's 1 ms/tick threshold for triggering a GPU↔GPU interop follow-up; **no follow-up filed.**
- Plan doc marked COMPLETE; engine status doc adds a Voxel terrain row.

## Test plan

- [x] `cargo build --release` clean across full workspace
- [x] `cargo test -p engine --release --test schema_hash` — schema unchanged
- [x] `cargo test -p engine_voxel --release` — 22 unit tests pass
- [x] `cargo test -p dsl_compiler --release` — full suite green
- [x] `RUST_MIN_STACK=33554432 cargo test -p voxel_probe_runtime --release --lib` — **5 pins** (4 prior + new `same_seed_same_voxel_world`)
- [x] `RUST_MIN_STACK=33554432 cargo test -p wave_defense_runtime --release --lib` — **4 pins** (3 prior + new `monsters_blocked_by_palisade`); `same_seed_same_death_tick` still green
- [x] `RUST_MIN_STACK=33554432 cargo test -p spy_network_runtime --release --lib` — green
- [x] `RUST_MIN_STACK=33554432 cargo test -p village_economy_runtime --release --lib` — green
- [x] `RUST_MIN_STACK=33554432 cargo run --release --bin wave_defense_app -- 0` — settles at tick 360, score 3350, 175 palisade records drained, flush_dirty perf landed in stress-ceilings.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)