### PR TITLE
refactor(runtimes): migrate Phase 4 batch 3/5 to compiler-emitted Bindings constructors

### DIFF
--- a/crates/for_each_agent_probe_runtime/src/lib.rs
+++ b/crates/for_each_agent_probe_runtime/src/lib.rs
@@ -29,6 +29,9 @@
 //! (init: 0). Dead slots stay at their initial value. The harness
 //! test (`tests/probe.rs`) uses this exact contract.
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 use engine::sim_trait::CompiledSim;
 use engine::GpuContext;
 use glam::Vec3;
@@ -60,6 +63,18 @@ pub struct ForEachAgentProbeState {
     sim_cfg_buf: wgpu::Buffer,
     /// Per-kernel cfg uniform — `agent_cap`, `tick`, `seed`, `_pad`.
     physics_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::event_ring`] field — this fixture has no
+    /// emitted events, but the compiler-emitted `from_context_with_extras`
+    /// constructor signature requires the context to expose one.
+    event_ring: EventRing,
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (the `FusedBumpAllMana` kernel never
+    /// touches any `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     tick: u64,
@@ -115,12 +130,21 @@ impl ForEachAgentProbeState {
             },
         );
 
+        let event_ring = EventRing::new(&gpu, "for_each_agent_probe_runtime");
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "for_each_agent_probe_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
             agent_mana_buf,
             sim_cfg_buf,
             physics_cfg_buf,
+            event_ring,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -205,12 +229,24 @@ impl CompiledSim for ForEachAgentProbeState {
             .queue
             .write_buffer(&self.physics_cfg_buf, 0, bytemuck::bytes_of(&physics_cfg));
 
-        let bindings = fused_BumpAllMana::FusedBumpAllManaBindings {
-            agent_alive: &self.agent_alive_buf,
-            agent_mana: &self.agent_mana_buf,
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = fused_BumpAllMana::FusedBumpAllManaExtras {
             sim_cfg: &self.sim_cfg_buf,
             cfg: &self.physics_cfg_buf,
         };
+        let bindings = fused_BumpAllMana::FusedBumpAllManaBindings::from_context_with_extras(
+            &ctx, &extras,
+        );
         dispatch::dispatch_fused_bumpallmana(
             &mut self.cache,
             &bindings,

--- a/crates/foraging_runtime/src/lib.rs
+++ b/crates/foraging_runtime/src/lib.rs
@@ -44,7 +44,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture Food-entity population. Sets the `pair_map`
 /// `pheromone_trail` view's second-axis size: storage allocates
@@ -153,6 +155,13 @@ pub struct ForagingState {
     pheromone_trail: ViewStorage,
     pheromone_trail_cfg_buf: wgpu::Buffer,
     pheromone_trail_decay_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     pos_cache: Vec<Vec3>,
@@ -364,6 +373,12 @@ impl ForagingState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "foraging_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -381,6 +396,7 @@ impl ForagingState {
             pheromone_trail,
             pheromone_trail_cfg_buf,
             pheromone_trail_decay_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -478,16 +494,30 @@ impl CompiledSim for ForagingState {
         // read back to size the fold dispatch.
         self.event_ring.clear_tail_in(&mut encoder);
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            alive_buf: Some(&self.alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) WanderAndDrop — emits 1 Drop event per alive ant per
         // tick (`emit Drop { ant: self, carried: self, pos: new_pos }`).
-        let bindings = physics_WanderAndDrop::PhysicsWanderAndDropBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
-            agent_alive: &self.alive_buf,
+        let extras = physics_WanderAndDrop::PhysicsWanderAndDropExtras {
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let bindings =
+            physics_WanderAndDrop::PhysicsWanderAndDropBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_wanderanddrop(
             &mut self.cache,
             &bindings,
@@ -500,12 +530,12 @@ impl CompiledSim for ForagingState {
         // for the eventual `dispatch_workgroups_indirect` wire-up
         // (siblings dispatch this even though they don't consume the
         // indirect path yet — keeping the parity).
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(&ctx, &seed_extras);
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,
@@ -532,11 +562,15 @@ impl CompiledSim for ForagingState {
             0,
             bytemuck::bytes_of(&pd_decay_cfg),
         );
+        let pd_decay_extras = decay_pheromone_deposits::DecayPheromoneDepositsExtras {
+            view_storage_primary: self.pheromone_deposits.primary(),
+            cfg: &self.pheromone_deposits_decay_cfg_buf,
+        };
         let pd_decay_bindings =
-            decay_pheromone_deposits::DecayPheromoneDepositsBindings {
-                view_storage_primary: self.pheromone_deposits.primary(),
-                cfg: &self.pheromone_deposits_decay_cfg_buf,
-            };
+            decay_pheromone_deposits::DecayPheromoneDepositsBindings::from_context_with_extras(
+                &ctx,
+                &pd_decay_extras,
+            );
         dispatch::dispatch_decay_pheromone_deposits(
             &mut self.cache,
             &pd_decay_bindings,
@@ -590,10 +624,15 @@ impl CompiledSim for ForagingState {
             0,
             bytemuck::bytes_of(&ci_decay_cfg),
         );
-        let ci_decay_bindings = decay_colony_intake::DecayColonyIntakeBindings {
+        let ci_decay_extras = decay_colony_intake::DecayColonyIntakeExtras {
             view_storage_primary: self.colony_intake.primary(),
             cfg: &self.colony_intake_decay_cfg_buf,
         };
+        let ci_decay_bindings =
+            decay_colony_intake::DecayColonyIntakeBindings::from_context_with_extras(
+                &ctx,
+                &ci_decay_extras,
+            );
         dispatch::dispatch_decay_colony_intake(
             &mut self.cache,
             &ci_decay_bindings,
@@ -650,10 +689,15 @@ impl CompiledSim for ForagingState {
             0,
             bytemuck::bytes_of(&pt_decay_cfg),
         );
-        let pt_decay_bindings = decay_pheromone_trail::DecayPheromoneTrailBindings {
+        let pt_decay_extras = decay_pheromone_trail::DecayPheromoneTrailExtras {
             view_storage_primary: self.pheromone_trail.primary(),
             cfg: &self.pheromone_trail_decay_cfg_buf,
         };
+        let pt_decay_bindings =
+            decay_pheromone_trail::DecayPheromoneTrailBindings::from_context_with_extras(
+                &ctx,
+                &pt_decay_extras,
+            );
         dispatch::dispatch_decay_pheromone_trail(
             &mut self.cache,
             &pt_decay_bindings,

--- a/crates/mass_battle_100v100_runtime/src/lib.rs
+++ b/crates/mass_battle_100v100_runtime/src/lib.rs
@@ -48,7 +48,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 mod binding_check;
 
@@ -744,6 +744,28 @@ impl CompiledSim for MassBattle100v100State {
             0, scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            level_buf: Some(&self.agent_level_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round — fused PerPair kernel writes all 3 mask
         // bitmaps. Dispatches `agent_cap × agent_cap` threads (=
         // 200×200 = 40 000 at full scale), one per (actor, candidate)
@@ -758,21 +780,18 @@ impl CompiledSim for MassBattle100v100State {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_Strike::FusedMaskVerbStrikeBindings {
-            agent_alive: &self.agent_alive_buf,
-            agent_level: &self.agent_level_buf,
+        let mask_extras = fused_mask_verb_Strike::FusedMaskVerbStrikeExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
-            // StunBolt control-status proof (200-agent scale,
-            // 2026-05-07): fourth verb mask (StunBolt at source index 2).
             mask_3_bitmap: &self.mask_3_bitmap_buf,
-            // MassHeal recovery-dynamics proof (200-agent scale,
-            // 2026-05-07): fifth verb mask (MassHeal at source index 3
-            // shifts Heal to source index 4).
             mask_4_bitmap: &self.mask_4_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_Strike::FusedMaskVerbStrikeBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         // Dispatch agent_cap × agent_cap threads. The `agent_cap`
         // parameter to `dispatch_*` is interpreted as the total
         // thread count to round up against the workgroup_x.
@@ -792,38 +811,17 @@ impl CompiledSim for MassBattle100v100State {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
-            // StunBolt control-status proof (200-agent scale,
-            // 2026-05-07): scoring's argmax now reads four mask rows.
             mask_3_bitmap: &self.mask_3_bitmap_buf,
-            // MassHeal recovery-dynamics proof (200-agent scale,
-            // 2026-05-07): scoring's argmax now reads five mask rows
-            // (MassHeal at source index 3 shifts Heal to index 4).
             mask_4_bitmap: &self.mask_4_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
-            // Wave 1.5#7 follow-on (predicate-aware scoring,
-            // 2026-05-07): scoring kernel now inlines per-effect when-
-            // predicate eval; same SoA + agent stat columns as the
-            // chronicle dispatcher.
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -843,32 +841,13 @@ impl CompiledSim for MassBattle100v100State {
         self.gpu.queue.write_buffer(
             &self.chronicle_strike_cfg_buf, 0, bytemuck::bytes_of(&strike_cfg),
         );
-        let strike_bindings = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
+        let strike_extras = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeExtras {
             cfg: &self.chronicle_strike_cfg_buf,
         };
+        let strike_bindings =
+            physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings::from_context_with_extras(
+                &ctx, &strike_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_strike(
             &mut self.cache, &strike_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -885,32 +864,13 @@ impl CompiledSim for MassBattle100v100State {
         self.gpu.queue.write_buffer(
             &self.chronicle_snipe_cfg_buf, 0, bytemuck::bytes_of(&snipe_cfg),
         );
-        let snipe_bindings = physics_verb_chronicle_Snipe::PhysicsVerbChronicleSnipeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
+        let snipe_extras = physics_verb_chronicle_Snipe::PhysicsVerbChronicleSnipeExtras {
             cfg: &self.chronicle_snipe_cfg_buf,
         };
+        let snipe_bindings =
+            physics_verb_chronicle_Snipe::PhysicsVerbChronicleSnipeBindings::from_context_with_extras(
+                &ctx, &snipe_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_snipe(
             &mut self.cache, &snipe_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -936,32 +896,14 @@ impl CompiledSim for MassBattle100v100State {
         self.gpu.queue.write_buffer(
             &self.chronicle_stun_bolt_cfg_buf, 0, bytemuck::bytes_of(&stun_bolt_cfg),
         );
-        let stun_bolt_bindings = physics_verb_chronicle_StunBolt::PhysicsVerbChronicleStunBoltBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            cfg: &self.chronicle_stun_bolt_cfg_buf,
-        };
+        let stun_bolt_extras =
+            physics_verb_chronicle_StunBolt::PhysicsVerbChronicleStunBoltExtras {
+                cfg: &self.chronicle_stun_bolt_cfg_buf,
+            };
+        let stun_bolt_bindings =
+            physics_verb_chronicle_StunBolt::PhysicsVerbChronicleStunBoltBindings::from_context_with_extras(
+                &ctx, &stun_bolt_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_stunbolt(
             &mut self.cache, &stun_bolt_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -988,32 +930,14 @@ impl CompiledSim for MassBattle100v100State {
         self.gpu.queue.write_buffer(
             &self.chronicle_mass_heal_cfg_buf, 0, bytemuck::bytes_of(&mass_heal_cfg),
         );
-        let mass_heal_bindings = physics_verb_chronicle_MassHeal::PhysicsVerbChronicleMassHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana: &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            cfg: &self.chronicle_mass_heal_cfg_buf,
-        };
+        let mass_heal_extras =
+            physics_verb_chronicle_MassHeal::PhysicsVerbChronicleMassHealExtras {
+                cfg: &self.chronicle_mass_heal_cfg_buf,
+            };
+        let mass_heal_bindings =
+            physics_verb_chronicle_MassHeal::PhysicsVerbChronicleMassHealBindings::from_context_with_extras(
+                &ctx, &mass_heal_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_massheal(
             &mut self.cache, &mass_heal_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1034,11 +958,13 @@ impl CompiledSim for MassBattle100v100State {
         self.gpu.queue.write_buffer(
             &self.chronicle_heal_cfg_buf, 0, bytemuck::bytes_of(&heal_cfg),
         );
-        let heal_bindings = physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let heal_extras = physics_verb_chronicle_Heal::PhysicsVerbChronicleHealExtras {
             cfg: &self.chronicle_heal_cfg_buf,
         };
+        let heal_bindings =
+            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings::from_context_with_extras(
+                &ctx, &heal_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_heal(
             &mut self.cache, &heal_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1077,15 +1003,15 @@ impl CompiledSim for MassBattle100v100State {
             0,
             bytemuck::bytes_of(&apply_chronicle_cfg),
         );
-        let apply_chronicle_bindings =
-            physics_ApplyDamageFromChronicle_and_ApplyStunFromChronicle_and_ApplyHealFromChronicle::PhysicsApplyDamageFromChronicleAndApplyStunFromChronicleAndApplyHealFromChronicleBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_max_hp: &self.agent_max_hp_buf,
+        let apply_chronicle_extras =
+            physics_ApplyDamageFromChronicle_and_ApplyStunFromChronicle_and_ApplyHealFromChronicle::PhysicsApplyDamageFromChronicleAndApplyStunFromChronicleAndApplyHealFromChronicleExtras {
                 agent_stun_expires_at_tick: &self.agent_stun_expires_at_tick_buf,
                 cfg: &self.apply_chronicle_cfg_buf,
             };
+        let apply_chronicle_bindings =
+            physics_ApplyDamageFromChronicle_and_ApplyStunFromChronicle_and_ApplyHealFromChronicle::PhysicsApplyDamageFromChronicleAndApplyStunFromChronicleAndApplyHealFromChronicleBindings::from_context_with_extras(
+                &ctx, &apply_chronicle_extras,
+            );
         dispatch::dispatch_physics_applydamagefromchronicle_and_applystunfromchronicle_and_applyhealfromchronicle(
             &mut self.cache,
             &apply_chronicle_bindings,
@@ -1105,13 +1031,14 @@ impl CompiledSim for MassBattle100v100State {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
-            cfg: &self.apply_cfg_buf,
-        };
+        let apply_extras =
+            physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealExtras {
+                cfg: &self.apply_cfg_buf,
+            };
+        let apply_bindings =
+            physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings::from_context_with_extras(
+                &ctx, &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage_and_applyheal(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -1126,12 +1053,12 @@ impl CompiledSim for MassBattle100v100State {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(&ctx, &seed_extras);
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/megaswarm_10000_runtime/src/lib.rs
+++ b/crates/megaswarm_10000_runtime/src/lib.rs
@@ -50,7 +50,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-team agent populations. 5000 + 5000 = 10000.
 pub const PER_TEAM: u32 = 5000;
@@ -101,6 +103,13 @@ pub struct Megaswarm10000State {
     event_ring: EventRing,
     damage_dealt: ViewStorage,
     damage_dealt_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     // -- Per-kernel cfg uniforms --
     // Mask cfg: one buffer per chunk slot. `mask_chunk_cfgs[i]` carries
@@ -286,6 +295,12 @@ impl Megaswarm10000State {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "megaswarm_10000",
+        );
+
         Self {
             gpu,
             agent_hp_buf,
@@ -300,6 +315,7 @@ impl Megaswarm10000State {
             event_ring,
             damage_dealt,
             damage_dealt_cfg_buf,
+            registry_gpu,
             mask_chunk_cfgs,
             num_mask_chunks,
             scoring_cfg_buf,
@@ -497,6 +513,21 @@ impl CompiledSim for Megaswarm10000State {
         // dispatches loop, then again for the rest of the tick.
         self.gpu.queue.submit(Some(encoder.finish()));
 
+        // Shared once per tick; per-chunk mask + downstream dispatches
+        // each add their fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            level_buf: Some(&self.agent_level_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         let total_pairs = (self.agent_count as u64) * (self.agent_count as u64);
         for chunk_idx in 0..self.num_mask_chunks {
             let pair_offset = chunk_idx * PAIRS_PER_CHUNK;
@@ -514,13 +545,15 @@ impl CompiledSim for Megaswarm10000State {
                 0,
                 bytemuck::bytes_of(&cfg),
             );
-            let bindings = fused_mask_verb_RedStrike::FusedMaskVerbRedStrikeBindings {
-                agent_alive: &self.agent_alive_buf,
-                agent_level: &self.agent_level_buf,
+            let mask_extras = fused_mask_verb_RedStrike::FusedMaskVerbRedStrikeExtras {
                 mask_0_bitmap: &self.mask_0_bitmap_buf,
                 mask_1_bitmap: &self.mask_1_bitmap_buf,
                 cfg: &self.mask_chunk_cfgs[chunk_idx as usize],
             };
+            let bindings =
+                fused_mask_verb_RedStrike::FusedMaskVerbRedStrikeBindings::from_context_with_extras(
+                    &ctx, &mask_extras,
+                );
             let mut chunk_encoder = self.gpu.device.create_command_encoder(
                 &wgpu::CommandEncoderDescriptor {
                     label: Some("megaswarm_10000::mask_chunk"),
@@ -553,16 +586,14 @@ impl CompiledSim for Megaswarm10000State {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_level: &self.agent_level_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -575,11 +606,14 @@ impl CompiledSim for Megaswarm10000State {
         self.gpu.queue.write_buffer(
             &self.chronicle_red_strike_cfg_buf, 0, bytemuck::bytes_of(&red_strike_cfg),
         );
-        let red_strike_bindings = physics_verb_chronicle_RedStrike::PhysicsVerbChronicleRedStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.chronicle_red_strike_cfg_buf,
-        };
+        let red_strike_extras =
+            physics_verb_chronicle_RedStrike::PhysicsVerbChronicleRedStrikeExtras {
+                cfg: &self.chronicle_red_strike_cfg_buf,
+            };
+        let red_strike_bindings =
+            physics_verb_chronicle_RedStrike::PhysicsVerbChronicleRedStrikeBindings::from_context_with_extras(
+                &ctx, &red_strike_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_redstrike(
             &mut self.cache, &red_strike_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -592,11 +626,14 @@ impl CompiledSim for Megaswarm10000State {
         self.gpu.queue.write_buffer(
             &self.chronicle_blue_strike_cfg_buf, 0, bytemuck::bytes_of(&blue_strike_cfg),
         );
-        let blue_strike_bindings = physics_verb_chronicle_BlueStrike::PhysicsVerbChronicleBlueStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.chronicle_blue_strike_cfg_buf,
-        };
+        let blue_strike_extras =
+            physics_verb_chronicle_BlueStrike::PhysicsVerbChronicleBlueStrikeExtras {
+                cfg: &self.chronicle_blue_strike_cfg_buf,
+            };
+        let blue_strike_bindings =
+            physics_verb_chronicle_BlueStrike::PhysicsVerbChronicleBlueStrikeBindings::from_context_with_extras(
+                &ctx, &blue_strike_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_bluestrike(
             &mut self.cache, &blue_strike_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -611,13 +648,13 @@ impl CompiledSim for Megaswarm10000State {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage::PhysicsApplyDamageBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage::PhysicsApplyDamageExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings =
+            physics_ApplyDamage::PhysicsApplyDamageBindings::from_context_with_extras(
+                &ctx, &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -632,12 +669,12 @@ impl CompiledSim for Megaswarm10000State {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(&ctx, &seed_extras);
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/megaswarm_1000_runtime/src/lib.rs
+++ b/crates/megaswarm_1000_runtime/src/lib.rs
@@ -40,7 +40,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-team agent populations. 500 + 500 = 1000.
 pub const PER_TEAM: u32 = 500;
@@ -82,6 +84,13 @@ pub struct Megaswarm1000State {
     event_ring: EventRing,
     damage_dealt: ViewStorage,
     damage_dealt_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     // -- Per-kernel cfg uniforms --
     mask_cfg_buf: wgpu::Buffer,
@@ -241,6 +250,12 @@ impl Megaswarm1000State {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "megaswarm_1000",
+        );
+
         Self {
             gpu,
             agent_hp_buf,
@@ -255,6 +270,7 @@ impl Megaswarm1000State {
             event_ring,
             damage_dealt,
             damage_dealt_cfg_buf,
+            registry_gpu,
             mask_cfg_buf,
             scoring_cfg_buf,
             chronicle_red_strike_cfg_buf,
@@ -431,6 +447,21 @@ impl CompiledSim for Megaswarm1000State {
             0, scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            level_buf: Some(&self.agent_level_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round — fused PerPair kernel writes BOTH mask
         // bitmaps (RedStrike → mask_0, BlueStrike → mask_1).
         // Dispatches `agent_cap × agent_cap` threads
@@ -443,13 +474,15 @@ impl CompiledSim for Megaswarm1000State {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_RedStrike::FusedMaskVerbRedStrikeBindings {
-            agent_alive: &self.agent_alive_buf,
-            agent_level: &self.agent_level_buf,
+        let mask_extras = fused_mask_verb_RedStrike::FusedMaskVerbRedStrikeExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_RedStrike::FusedMaskVerbRedStrikeBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_redstrike(
             &mut self.cache, &mask_bindings, &self.gpu.device, &mut encoder,
             self.agent_count * self.agent_count,
@@ -466,16 +499,14 @@ impl CompiledSim for Megaswarm1000State {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_level: &self.agent_level_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -489,11 +520,14 @@ impl CompiledSim for Megaswarm1000State {
         self.gpu.queue.write_buffer(
             &self.chronicle_red_strike_cfg_buf, 0, bytemuck::bytes_of(&red_strike_cfg),
         );
-        let red_strike_bindings = physics_verb_chronicle_RedStrike::PhysicsVerbChronicleRedStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.chronicle_red_strike_cfg_buf,
-        };
+        let red_strike_extras =
+            physics_verb_chronicle_RedStrike::PhysicsVerbChronicleRedStrikeExtras {
+                cfg: &self.chronicle_red_strike_cfg_buf,
+            };
+        let red_strike_bindings =
+            physics_verb_chronicle_RedStrike::PhysicsVerbChronicleRedStrikeBindings::from_context_with_extras(
+                &ctx, &red_strike_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_redstrike(
             &mut self.cache, &red_strike_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -507,11 +541,14 @@ impl CompiledSim for Megaswarm1000State {
         self.gpu.queue.write_buffer(
             &self.chronicle_blue_strike_cfg_buf, 0, bytemuck::bytes_of(&blue_strike_cfg),
         );
-        let blue_strike_bindings = physics_verb_chronicle_BlueStrike::PhysicsVerbChronicleBlueStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.chronicle_blue_strike_cfg_buf,
-        };
+        let blue_strike_extras =
+            physics_verb_chronicle_BlueStrike::PhysicsVerbChronicleBlueStrikeExtras {
+                cfg: &self.chronicle_blue_strike_cfg_buf,
+            };
+        let blue_strike_bindings =
+            physics_verb_chronicle_BlueStrike::PhysicsVerbChronicleBlueStrikeBindings::from_context_with_extras(
+                &ctx, &blue_strike_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_bluestrike(
             &mut self.cache, &blue_strike_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -526,13 +563,13 @@ impl CompiledSim for Megaswarm1000State {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage::PhysicsApplyDamageBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage::PhysicsApplyDamageExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings =
+            physics_ApplyDamage::PhysicsApplyDamageBindings::from_context_with_extras(
+                &ctx, &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -547,12 +584,12 @@ impl CompiledSim for Megaswarm1000State {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(&ctx, &seed_extras);
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/multi_zone_world_runtime/src/lib.rs
+++ b/crates/multi_zone_world_runtime/src/lib.rs
@@ -42,7 +42,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 pub const ADVENTURER_COUNT: u32 = 30;
 pub const MONSTER_COUNT: u32 = 5;
@@ -121,6 +123,13 @@ pub struct MultiZoneWorldState {
     chronicle_trade_cfg_buf: wgpu::Buffer,
     chronicle_strike_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -352,6 +361,12 @@ impl MultiZoneWorldState {
         let gold_earned_total_cfg_buf = mk_view_cfg("multi_zone_world_runtime::gold_earned_total_cfg");
         let damage_dealt_cfg_buf = mk_view_cfg("multi_zone_world_runtime::damage_dealt_cfg");
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "multi_zone_world_runtime",
+        );
+
         Self {
             gpu,
             agent_hp_buf,
@@ -378,6 +393,7 @@ impl MultiZoneWorldState {
             chronicle_trade_cfg_buf,
             chronicle_strike_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -713,6 +729,22 @@ impl CompiledSim for MultiZoneWorldState {
             0, scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            level_buf: Some(&self.agent_level_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round.
         let mask_cfg = fused_mask_verb_GatherWood::FusedMaskVerbGatherWoodCfg {
             agent_cap: self.agent_count,
@@ -722,15 +754,16 @@ impl CompiledSim for MultiZoneWorldState {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_GatherWood::FusedMaskVerbGatherWoodBindings {
-            agent_alive: &self.agent_alive_buf,
-            agent_level: &self.agent_level_buf,
-            agent_mana: &self.agent_mana_buf,
+        let mask_extras = fused_mask_verb_GatherWood::FusedMaskVerbGatherWoodExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_GatherWood::FusedMaskVerbGatherWoodBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_gatherwood(
             &mut self.cache, &mask_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -745,15 +778,15 @@ impl CompiledSim for MultiZoneWorldState {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -768,11 +801,14 @@ impl CompiledSim for MultiZoneWorldState {
             event_count: self.agent_count, tick: self.tick as u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.chronicle_gather_cfg_buf, 0, bytemuck::bytes_of(&cg));
-        let cb = physics_verb_chronicle_GatherWood::PhysicsVerbChronicleGatherWoodBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.chronicle_gather_cfg_buf,
-        };
+        let cb_extras =
+            physics_verb_chronicle_GatherWood::PhysicsVerbChronicleGatherWoodExtras {
+                cfg: &self.chronicle_gather_cfg_buf,
+            };
+        let cb =
+            physics_verb_chronicle_GatherWood::PhysicsVerbChronicleGatherWoodBindings::from_context_with_extras(
+                &ctx, &cb_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_gatherwood(
             &mut self.cache, &cb, &self.gpu.device, &mut encoder, self.agent_count,
         );
@@ -782,11 +818,14 @@ impl CompiledSim for MultiZoneWorldState {
             event_count: self.agent_count, tick: self.tick as u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.chronicle_trade_cfg_buf, 0, bytemuck::bytes_of(&cg));
-        let cb = physics_verb_chronicle_TradeWoodForGold::PhysicsVerbChronicleTradeWoodForGoldBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.chronicle_trade_cfg_buf,
-        };
+        let cb_extras =
+            physics_verb_chronicle_TradeWoodForGold::PhysicsVerbChronicleTradeWoodForGoldExtras {
+                cfg: &self.chronicle_trade_cfg_buf,
+            };
+        let cb =
+            physics_verb_chronicle_TradeWoodForGold::PhysicsVerbChronicleTradeWoodForGoldBindings::from_context_with_extras(
+                &ctx, &cb_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_tradewoodforgold(
             &mut self.cache, &cb, &self.gpu.device, &mut encoder, self.agent_count,
         );
@@ -796,11 +835,14 @@ impl CompiledSim for MultiZoneWorldState {
             event_count: self.agent_count, tick: self.tick as u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.chronicle_strike_cfg_buf, 0, bytemuck::bytes_of(&cg));
-        let cb = physics_verb_chronicle_DungeonStrike::PhysicsVerbChronicleDungeonStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.chronicle_strike_cfg_buf,
-        };
+        let cb_extras =
+            physics_verb_chronicle_DungeonStrike::PhysicsVerbChronicleDungeonStrikeExtras {
+                cfg: &self.chronicle_strike_cfg_buf,
+            };
+        let cb =
+            physics_verb_chronicle_DungeonStrike::PhysicsVerbChronicleDungeonStrikeBindings::from_context_with_extras(
+                &ctx, &cb_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_dungeonstrike(
             &mut self.cache, &cb, &self.gpu.device, &mut encoder, self.agent_count,
         );
@@ -814,12 +856,12 @@ impl CompiledSim for MultiZoneWorldState {
             seed: 0, _pad: 0,
         };
         self.gpu.queue.write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(&ctx, &seed_extras);
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/objective_capture_10v10_runtime/src/lib.rs
+++ b/crates/objective_capture_10v10_runtime/src/lib.rs
@@ -50,7 +50,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 // --- Objective parameters (host-side authoritative) --------------
 /// World position of the control point. Both teams race toward it.
@@ -155,6 +157,13 @@ pub struct ObjectiveCapture10v10State {
     chronicle_strike_cfg_buf: wgpu::Buffer,
     apply_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -321,6 +330,12 @@ impl ObjectiveCapture10v10State {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "objective_capture_10v10_runtime",
+        );
+
         Self {
             gpu,
             agent_hp_buf,
@@ -339,6 +354,7 @@ impl ObjectiveCapture10v10State {
             chronicle_strike_cfg_buf,
             apply_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -594,6 +610,21 @@ impl CompiledSim for ObjectiveCapture10v10State {
             0, scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round.
         let mask_cfg = mask_verb_Strike::MaskVerbStrikeCfg {
             agent_cap: self.agent_count,
@@ -603,11 +634,14 @@ impl CompiledSim for ObjectiveCapture10v10State {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = mask_verb_Strike::MaskVerbStrikeBindings {
-            agent_alive: &self.agent_alive_buf,
+        let mask_extras = mask_verb_Strike::MaskVerbStrikeExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            mask_verb_Strike::MaskVerbStrikeBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         dispatch::dispatch_mask_verb_strike(
             &mut self.cache, &mask_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -622,14 +656,13 @@ impl CompiledSim for ObjectiveCapture10v10State {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -642,11 +675,14 @@ impl CompiledSim for ObjectiveCapture10v10State {
         self.gpu.queue.write_buffer(
             &self.chronicle_strike_cfg_buf, 0, bytemuck::bytes_of(&strike_cfg),
         );
-        let strike_bindings = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.chronicle_strike_cfg_buf,
-        };
+        let strike_extras =
+            physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeExtras {
+                cfg: &self.chronicle_strike_cfg_buf,
+            };
+        let strike_bindings =
+            physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings::from_context_with_extras(
+                &ctx, &strike_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_strike(
             &mut self.cache, &strike_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -661,13 +697,13 @@ impl CompiledSim for ObjectiveCapture10v10State {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage::PhysicsApplyDamageBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage::PhysicsApplyDamageExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings =
+            physics_ApplyDamage::PhysicsApplyDamageBindings::from_context_with_extras(
+                &ctx, &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -682,12 +718,12 @@ impl CompiledSim for ObjectiveCapture10v10State {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(&ctx, &seed_extras);
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/pair_scoring_probe_runtime/src/lib.rs
+++ b/crates/pair_scoring_probe_runtime/src/lib.rs
@@ -59,7 +59,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture state for the pair-scoring probe. Owns the agent SoA,
 /// the event ring, the view storage, the per-mask bitmap, the
@@ -107,6 +109,13 @@ pub struct PairScoringProbeState {
     scoring_cfg_buf: wgpu::Buffer,
     chronicle_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -226,6 +235,12 @@ impl PairScoringProbeState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "pair_scoring_probe_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -241,6 +256,7 @@ impl PairScoringProbeState {
             scoring_cfg_buf,
             chronicle_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -354,10 +370,26 @@ impl CompiledSim for PairScoringProbeState {
             0,
             bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = mask_verb_Heal::MaskVerbHealBindings {
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`. `agent_alive_buf` lives on
+        // the runtime but no kernel here actually binds `agent_alive`,
+        // so it stays absent from `agent_buffers`.
+        let agent_buffers = AgentBuffers::default();
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
+        let mask_extras = mask_verb_Heal::MaskVerbHealExtras {
             mask_0_bitmap: &self.mask_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            mask_verb_Heal::MaskVerbHealBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         dispatch::dispatch_mask_verb_heal(
             &mut self.cache,
             &mask_bindings,
@@ -380,15 +412,14 @@ impl CompiledSim for PairScoringProbeState {
             0,
             bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_cooldown_next_ready_tick: &self
-                .agent_cooldown_next_ready_tick_buf,
+        let scoring_extras = scoring::ScoringExtras {
+            agent_cooldown_next_ready_tick: &self.agent_cooldown_next_ready_tick_buf,
             mask_0_bitmap: &self.mask_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache,
             &scoring_bindings,
@@ -416,12 +447,14 @@ impl CompiledSim for PairScoringProbeState {
             0,
             bytemuck::bytes_of(&chronicle_cfg),
         );
-        let chronicle_bindings =
-            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
+        let chronicle_extras =
+            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealExtras {
                 cfg: &self.chronicle_cfg_buf,
             };
+        let chronicle_bindings =
+            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings::from_context_with_extras(
+                &ctx, &chronicle_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_heal(
             &mut self.cache,
             &chronicle_bindings,
@@ -441,12 +474,12 @@ impl CompiledSim for PairScoringProbeState {
         self.gpu
             .queue
             .write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(&ctx, &seed_extras);
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,

--- a/crates/particle_collision_runtime/src/lib.rs
+++ b/crates/particle_collision_runtime/src/lib.rs
@@ -15,7 +15,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, bytemuck::Pod, bytemuck::Zeroable)]
@@ -75,6 +77,13 @@ pub struct ParticleCollisionState {
     /// Pre-allocated zero buffer used as the COPY_SRC for the per-tick
     /// offsets clear.
     spatial_offsets_zero: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     pos_cache: Vec<Vec3>,
@@ -216,6 +225,12 @@ impl ParticleCollisionState {
                 usage: wgpu::BufferUsages::COPY_SRC,
             });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "particle_collision_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -230,6 +245,7 @@ impl ParticleCollisionState {
             spatial_grid_starts,
             spatial_chunk_sums,
             spatial_offsets_zero,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -318,15 +334,31 @@ impl CompiledSim for ParticleCollisionState {
             offsets_size,
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) Spatial-hash counting sort (5 phases). Required input
         // for the body-form spatial walk emitted into MoveParticle.
         // Same layout as boids — see boids_runtime::step for the
         // fixture-agnostic narrative.
-        let count_b = spatial_build_hash_count::SpatialBuildHashCountBindings {
-            agent_pos: &self.pos_buf,
+        let count_extras = spatial_build_hash_count::SpatialBuildHashCountExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             cfg: &self.cfg_buf,
         };
+        let count_b =
+            spatial_build_hash_count::SpatialBuildHashCountBindings::from_context_with_extras(
+                &ctx, &count_extras,
+            );
         dispatch::dispatch_spatial_build_hash_count(
             &mut self.cache,
             &count_b,
@@ -334,12 +366,17 @@ impl CompiledSim for ParticleCollisionState {
             &mut encoder,
             self.agent_count,
         );
-        let scan_local_b = spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings {
-            spatial_grid_offsets: &self.spatial_grid_offsets,
-            spatial_grid_starts: &self.spatial_grid_starts,
-            spatial_chunk_sums: &self.spatial_chunk_sums,
-            cfg: &self.cfg_buf,
-        };
+        let scan_local_extras =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalExtras {
+                spatial_grid_offsets: &self.spatial_grid_offsets,
+                spatial_grid_starts: &self.spatial_grid_starts,
+                spatial_chunk_sums: &self.spatial_chunk_sums,
+                cfg: &self.cfg_buf,
+            };
+        let scan_local_b =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings::from_context_with_extras(
+                &ctx, &scan_local_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_local(
             &mut self.cache,
             &scan_local_b,
@@ -347,10 +384,15 @@ impl CompiledSim for ParticleCollisionState {
             &mut encoder,
             self.agent_count,
         );
-        let scan_carry_b = spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings {
-            spatial_chunk_sums: &self.spatial_chunk_sums,
-            cfg: &self.cfg_buf,
-        };
+        let scan_carry_extras =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryExtras {
+                spatial_chunk_sums: &self.spatial_chunk_sums,
+                cfg: &self.cfg_buf,
+            };
+        let scan_carry_b =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings::from_context_with_extras(
+                &ctx, &scan_carry_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_carry(
             &mut self.cache,
             &scan_carry_b,
@@ -358,12 +400,17 @@ impl CompiledSim for ParticleCollisionState {
             &mut encoder,
             self.agent_count,
         );
-        let scan_add_b = spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings {
-            spatial_grid_offsets: &self.spatial_grid_offsets,
-            spatial_grid_starts: &self.spatial_grid_starts,
-            spatial_chunk_sums: &self.spatial_chunk_sums,
-            cfg: &self.cfg_buf,
-        };
+        let scan_add_extras =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddExtras {
+                spatial_grid_offsets: &self.spatial_grid_offsets,
+                spatial_grid_starts: &self.spatial_grid_starts,
+                spatial_chunk_sums: &self.spatial_chunk_sums,
+                cfg: &self.cfg_buf,
+            };
+        let scan_add_b =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings::from_context_with_extras(
+                &ctx, &scan_add_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_add(
             &mut self.cache,
             &scan_add_b,
@@ -371,13 +418,16 @@ impl CompiledSim for ParticleCollisionState {
             &mut encoder,
             self.agent_count,
         );
-        let scatter_b = spatial_build_hash_scatter::SpatialBuildHashScatterBindings {
-            agent_pos: &self.pos_buf,
+        let scatter_extras = spatial_build_hash_scatter::SpatialBuildHashScatterExtras {
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.cfg_buf,
         };
+        let scatter_b =
+            spatial_build_hash_scatter::SpatialBuildHashScatterBindings::from_context_with_extras(
+                &ctx, &scatter_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scatter(
             &mut self.cache,
             &scatter_b,
@@ -392,16 +442,17 @@ impl CompiledSim for ParticleCollisionState {
         // physics rule both reads it (for the walk's self-cell
         // computation) and writes the integrated position before the
         // walk.
-        let bindings = physics_MoveParticle::PhysicsMoveParticleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
+        let mp_extras = physics_MoveParticle::PhysicsMoveParticleExtras {
             agent_vel: &self.vel_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.cfg_buf,
         };
+        let bindings =
+            physics_MoveParticle::PhysicsMoveParticleBindings::from_context_with_extras(
+                &ctx, &mp_extras,
+            );
         dispatch::dispatch_physics_moveparticle(
             &mut self.cache,
             &bindings,
@@ -411,12 +462,12 @@ impl CompiledSim for ParticleCollisionState {
         );
 
         // (3) seed_indirect_0 — keeps indirect-args buffer warm.
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(&ctx, &seed_extras);
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,


### PR DESCRIPTION
## Summary

Phase 4 batch 3 of 5 of the compiler-emitted bindings constructors rollout. Migrates 9 runtimes' `step()` dispatch sites from hand-written `Bindings { ... }` literals to compiler-emitted `from_context_with_extras()` calls.

Plan: `docs/superpowers/plans/2026-05-09-compiler-emitted-bindings-constructors.md`

### Migrated runtimes (this batch)

- `for_each_agent_probe_runtime` — 1 site
- `foraging_runtime` — 5 non-fold sites
- `mass_battle_100v100_runtime` — 10 non-fold sites (biggest LOC win, ~60-line chronicle dispatches)
- `megaswarm_1000_runtime` — 6 non-fold sites
- `megaswarm_10000_runtime` — 6 non-fold sites (incl. per-chunk mask loop)
- `multi_zone_world_runtime` — 6 non-fold sites
- `objective_capture_10v10_runtime` — 5 non-fold sites
- `pair_scoring_probe_runtime` — 4 non-fold sites
- `particle_collision_runtime` — 7 non-fold sites (incl. all 5 spatial counting-sort kernels)

`fold_*` view-fold kernels left hand-written (no compiler-emitted constructors).

### Implementation note

8 of the 9 runtimes had no `PackedAbilityRegistryGpu` field before; the migration adds an empty placeholder (`PackedAbilityRegistry::pack(&AbilityRegistry::new())`) since the `KernelBindingsContext` struct requires one even though none of these fixtures' kernels reference any `ability_registry_*` field. `for_each_agent_probe` additionally gains an empty `EventRing` placeholder for the same reason. Cost: a handful of zero-sized `wgpu::Buffer` allocations at construction time, none bound to any kernel.

LOC delta: +243 net (+555 / -312). Net-positive because 8 small runtimes now pay a one-time `registry_gpu` field + `ctx`/`agent_buffers` construction floor; mass_battle_100v100's 60+-line chronicle dispatch collapses dominate but can't fully offset the small-runtime arithmetic. Future per-buffer additions (e.g. new agent SoA columns) now accrue zero lines per migrated runtime instead of ~3-8 lines each.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test -p engine --release --test schema_hash` — both pass (P2 unchanged)
- [x] `RUST_MIN_STACK=33554432 cargo test -p <crate> --release` for all 9 runtimes — all green
  - **except** `mass_battle_100v100::viz_tests::mass_heal_recovers_friendly_hp_at_200_agent_scale`, which fails identically on main pre-migration (`agent 0: hp=300 exceeds max_hp=100.0`). Pre-existing not-a-regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)