### PR TITLE
refactor(runtimes): migrate Phase 4 batch 1/5 to compiler-emitted Bindings constructors

### DIFF
--- a/crates/abilities_runtime/src/lib.rs
+++ b/crates/abilities_runtime/src/lib.rs
@@ -64,7 +64,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, bytemuck::Pod, bytemuck::Zeroable)]
@@ -136,6 +138,13 @@ pub struct AbilitiesProbeState {
     seed_cfg_buf: wgpu::Buffer,
     #[allow(dead_code)]
     snapshot_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities (the .sim only declares verbs/predicates), but the
+    /// compiler-emitted constructor signature requires the context to
+    /// expose one (no kernel here touches any `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -312,6 +321,12 @@ impl AbilitiesProbeState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "abilities_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -331,6 +346,7 @@ impl AbilitiesProbeState {
             chronicle_heal_cfg_buf,
             seed_cfg_buf,
             snapshot_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -398,6 +414,19 @@ impl CompiledSim for AbilitiesProbeState {
             mask_bytes.max(4),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round — `fused_mask_verb_Strike` runs both
         // mask predicates (mask_0 + mask_1) in one PerAgent pass.
         // Both predicates are `self.alive` so every alive slot's
@@ -410,12 +439,15 @@ impl CompiledSim for AbilitiesProbeState {
         self.gpu
             .queue
             .write_buffer(&self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg));
-        let mask_bindings = fused_mask_verb_Strike::FusedMaskVerbStrikeBindings {
-            agent_alive: &self.agent_alive_buf,
+        let mask_extras = fused_mask_verb_Strike::FusedMaskVerbStrikeExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_Strike::FusedMaskVerbStrikeBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_strike(
             &mut self.cache,
             &mask_bindings,
@@ -438,14 +470,14 @@ impl CompiledSim for AbilitiesProbeState {
             0,
             bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache,
             &scoring_bindings,
@@ -473,12 +505,14 @@ impl CompiledSim for AbilitiesProbeState {
             0,
             bytemuck::bytes_of(&strike_chronicle_cfg),
         );
-        let strike_chronicle_bindings =
-            physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
+        let strike_chronicle_extras =
+            physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeExtras {
                 cfg: &self.chronicle_strike_cfg_buf,
             };
+        let strike_chronicle_bindings =
+            physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings::from_context_with_extras(
+                &ctx, &strike_chronicle_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_strike(
             &mut self.cache,
             &strike_chronicle_bindings,
@@ -504,12 +538,14 @@ impl CompiledSim for AbilitiesProbeState {
             0,
             bytemuck::bytes_of(&chronicle_cfg),
         );
-        let chronicle_bindings =
-            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
+        let chronicle_extras =
+            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealExtras {
                 cfg: &self.chronicle_heal_cfg_buf,
             };
+        let chronicle_bindings =
+            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings::from_context_with_extras(
+                &ctx, &chronicle_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_heal(
             &mut self.cache,
             &chronicle_bindings,
@@ -528,12 +564,14 @@ impl CompiledSim for AbilitiesProbeState {
         self.gpu
             .queue
             .write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx, &seed_extras,
+            );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,

--- a/crates/apply_ability_chronicle_consumer_runtime/src/lib.rs
+++ b/crates/apply_ability_chronicle_consumer_runtime/src/lib.rs
@@ -49,6 +49,7 @@ use engine::ability::{
     AbilityId, AbilityProgram, AbilityRegistryBuilder, EffectOp, Gate, PackedAbilityRegistry,
 };
 use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 use engine::GpuContext;
 use wgpu::util::DeviceExt;
 
@@ -60,9 +61,9 @@ include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 /// payload 8).
 pub const CHRONICLE_STRIDE_U32: u32 = 10;
 
-/// Default ring slot capacity. We only need a few records per tick for
-/// the smoke loop (one per agent), so 256 slots is plenty.
-const RING_SLOTS: u32 = 256;
+// Ring capacity now comes from the shared `EventRing` infrastructure
+// (1 M slots) — the per-tick smoke records are bounded by `n_agents`,
+// well below the cap.
 
 /// Per-fixture state for the chronicle-consumer closed-loop demo.
 /// Owns:
@@ -108,15 +109,13 @@ pub struct ApplyAbilityChronicleConsumerState {
     // -- Packed AbilityRegistry on GPU --
     registry_gpu: PackedAbilityRegistryGpu,
 
-    // -- Event ring + tail --
-    event_ring_buf: wgpu::Buffer,
-    event_tail_buf: wgpu::Buffer,
+    // -- Event ring + tail (shared `EventRing` so the compiler-emitted
+    //    `Bindings::from_context_with_extras` constructor can resolve
+    //    `event_ring` / `event_tail` through the standard
+    //    `KernelBindingsContext`). --
+    event_ring: EventRing,
+    /// Staging buffer for `event_tail` host readback (4 bytes).
     event_tail_staging: wgpu::Buffer,
-    /// Pre-built zero buffer for per-tick `event_tail = 0` clears.
-    event_tail_zero: wgpu::Buffer,
-
-    // -- Indirect args (for seed_indirect_0) --
-    indirect_args_buf: wgpu::Buffer,
 
     // -- Cfg uniforms --
     physics_cfg_buf: wgpu::Buffer,
@@ -248,31 +247,11 @@ impl ApplyAbilityChronicleConsumerState {
         let agent_move_speed_buf    = mk_stat("apply_ability_chronicle_consumer::agent_move_speed");
         let agent_mana_buf          = mk_stat("apply_ability_chronicle_consumer::agent_mana");
 
-        // -- Event ring + tail. Both atomic-typed for the producer's
-        //    atomicAdd / atomicStore.
-        let ring_bytes = (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
-        let event_ring_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("apply_ability_chronicle_consumer::event_ring"),
-            size: ring_bytes,
-            usage: wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let event_tail_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("apply_ability_chronicle_consumer::event_tail"),
-            size: 4,
-            usage: wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let event_tail_zero =
-            gpu.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("apply_ability_chronicle_consumer::event_tail_zero"),
-                contents: bytemuck::bytes_of(&0u32),
-                usage: wgpu::BufferUsages::COPY_SRC,
-            });
+        // -- Event ring + tail. Standard `EventRing` so the compiler-
+        //    emitted `Bindings::from_context_with_extras` constructor
+        //    can resolve the `event_ring` / `event_tail` bindings via
+        //    `KernelBindingsContext::event_ring`.
+        let event_ring = EventRing::new(&gpu, "apply_ability_chronicle_consumer");
         let event_tail_staging = gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("apply_ability_chronicle_consumer::event_tail_staging"),
             size: 4,
@@ -280,15 +259,7 @@ impl ApplyAbilityChronicleConsumerState {
             mapped_at_creation: false,
         });
 
-        // -- Indirect args buffer (3 u32s: x,y,z workgroup counts).
-        //    seed_indirect_0 writes into it; we never read it on the
-        //    host (the consumer dispatches directly anyway).
-        let indirect_args_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("apply_ability_chronicle_consumer::indirect_args_0"),
-            size: 12,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::INDIRECT,
-            mapped_at_creation: false,
-        });
+        // -- Indirect args: provided by `EventRing::indirect_args_0()`.
 
         // -- Cfg uniforms. Three different cfg structs across the
         //    three kernels we drive each tick. Values are seeded once
@@ -349,11 +320,8 @@ impl ApplyAbilityChronicleConsumerState {
             agent_move_speed_buf,
             agent_mana_buf,
             registry_gpu,
-            event_ring_buf,
-            event_tail_buf,
+            event_ring,
             event_tail_staging,
-            event_tail_zero,
-            indirect_args_buf,
             physics_cfg_buf,
             consumer_cfg_buf,
             seed_cfg_buf,
@@ -408,38 +376,39 @@ impl ApplyAbilityChronicleConsumerState {
                 });
 
         // 1. Clear event_tail to 0 so the dispatcher's atomicAdd starts at 0.
-        encoder.copy_buffer_to_buffer(&self.event_tail_zero, 0, &self.event_tail_buf, 0, 4);
+        self.event_ring.clear_tail_in(&mut encoder);
+
+        // Shared per-tick context — each non-fold dispatch below adds
+        // only its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            level_buf: Some(&self.agent_level_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
 
         // 2. Dispatch the apply_ability dispatcher.
-        let dispatch_bindings =
-            physics_DispatchAbility::PhysicsDispatchAbilityBindings {
-                event_ring: &self.event_ring_buf,
-                event_tail: &self.event_tail_buf,
-                agent_alive: &self.agent_alive_buf,
-                agent_level: &self.agent_level_buf,
-                ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-                ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-                ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-                ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-                ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-                ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-                ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-                ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-                ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-                ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-                ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-                ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-                ability_registry_chances:           &self.registry_gpu.chances,
-                agent_attack_damage: &self.agent_attack_damage_buf,
-                agent_ability_power: &self.agent_ability_power_buf,
-                agent_max_hp:        &self.agent_max_hp_buf,
-                agent_hp:            &self.agent_hp_buf,
-                agent_armor:         &self.agent_armor_buf,
-                agent_magic_resist:  &self.agent_magic_resist_buf,
-                agent_move_speed:    &self.agent_move_speed_buf,
-                agent_mana:          &self.agent_mana_buf,
+        let dispatch_extras =
+            physics_DispatchAbility::PhysicsDispatchAbilityExtras {
                 cfg: &self.physics_cfg_buf,
             };
+        let dispatch_bindings =
+            physics_DispatchAbility::PhysicsDispatchAbilityBindings::from_context_with_extras(
+                &ctx, &dispatch_extras,
+            );
         dispatch::dispatch_physics_dispatchability(
             &mut self.cache,
             &dispatch_bindings,
@@ -451,12 +420,14 @@ impl ApplyAbilityChronicleConsumerState {
         // 3. Dispatch the seed_indirect_0 plumbing kernel (fills
         //    indirect_args_0 — unused in our direct-dispatch path,
         //    but the schedule lists it and a future runtime may use it).
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: &self.event_ring_buf,
-            event_tail: &self.event_tail_buf,
-            indirect_args_0: &self.indirect_args_buf,
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
+            indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx, &seed_extras,
+            );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,
@@ -466,7 +437,7 @@ impl ApplyAbilityChronicleConsumerState {
         );
 
         // 4. Copy tail to staging so we can read it back below.
-        encoder.copy_buffer_to_buffer(&self.event_tail_buf, 0, &self.event_tail_staging, 0, 4);
+        encoder.copy_buffer_to_buffer(self.event_ring.tail(), 0, &self.event_tail_staging, 0, 4);
 
         self.gpu.queue.submit(Some(encoder.finish()));
 
@@ -507,13 +478,37 @@ impl ApplyAbilityChronicleConsumerState {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("apply_ability_chronicle_consumer::step::consume"),
                 });
-        let consumer_bindings =
-            physics_ApplyChronicleDamage::PhysicsApplyChronicleDamageBindings {
-                event_ring: &self.event_ring_buf,
-                event_tail: &self.event_tail_buf,
-                agent_hp: &self.agent_hp_buf,
+        // Rebuild the per-tick context for stage 3 — no encoder change,
+        // just the same shared sources the dispatch stage used. Cheaper
+        // than threading a `&KernelBindingsContext` across the host
+        // readback of `tail` (which moves `&self` through map_async).
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            level_buf: Some(&self.agent_level_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let consumer_extras =
+            physics_ApplyChronicleDamage::PhysicsApplyChronicleDamageExtras {
                 cfg: &self.consumer_cfg_buf,
             };
+        let consumer_bindings =
+            physics_ApplyChronicleDamage::PhysicsApplyChronicleDamageBindings::from_context_with_extras(
+                &ctx, &consumer_extras,
+            );
         // Dispatch enough workgroups to cover `tail` records. The
         // kernel's record() helper uses `(agent_cap+63)/64` workgroups,
         // so passing `n_agents` works as long as event_count <= n_agents

--- a/crates/apply_ability_smoke_runtime/src/lib.rs
+++ b/crates/apply_ability_smoke_runtime/src/lib.rs
@@ -49,6 +49,7 @@ use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
 use engine::ability::{
     AbilityId, AbilityProgram, AbilityRegistryBuilder, EffectOp, Gate, PackedAbilityRegistry,
 };
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 use engine::GpuContext;
 use wgpu::util::DeviceExt;
 
@@ -192,13 +193,16 @@ pub struct ApplyAbilitySmokeState {
     // columns regardless — wasted bytes are bounded by registry size). --
     registry_gpu: PackedAbilityRegistryGpu,
 
-    // -- Event ring + tail --
-    event_ring_buf: wgpu::Buffer,
-    event_tail_buf: wgpu::Buffer,
+    // -- Event ring + tail (shared infrastructure via `EventRing` so the
+    //    compiler-emitted `Bindings::from_context_with_extras` constructor
+    //    can resolve `event_ring` / `event_tail` through the standard
+    //    `KernelBindingsContext`). --
+    event_ring: EventRing,
+    /// Staging buffer for `read_event_ring` host readback. Sized
+    /// to the standard `EventRing` ring capacity.
     event_ring_staging: wgpu::Buffer,
+    /// Staging buffer for `read_event_tail` host readback (4 bytes).
     event_tail_staging: wgpu::Buffer,
-    /// Pre-built zero buffer for per-tick `event_tail = 0` clears.
-    event_tail_zero: wgpu::Buffer,
 
     // -- Cfg uniform --
     physics_cfg_buf: wgpu::Buffer,
@@ -411,38 +415,19 @@ impl ApplyAbilitySmokeState {
                 contents: bytemuck::cast_slice(&engaged_with_init),
                 usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             });
-        // -- Event ring + tail. The kernel binds both as
-        //    `array<atomic<u32>>` so we tag them STORAGE (the dispatcher
-        //    writes via atomicAdd / atomicStore). COPY_SRC needed for
-        //    readback into the staging buffer.
-        let ring_bytes = (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
-        let event_ring_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("apply_ability_smoke_runtime::event_ring"),
-            size: ring_bytes,
-            usage: wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let event_tail_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("apply_ability_smoke_runtime::event_tail"),
-            size: 4,
-            usage: wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let event_tail_zero =
-            gpu.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("apply_ability_smoke_runtime::event_tail_zero"),
-                contents: bytemuck::bytes_of(&0u32),
-                usage: wgpu::BufferUsages::COPY_SRC,
-            });
-
-        // Staging buffers for host readback.
+        // -- Event ring + tail. Standard `EventRing` so the compiler-
+        //    emitted `Bindings::from_context_with_extras` constructor
+        //    can resolve the `event_ring` / `event_tail` bindings via
+        //    `KernelBindingsContext::event_ring`.
+        let event_ring = EventRing::new(&gpu, "apply_ability_smoke_runtime");
+        // Staging buffer sized for the smoke fixture's worst-case readback
+        // (a few records per tick — the per-tick smoke records are bounded
+        // by `RING_SLOTS`). `read_event_ring` only copies the actually-
+        // requested record count, not the full 1M-slot ring.
+        let staging_bytes = (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
         let event_ring_staging = gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("apply_ability_smoke_runtime::event_ring_staging"),
-            size: ring_bytes,
+            size: staging_bytes,
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
         });
@@ -488,11 +473,9 @@ impl ApplyAbilitySmokeState {
             spatial_grid_cells_buf,
             spatial_grid_starts_buf,
             registry_gpu,
-            event_ring_buf,
-            event_tail_buf,
+            event_ring,
             event_ring_staging,
             event_tail_staging,
-            event_tail_zero,
             physics_cfg_buf,
             cache: dispatch::KernelCache::default(),
             n_agents,
@@ -682,41 +665,37 @@ impl ApplyAbilitySmokeState {
                 });
 
         // Clear event_tail to 0 so producer atomicAdd starts from slot 0.
-        encoder.copy_buffer_to_buffer(&self.event_tail_zero, 0, &self.event_tail_buf, 0, 4);
+        self.event_ring.clear_tail_in(&mut encoder);
 
-        let bindings = physics_DispatchAbility::PhysicsDispatchAbilityBindings {
-            event_ring: &self.event_ring_buf,
-            event_tail: &self.event_tail_buf,
-            agent_alive: &self.agent_alive_buf,
-            agent_level: &self.agent_level_buf,
-            agent_pos:           &self.agent_pos_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            ability_registry_area_kinds:        &self.registry_gpu.area_kinds,
-            ability_registry_area_args:         &self.registry_gpu.area_args,
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            level_buf: Some(&self.agent_level_buf),
+            pos_buf: Some(&self.agent_pos_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_DispatchAbility::PhysicsDispatchAbilityExtras {
             spatial_grid_cells:  &self.spatial_grid_cells_buf,
             spatial_grid_starts: &self.spatial_grid_starts_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
             cfg: &self.physics_cfg_buf,
         };
+        let bindings =
+            physics_DispatchAbility::PhysicsDispatchAbilityBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_dispatchability(
             &mut self.cache,
             &bindings,
@@ -765,45 +744,39 @@ impl ApplyAbilitySmokeState {
                     label: Some("apply_ability_smoke_runtime::step_explicit_target"),
                 });
 
-        encoder.copy_buffer_to_buffer(&self.event_tail_zero, 0, &self.event_tail_buf, 0, 4);
+        self.event_ring.clear_tail_in(&mut encoder);
 
-        let bindings =
-            physics_DispatchAbilityToOther::PhysicsDispatchAbilityToOtherBindings {
-                event_ring: &self.event_ring_buf,
-                event_tail: &self.event_tail_buf,
-                agent_alive: &self.agent_alive_buf,
-                agent_level: &self.agent_level_buf,
-                agent_pos:           &self.agent_pos_buf,
-                agent_engaged_with:  &self.agent_engaged_with_buf,
-                ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-                ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-                ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-                ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-                ability_registry_nested_effect_payload_a:
-                    &self.registry_gpu.nested_effect_payload_a,
-                ability_registry_nested_effect_payload_b:
-                    &self.registry_gpu.nested_effect_payload_b,
-                ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-                ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-                ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-                ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-                ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-                ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-                ability_registry_chances:           &self.registry_gpu.chances,
-                ability_registry_area_kinds:        &self.registry_gpu.area_kinds,
-                ability_registry_area_args:         &self.registry_gpu.area_args,
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            level_buf: Some(&self.agent_level_buf),
+            pos_buf: Some(&self.agent_pos_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras =
+            physics_DispatchAbilityToOther::PhysicsDispatchAbilityToOtherExtras {
+                agent_engaged_with: &self.agent_engaged_with_buf,
                 spatial_grid_cells:  &self.spatial_grid_cells_buf,
                 spatial_grid_starts: &self.spatial_grid_starts_buf,
-                agent_attack_damage: &self.agent_attack_damage_buf,
-                agent_ability_power: &self.agent_ability_power_buf,
-                agent_max_hp:        &self.agent_max_hp_buf,
-                agent_hp:            &self.agent_hp_buf,
-                agent_armor:         &self.agent_armor_buf,
-                agent_magic_resist:  &self.agent_magic_resist_buf,
-                agent_move_speed:    &self.agent_move_speed_buf,
-                agent_mana:          &self.agent_mana_buf,
                 cfg: &self.physics_cfg_buf,
             };
+        let bindings =
+            physics_DispatchAbilityToOther::PhysicsDispatchAbilityToOtherBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_dispatchabilitytoother(
             &mut self.cache,
             &bindings,
@@ -830,7 +803,7 @@ impl ApplyAbilitySmokeState {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("apply_ability_smoke_runtime::read_event_tail"),
                 });
-        encoder.copy_buffer_to_buffer(&self.event_tail_buf, 0, &self.event_tail_staging, 0, 4);
+        encoder.copy_buffer_to_buffer(self.event_ring.tail(), 0, &self.event_tail_staging, 0, 4);
         self.gpu.queue.submit(Some(encoder.finish()));
 
         let slice = self.event_tail_staging.slice(..);
@@ -854,11 +827,14 @@ impl ApplyAbilitySmokeState {
     /// Block on the GPU and read back the first `n_records` records
     /// from `event_ring`. Each record is 10 u32 words.
     pub fn read_event_ring(&self, n_records: u32) -> Vec<[u32; 10]> {
-        // Always copy back the full ring buffer; the host filters by
-        // n_records below. (Partial mapping in wgpu requires aligned
-        // offsets — easier to just blit the full ring for the smoke
-        // test.)
-        let total_bytes = (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
+        // Copy only the bytes covering `n_records` (capped at the
+        // staging buffer size) — the host then walks the staging slice
+        // word-by-word.
+        let want_bytes =
+            (n_records as u64).max(1) * (CHRONICLE_STRIDE_U32 as u64) * 4;
+        let staging_cap_bytes =
+            (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
+        let copy_bytes = want_bytes.min(staging_cap_bytes);
         let mut encoder =
             self.gpu
                 .device
@@ -866,11 +842,11 @@ impl ApplyAbilitySmokeState {
                     label: Some("apply_ability_smoke_runtime::read_event_ring"),
                 });
         encoder.copy_buffer_to_buffer(
-            &self.event_ring_buf,
+            self.event_ring.ring(),
             0,
             &self.event_ring_staging,
             0,
-            total_bytes,
+            copy_bytes,
         );
         self.gpu.queue.submit(Some(encoder.finish()));
 

--- a/crates/apply_ability_verb_chronicle_consumer_runtime/src/lib.rs
+++ b/crates/apply_ability_verb_chronicle_consumer_runtime/src/lib.rs
@@ -73,6 +73,7 @@ use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
 use engine::ability::{
     AbilityId, AbilityProgram, AbilityRegistryBuilder, EffectOp, Gate, PackedAbilityRegistry,
 };
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 use engine::GpuContext;
 use wgpu::util::DeviceExt;
 
@@ -83,11 +84,9 @@ include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 /// and the engine's `EVENT_STRIDE_U32`. Pinned at 10 (header 2 + payload 8).
 pub const CHRONICLE_STRIDE_U32: u32 = 10;
 
-/// Default ring slot capacity — generous for the smoke fixture (we
-/// emit n_agents seeded ActionSelected + n_agents damage on dispatch 1
-/// + n_agents MORE damage on dispatch 2, then garbage-collect on the
-/// next tick).
-const RING_SLOTS: u32 = 256;
+// Ring capacity now comes from the shared `EventRing` infrastructure
+// (1 M slots) — the per-tick smoke records are bounded by `n_agents`,
+// well below the cap.
 
 /// EventKindId for `ActionSelected` in this fixture's .sim-local
 /// declaration order. The fixture declares:
@@ -143,12 +142,13 @@ pub struct ApplyAbilityVerbChronicleConsumerState {
     // -- Packed AbilityRegistry on GPU --
     registry_gpu: PackedAbilityRegistryGpu,
 
-    // -- Event ring + tail --
-    event_ring_buf: wgpu::Buffer,
-    event_tail_buf: wgpu::Buffer,
+    // -- Event ring + tail (shared `EventRing` so the compiler-emitted
+    //    `Bindings::from_context_with_extras` constructor can resolve
+    //    `event_ring` / `event_tail` through the standard
+    //    `KernelBindingsContext`). --
+    event_ring: EventRing,
+    /// Staging buffer for `event_tail` host readback (4 bytes).
     event_tail_staging: wgpu::Buffer,
-    /// Pre-built zero buffer for per-tick `event_tail = 0` clears.
-    event_tail_zero: wgpu::Buffer,
 
     // -- Cfg uniform --
     physics_cfg_buf: wgpu::Buffer,
@@ -251,37 +251,11 @@ impl ApplyAbilityVerbChronicleConsumerState {
         let agent_move_speed_buf    = mk_stat("apply_ability_verb_chronicle_consumer::agent_move_speed");
         let agent_mana_buf          = mk_stat("apply_ability_verb_chronicle_consumer::agent_mana");
 
-        // -- Event ring + tail (atomic-typed u32 storage).
-        let ring_bytes = (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
-        let event_ring_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some(
-                "apply_ability_verb_chronicle_consumer::event_ring",
-            ),
-            size: ring_bytes,
-            usage: wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let event_tail_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some(
-                "apply_ability_verb_chronicle_consumer::event_tail",
-            ),
-            size: 4,
-            usage: wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let event_tail_zero = gpu
-            .device
-            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some(
-                    "apply_ability_verb_chronicle_consumer::event_tail_zero",
-                ),
-                contents: bytemuck::bytes_of(&0u32),
-                usage: wgpu::BufferUsages::COPY_SRC,
-            });
+        // -- Event ring + tail. Standard `EventRing` so the compiler-
+        //    emitted `Bindings::from_context_with_extras` constructor
+        //    can resolve the `event_ring` / `event_tail` bindings via
+        //    `KernelBindingsContext::event_ring`.
+        let event_ring = EventRing::new(&gpu, "apply_ability_verb_chronicle_consumer");
         let event_tail_staging = gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some(
                 "apply_ability_verb_chronicle_consumer::event_tail_staging",
@@ -321,10 +295,8 @@ impl ApplyAbilityVerbChronicleConsumerState {
             agent_move_speed_buf,
             agent_mana_buf,
             registry_gpu,
-            event_ring_buf,
-            event_tail_buf,
+            event_ring,
             event_tail_staging,
-            event_tail_zero,
             physics_cfg_buf,
             cache: dispatch::KernelCache::default(),
             n_agents,
@@ -382,7 +354,7 @@ impl ApplyAbilityVerbChronicleConsumerState {
         }
         self.gpu
             .queue
-            .write_buffer(&self.event_ring_buf, 0, bytemuck::cast_slice(&seeded));
+            .write_buffer(self.event_ring.ring(), 0, bytemuck::cast_slice(&seeded));
 
         let mut encoder1 =
             self.gpu
@@ -394,21 +366,15 @@ impl ApplyAbilityVerbChronicleConsumerState {
                 });
 
         // Clear event_tail to 0 first, then write n_agents below.
-        encoder1.copy_buffer_to_buffer(
-            &self.event_tail_zero,
-            0,
-            &self.event_tail_buf,
-            0,
-            4,
-        );
+        self.event_ring.clear_tail_in(&mut encoder1);
         // event_tail = n_agents — dispatcher's atomicAdd starts allocating
         // slots from n_agents upward, leaving the seeded ActionSelected
         // entries intact. (Submit + write_buffer between submit calls is
-        // also valid; we use copy_buffer_to_buffer earlier and then write
+        // also valid; we use clear_tail_in() earlier and then write
         // n_agents directly.)
         self.gpu.queue.submit(Some(encoder1.finish()));
         self.gpu.queue.write_buffer(
-            &self.event_tail_buf,
+            self.event_ring.tail(),
             0,
             bytemuck::bytes_of(&self.n_agents),
         );
@@ -422,33 +388,30 @@ impl ApplyAbilityVerbChronicleConsumerState {
                         "apply_ability_verb_chronicle_consumer::step::stage1_dispatch",
                     ),
                 });
-        let bindings = physics_ApplyChronicleDamage_and_verb_chronicle_Cast::PhysicsApplyChronicleDamageAndVerbChronicleCastBindings {
-            event_ring: &self.event_ring_buf,
-            event_tail: &self.event_tail_buf,
-            agent_hp: &self.agent_hp_buf,
-            agent_level: &self.agent_level_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let agent_buffers = AgentBuffers {
+            level_buf: Some(&self.agent_level_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_ApplyChronicleDamage_and_verb_chronicle_Cast::PhysicsApplyChronicleDamageAndVerbChronicleCastExtras {
             cfg: &self.physics_cfg_buf,
         };
+        let bindings = physics_ApplyChronicleDamage_and_verb_chronicle_Cast::PhysicsApplyChronicleDamageAndVerbChronicleCastBindings::from_context_with_extras(
+            &ctx, &extras,
+        );
         dispatch::dispatch_physics_applychronicledamage_and_verb_chronicle_cast(
             &mut self.cache,
             &bindings,
@@ -458,7 +421,7 @@ impl ApplyAbilityVerbChronicleConsumerState {
         );
         // Copy tail to staging in the same submit.
         encoder2.copy_buffer_to_buffer(
-            &self.event_tail_buf,
+            self.event_ring.tail(),
             0,
             &self.event_tail_staging,
             0,
@@ -513,33 +476,30 @@ impl ApplyAbilityVerbChronicleConsumerState {
                     ),
                 });
         // Re-bind (Bindings borrows are short-lived; ok to rebuild).
-        let bindings2 = physics_ApplyChronicleDamage_and_verb_chronicle_Cast::PhysicsApplyChronicleDamageAndVerbChronicleCastBindings {
-            event_ring: &self.event_ring_buf,
-            event_tail: &self.event_tail_buf,
-            agent_hp: &self.agent_hp_buf,
-            agent_level: &self.agent_level_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let agent_buffers2 = AgentBuffers {
+            level_buf: Some(&self.agent_level_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx2 = KernelBindingsContext {
+            state: &agent_buffers2,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras2 = physics_ApplyChronicleDamage_and_verb_chronicle_Cast::PhysicsApplyChronicleDamageAndVerbChronicleCastExtras {
             cfg: &self.physics_cfg_buf,
         };
+        let bindings2 = physics_ApplyChronicleDamage_and_verb_chronicle_Cast::PhysicsApplyChronicleDamageAndVerbChronicleCastBindings::from_context_with_extras(
+            &ctx2, &extras2,
+        );
         // Workgroup count covers `tail` invocations (one per slot).
         dispatch::dispatch_physics_applychronicledamage_and_verb_chronicle_cast(
             &mut self.cache,

--- a/crates/apply_ability_verb_smoke_runtime/src/lib.rs
+++ b/crates/apply_ability_verb_smoke_runtime/src/lib.rs
@@ -76,6 +76,7 @@ use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
 use engine::ability::{
     AbilityId, AbilityProgram, AbilityRegistryBuilder, EffectOp, Gate, PackedAbilityRegistry,
 };
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 use engine::GpuContext;
 use wgpu::util::DeviceExt;
 
@@ -141,10 +142,15 @@ pub struct ApplyAbilityVerbSmokeState {
     // columns regardless — wasted bytes are bounded by registry size). --
     registry_gpu: PackedAbilityRegistryGpu,
 
-    // -- Event ring + tail --
-    event_ring_buf: wgpu::Buffer,
-    event_tail_buf: wgpu::Buffer,
+    // -- Event ring + tail (shared `EventRing` so the compiler-emitted
+    //    `Bindings::from_context_with_extras` constructor can resolve
+    //    `event_ring` / `event_tail` through the standard
+    //    `KernelBindingsContext`). --
+    event_ring: EventRing,
+    /// Staging buffer for `read_event_ring` host readback. Sized
+    /// to the smoke fixture's worst-case readback window.
     event_ring_staging: wgpu::Buffer,
+    /// Staging buffer for `read_event_tail` host readback (4 bytes).
     event_tail_staging: wgpu::Buffer,
 
     // -- Cfg uniform --
@@ -227,34 +233,15 @@ impl ApplyAbilityVerbSmokeState {
         let agent_move_speed_buf    = mk_stat("apply_ability_verb_smoke_runtime::agent_move_speed");
         let agent_mana_buf          = mk_stat("apply_ability_verb_smoke_runtime::agent_mana");
 
-        // -- Event ring + tail. The kernel binds both as
-        //    `array<atomic<u32>>` so we tag them STORAGE (the dispatcher
-        //    reads via atomicLoad and writes via atomicAdd / atomicStore).
-        //    COPY_SRC needed for readback into the staging buffer;
-        //    COPY_DST needed to seed the synthetic ActionSelected
-        //    records before each dispatch.
-        let ring_bytes = (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
-        let event_ring_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("apply_ability_verb_smoke_runtime::event_ring"),
-            size: ring_bytes,
-            usage: wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let event_tail_buf = gpu.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("apply_ability_verb_smoke_runtime::event_tail"),
-            size: 4,
-            usage: wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
-        // Staging buffers for host readback.
+        // -- Event ring + tail. Standard `EventRing` so the compiler-
+        //    emitted `Bindings::from_context_with_extras` constructor
+        //    can resolve the `event_ring` / `event_tail` bindings via
+        //    `KernelBindingsContext::event_ring`.
+        let event_ring = EventRing::new(&gpu, "apply_ability_verb_smoke_runtime");
+        let staging_bytes = (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
         let event_ring_staging = gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("apply_ability_verb_smoke_runtime::event_ring_staging"),
-            size: ring_bytes,
+            size: staging_bytes,
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
         });
@@ -296,8 +283,7 @@ impl ApplyAbilityVerbSmokeState {
             agent_move_speed_buf,
             agent_mana_buf,
             registry_gpu,
-            event_ring_buf,
-            event_tail_buf,
+            event_ring,
             event_ring_staging,
             event_tail_staging,
             physics_cfg_buf,
@@ -350,12 +336,12 @@ impl ApplyAbilityVerbSmokeState {
         }
         self.gpu
             .queue
-            .write_buffer(&self.event_ring_buf, 0, bytemuck::cast_slice(&seeded));
+            .write_buffer(self.event_ring.ring(), 0, bytemuck::cast_slice(&seeded));
 
         // event_tail = n_agents — chronicle's atomicAdd starts allocating
         // slots from `n_agents` upward, leaving the seeded records intact.
         self.gpu.queue.write_buffer(
-            &self.event_tail_buf,
+            self.event_ring.tail(),
             0,
             bytemuck::bytes_of(&self.n_agents),
         );
@@ -367,33 +353,31 @@ impl ApplyAbilityVerbSmokeState {
                 label: Some("apply_ability_verb_smoke_runtime::step"),
             });
 
-        let bindings = physics_verb_chronicle_Cast::PhysicsVerbChronicleCastBindings {
-            event_ring: &self.event_ring_buf,
-            event_tail: &self.event_tail_buf,
-            agent_level: &self.agent_level_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let agent_buffers = AgentBuffers {
+            level_buf: Some(&self.agent_level_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_verb_chronicle_Cast::PhysicsVerbChronicleCastExtras {
             cfg: &self.physics_cfg_buf,
         };
+        let bindings =
+            physics_verb_chronicle_Cast::PhysicsVerbChronicleCastBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         // The dispatch helper takes `agent_cap` but uses it solely for
         // the workgroup count `(N + 63) / 64`. For the PerEvent shape
         // here we pass `event_count` (= n_agents), so the kernel
@@ -419,7 +403,7 @@ impl ApplyAbilityVerbSmokeState {
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                 label: Some("apply_ability_verb_smoke_runtime::read_event_tail"),
             });
-        encoder.copy_buffer_to_buffer(&self.event_tail_buf, 0, &self.event_tail_staging, 0, 4);
+        encoder.copy_buffer_to_buffer(self.event_ring.tail(), 0, &self.event_tail_staging, 0, 4);
         self.gpu.queue.submit(Some(encoder.finish()));
 
         let slice = self.event_tail_staging.slice(..);
@@ -443,11 +427,13 @@ impl ApplyAbilityVerbSmokeState {
     /// Block on the GPU and read back the first `n_records` records
     /// from `event_ring`. Each record is 10 u32 words.
     pub fn read_event_ring(&self, n_records: u32) -> Vec<[u32; 10]> {
-        // Always copy back the full ring buffer; the host filters by
-        // n_records below. (Partial mapping in wgpu requires aligned
-        // offsets — easier to just blit the full ring for the smoke
-        // test.)
-        let total_bytes = (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
+        // Copy only the bytes covering `n_records` (capped at the
+        // staging buffer size).
+        let want_bytes =
+            (n_records as u64).max(1) * (CHRONICLE_STRIDE_U32 as u64) * 4;
+        let staging_cap_bytes =
+            (RING_SLOTS as u64) * (CHRONICLE_STRIDE_U32 as u64) * 4;
+        let copy_bytes = want_bytes.min(staging_cap_bytes);
         let mut encoder = self
             .gpu
             .device
@@ -455,11 +441,11 @@ impl ApplyAbilityVerbSmokeState {
                 label: Some("apply_ability_verb_smoke_runtime::read_event_ring"),
             });
         encoder.copy_buffer_to_buffer(
-            &self.event_ring_buf,
+            self.event_ring.ring(),
             0,
             &self.event_ring_staging,
             0,
-            total_bytes,
+            copy_bytes,
         );
         self.gpu.queue.submit(Some(encoder.finish()));
 

--- a/crates/auction_runtime/src/lib.rs
+++ b/crates/auction_runtime/src/lib.rs
@@ -25,7 +25,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// 16-byte WGSL `vec3<f32>` interop. Same shape as the sibling
 /// runtimes use; duplicated here to keep each fixture-runtime crate
@@ -98,6 +100,13 @@ pub struct AuctionState {
     faction_pressure: ViewStorage,
     faction_pressure_cfg_buf: wgpu::Buffer,
     faction_pressure_decay_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     pos_cache: Vec<Vec3>,
@@ -284,6 +293,12 @@ impl AuctionState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "auction_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -300,6 +315,7 @@ impl AuctionState {
             faction_pressure,
             faction_pressure_cfg_buf,
             faction_pressure_decay_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -392,17 +408,31 @@ impl CompiledSim for AuctionState {
         // read back to size the fold dispatch.
         self.event_ring.clear_tail_in(&mut encoder);
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            alive_buf: Some(&self.alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) WanderAndBid — emits 1 Bid event per alive Trader per
         // tick AND calls auctions.place_bid(self, self, amount)
         // (B1 stub `return true`).
-        let bindings = physics_WanderAndBid::PhysicsWanderAndBidBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
-            agent_alive: &self.alive_buf,
+        let extras = physics_WanderAndBid::PhysicsWanderAndBidExtras {
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let bindings =
+            physics_WanderAndBid::PhysicsWanderAndBidBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_wanderandbid(
             &mut self.cache,
             &bindings,
@@ -413,12 +443,14 @@ impl CompiledSim for AuctionState {
 
         // (2) seed_indirect_0 — keeps the indirect-args buffer warm
         // for the eventual `dispatch_workgroups_indirect` wire-up.
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx, &seed_extras,
+            );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,
@@ -444,11 +476,15 @@ impl CompiledSim for AuctionState {
             0,
             bytemuck::bytes_of(&ba_decay_cfg),
         );
+        let ba_decay_extras = decay_bid_activity::DecayBidActivityExtras {
+            view_storage_primary: self.bid_activity.primary(),
+            cfg: &self.bid_activity_decay_cfg_buf,
+        };
         let ba_decay_bindings =
-            decay_bid_activity::DecayBidActivityBindings {
-                view_storage_primary: self.bid_activity.primary(),
-                cfg: &self.bid_activity_decay_cfg_buf,
-            };
+            decay_bid_activity::DecayBidActivityBindings::from_context_with_extras(
+                &ctx,
+                &ba_decay_extras,
+            );
         dispatch::dispatch_decay_bid_activity(
             &mut self.cache,
             &ba_decay_bindings,
@@ -532,10 +568,15 @@ impl CompiledSim for AuctionState {
             0,
             bytemuck::bytes_of(&fp_decay_cfg),
         );
-        let fp_decay_bindings = decay_faction_pressure::DecayFactionPressureBindings {
+        let fp_decay_extras = decay_faction_pressure::DecayFactionPressureExtras {
             view_storage_primary: self.faction_pressure.primary(),
             cfg: &self.faction_pressure_decay_cfg_buf,
         };
+        let fp_decay_bindings =
+            decay_faction_pressure::DecayFactionPressureBindings::from_context_with_extras(
+                &ctx,
+                &fp_decay_extras,
+            );
         dispatch::dispatch_decay_faction_pressure(
             &mut self.cache,
             &fp_decay_bindings,

--- a/crates/bartering_runtime/src/lib.rs
+++ b/crates/bartering_runtime/src/lib.rs
@@ -30,7 +30,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, bytemuck::Pod, bytemuck::Zeroable)]
@@ -105,6 +107,13 @@ pub struct BarteringState {
     /// Per-receiver Trade counter. No @decay → has_anchor=false.
     trade_count: ViewStorage,
     trade_count_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     pos_cache: Vec<Vec3>,
@@ -242,6 +251,12 @@ impl BarteringState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "bartering_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -255,6 +270,7 @@ impl BarteringState {
             event_ring,
             trade_count,
             trade_count_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -318,18 +334,32 @@ impl CompiledSim for BarteringState {
 
         self.event_ring.clear_tail_in(&mut encoder);
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            alive_buf: Some(&self.alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) IdleDrift — emits 1 Trade event per alive agent.
-        let bindings = physics_IdleDrift::PhysicsIdleDriftBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
-            agent_alive: &self.alive_buf,
+        let extras = physics_IdleDrift::PhysicsIdleDriftExtras {
             agent_engaged_with: &self.engaged_with_buf,
             agent_vel: &self.vel_buf,
             coin_weight: &self.coin_weight_buf,
             caravan_size: &self.caravan_size_buf,
             cfg: &self.cfg_buf,
         };
+        let bindings =
+            physics_IdleDrift::PhysicsIdleDriftBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_idledrift(
             &mut self.cache,
             &bindings,
@@ -338,12 +368,14 @@ impl CompiledSim for BarteringState {
             self.agent_count,
         );
 
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx, &seed_extras,
+            );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,

--- a/crates/boids_runtime/src/lib.rs
+++ b/crates/boids_runtime/src/lib.rs
@@ -49,6 +49,9 @@
 //! trait, switching to a future fixture's runtime is a one-line
 //! Cargo.toml package alias change.
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 use engine::ids::AgentId;
 use engine::rng::per_agent_u32;
 use engine::sim_trait::{AgentSnapshot, CompiledSim, VizGlyph};
@@ -134,6 +137,18 @@ pub struct BoidsState {
     /// Allocated once at construction; cheaper than rebuilding a
     /// `vec![0u32; num_cells]` host array every tick.
     spatial_offsets_zero: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::event_ring`] field — boids has no
+    /// emitted events, but the compiler-emitted `from_context_with_extras`
+    /// constructor signature requires the context to expose one.
+    event_ring: EventRing,
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one (no kernel here touches any
+    /// `ability_registry_*` field).
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -583,6 +598,13 @@ impl BoidsState {
             None
         };
 
+        let event_ring = EventRing::new(&gpu, "boids_runtime");
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "boids_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -594,6 +616,8 @@ impl BoidsState {
             spatial_grid_starts,
             spatial_chunk_sums,
             spatial_offsets_zero,
+            event_ring,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -790,6 +814,19 @@ impl CompiledSim for BoidsState {
             encoder.write_timestamp(&t.query_set, 1);
         }
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Five-kernel real counting sort:
         //     2a. BuildHashCount      — per-agent atomicAdd into offsets
         //     2b. BuildHashScanLocal  — workgroup-local Hillis-Steele
@@ -813,11 +850,14 @@ impl CompiledSim for BoidsState {
         // against one another (same encoder + adjacent compute
         // passes). After the scatter, `cells` holds every agent id
         // grouped by cell, with no per-cell capacity cap.
-        let count_bindings = spatial_build_hash_count::SpatialBuildHashCountBindings {
-            agent_pos: &self.pos_buf,
+        let count_extras = spatial_build_hash_count::SpatialBuildHashCountExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             cfg: &self.cfg_buf,
         };
+        let count_bindings =
+            spatial_build_hash_count::SpatialBuildHashCountBindings::from_context_with_extras(
+                &ctx, &count_extras,
+            );
         dispatch::dispatch_spatial_build_hash_count(
             &mut self.cache,
             &count_bindings,
@@ -825,13 +865,17 @@ impl CompiledSim for BoidsState {
             &mut encoder,
             self.agent_count,
         );
-        let scan_local_bindings =
-            spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings {
+        let scan_local_extras =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalExtras {
                 spatial_grid_offsets: &self.spatial_grid_offsets,
                 spatial_grid_starts: &self.spatial_grid_starts,
                 spatial_chunk_sums: &self.spatial_chunk_sums,
                 cfg: &self.cfg_buf,
             };
+        let scan_local_bindings =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings::from_context_with_extras(
+                &ctx, &scan_local_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_local(
             &mut self.cache,
             &scan_local_bindings,
@@ -839,11 +883,15 @@ impl CompiledSim for BoidsState {
             &mut encoder,
             self.agent_count,
         );
-        let scan_carry_bindings =
-            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings {
+        let scan_carry_extras =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryExtras {
                 spatial_chunk_sums: &self.spatial_chunk_sums,
                 cfg: &self.cfg_buf,
             };
+        let scan_carry_bindings =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings::from_context_with_extras(
+                &ctx, &scan_carry_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_carry(
             &mut self.cache,
             &scan_carry_bindings,
@@ -851,13 +899,17 @@ impl CompiledSim for BoidsState {
             &mut encoder,
             self.agent_count,
         );
-        let scan_add_bindings =
-            spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings {
+        let scan_add_extras =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddExtras {
                 spatial_grid_offsets: &self.spatial_grid_offsets,
                 spatial_grid_starts: &self.spatial_grid_starts,
                 spatial_chunk_sums: &self.spatial_chunk_sums,
                 cfg: &self.cfg_buf,
             };
+        let scan_add_bindings =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings::from_context_with_extras(
+                &ctx, &scan_add_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_add(
             &mut self.cache,
             &scan_add_bindings,
@@ -865,13 +917,16 @@ impl CompiledSim for BoidsState {
             &mut encoder,
             self.agent_count,
         );
-        let scatter_bindings = spatial_build_hash_scatter::SpatialBuildHashScatterBindings {
-            agent_pos: &self.pos_buf,
+        let scatter_extras = spatial_build_hash_scatter::SpatialBuildHashScatterExtras {
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.cfg_buf,
         };
+        let scatter_bindings =
+            spatial_build_hash_scatter::SpatialBuildHashScatterBindings::from_context_with_extras(
+                &ctx, &scatter_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scatter(
             &mut self.cache,
             &scatter_bindings,
@@ -938,14 +993,16 @@ impl CompiledSim for BoidsState {
         // (3) Physics MoveBoid dispatch — reads agent_pos / agent_vel
         //     + the spatial grid (cells, offsets, starts), writes new
         //     positions/velocities.
-        let bindings = physics_MoveBoid::PhysicsMoveBoidBindings {
-            agent_pos: &self.pos_buf,
+        let extras = physics_MoveBoid::PhysicsMoveBoidExtras {
             agent_vel: &self.vel_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.cfg_buf,
         };
+        let bindings = physics_MoveBoid::PhysicsMoveBoidBindings::from_context_with_extras(
+            &ctx, &extras,
+        );
         dispatch::dispatch_physics_moveboid(
             &mut self.cache,
             &bindings,

--- a/crates/boss_fight_runtime/src/lib.rs
+++ b/crates/boss_fight_runtime/src/lib.rs
@@ -26,7 +26,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 mod binding_check;
 
@@ -675,6 +675,27 @@ impl CompiledSim for BossFightState {
             0, scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific `*Extras`.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round — fused PerPair kernel writes all 4 mask
         // bitmaps. Predicates are pure self-checks (no `target.*`
         // reads in `when`) so the mask_k=1u hardcoding doesn't matter
@@ -688,9 +709,7 @@ impl CompiledSim for BossFightState {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_BossStrike::FusedMaskVerbBossStrikeBindings {
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let mask_extras = fused_mask_verb_BossStrike::FusedMaskVerbBossStrikeExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
@@ -702,6 +721,10 @@ impl CompiledSim for BossFightState {
             mask_4_bitmap: &self.mask_4_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_BossStrike::FusedMaskVerbBossStrikeBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_bossstrike(
             &mut self.cache, &mask_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -720,10 +743,7 @@ impl CompiledSim for BossFightState {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_alive: &self.agent_alive_buf,
+        let scoring_extras = scoring::ScoringExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
@@ -734,23 +754,9 @@ impl CompiledSim for BossFightState {
             mask_4_bitmap: &self.mask_4_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
-            // Wave 1.5#7 follow-on (predicate-aware scoring,
-            // 2026-05-07): scoring kernel now inlines per-effect when-
-            // predicate eval; same SoA + agent stat columns as the
-            // chronicle dispatcher.
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -768,32 +774,13 @@ impl CompiledSim for BossFightState {
         self.gpu.queue.write_buffer(
             &self.chronicle_boss_strike_cfg_buf, 0, bytemuck::bytes_of(&bs_cfg),
         );
-        let bs_bindings = physics_verb_chronicle_BossStrike::PhysicsVerbChronicleBossStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_hp: &self.agent_hp_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_mana: &self.agent_mana_buf,
+        let bs_extras = physics_verb_chronicle_BossStrike::PhysicsVerbChronicleBossStrikeExtras {
             cfg: &self.chronicle_boss_strike_cfg_buf,
         };
+        let bs_bindings =
+            physics_verb_chronicle_BossStrike::PhysicsVerbChronicleBossStrikeBindings::from_context_with_extras(
+                &ctx, &bs_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_bossstrike(
             &mut self.cache, &bs_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -806,11 +793,13 @@ impl CompiledSim for BossFightState {
         self.gpu.queue.write_buffer(
             &self.chronicle_boss_heal_cfg_buf, 0, bytemuck::bytes_of(&bh_cfg),
         );
-        let bh_bindings = physics_verb_chronicle_BossSelfHeal::PhysicsVerbChronicleBossSelfHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let bh_extras = physics_verb_chronicle_BossSelfHeal::PhysicsVerbChronicleBossSelfHealExtras {
             cfg: &self.chronicle_boss_heal_cfg_buf,
         };
+        let bh_bindings =
+            physics_verb_chronicle_BossSelfHeal::PhysicsVerbChronicleBossSelfHealBindings::from_context_with_extras(
+                &ctx, &bh_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_bossselfheal(
             &mut self.cache, &bh_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -828,32 +817,13 @@ impl CompiledSim for BossFightState {
         self.gpu.queue.write_buffer(
             &self.chronicle_hero_attack_cfg_buf, 0, bytemuck::bytes_of(&ha_cfg),
         );
-        let ha_bindings = physics_verb_chronicle_HeroAttack::PhysicsVerbChronicleHeroAttackBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_hp: &self.agent_hp_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_mana: &self.agent_mana_buf,
+        let ha_extras = physics_verb_chronicle_HeroAttack::PhysicsVerbChronicleHeroAttackExtras {
             cfg: &self.chronicle_hero_attack_cfg_buf,
         };
+        let ha_bindings =
+            physics_verb_chronicle_HeroAttack::PhysicsVerbChronicleHeroAttackBindings::from_context_with_extras(
+                &ctx, &ha_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_heroattack(
             &mut self.cache, &ha_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -879,32 +849,13 @@ impl CompiledSim for BossFightState {
         self.gpu.queue.write_buffer(
             &self.chronicle_hero_stun_cfg_buf, 0, bytemuck::bytes_of(&hs_cfg),
         );
-        let hs_bindings = physics_verb_chronicle_HeroStun::PhysicsVerbChronicleHeroStunBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_hp: &self.agent_hp_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_mana: &self.agent_mana_buf,
+        let hs_extras = physics_verb_chronicle_HeroStun::PhysicsVerbChronicleHeroStunExtras {
             cfg: &self.chronicle_hero_stun_cfg_buf,
         };
+        let hs_bindings =
+            physics_verb_chronicle_HeroStun::PhysicsVerbChronicleHeroStunBindings::from_context_with_extras(
+                &ctx, &hs_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_herostun(
             &mut self.cache, &hs_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -932,32 +883,13 @@ impl CompiledSim for BossFightState {
         self.gpu.queue.write_buffer(
             &self.chronicle_hero_heal_cfg_buf, 0, bytemuck::bytes_of(&hh_cfg),
         );
-        let hh_bindings = physics_verb_chronicle_HeroHeal::PhysicsVerbChronicleHeroHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp: &self.agent_max_hp_buf,
-            agent_hp: &self.agent_hp_buf,
-            agent_armor: &self.agent_armor_buf,
-            agent_magic_resist: &self.agent_magic_resist_buf,
-            agent_move_speed: &self.agent_move_speed_buf,
-            agent_mana: &self.agent_mana_buf,
+        let hh_extras = physics_verb_chronicle_HeroHeal::PhysicsVerbChronicleHeroHealExtras {
             cfg: &self.chronicle_hero_heal_cfg_buf,
         };
+        let hh_bindings =
+            physics_verb_chronicle_HeroHeal::PhysicsVerbChronicleHeroHealBindings::from_context_with_extras(
+                &ctx, &hh_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_heroheal(
             &mut self.cache, &hh_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -999,15 +931,15 @@ impl CompiledSim for BossFightState {
             0,
             bytemuck::bytes_of(&apply_chronicle_cfg),
         );
-        let apply_chronicle_bindings =
-            physics_ApplyDamageFromChronicle_and_ApplyStunFromChronicle_and_ApplyHealFromChronicle::PhysicsApplyDamageFromChronicleAndApplyStunFromChronicleAndApplyHealFromChronicleBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_max_hp: &self.agent_max_hp_buf,
+        let apply_chronicle_extras =
+            physics_ApplyDamageFromChronicle_and_ApplyStunFromChronicle_and_ApplyHealFromChronicle::PhysicsApplyDamageFromChronicleAndApplyStunFromChronicleAndApplyHealFromChronicleExtras {
                 agent_stun_expires_at_tick: &self.agent_stun_expires_at_tick_buf,
                 cfg: &self.apply_chronicle_cfg_buf,
             };
+        let apply_chronicle_bindings =
+            physics_ApplyDamageFromChronicle_and_ApplyStunFromChronicle_and_ApplyHealFromChronicle::PhysicsApplyDamageFromChronicleAndApplyStunFromChronicleAndApplyHealFromChronicleBindings::from_context_with_extras(
+                &ctx, &apply_chronicle_extras,
+            );
         dispatch::dispatch_physics_applydamagefromchronicle_and_applystunfromchronicle_and_applyhealfromchronicle(
             &mut self.cache,
             &apply_chronicle_bindings,
@@ -1028,13 +960,13 @@ impl CompiledSim for BossFightState {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings =
+            physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings::from_context_with_extras(
+                &ctx, &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage_and_applyheal(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -1049,12 +981,14 @@ impl CompiledSim for BossFightState {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings =
+            seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx, &seed_extras,
+            );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,


### PR DESCRIPTION
## Summary

Phase 4 batch 1 of 5 of the compiler-emitted Bindings constructors plan (`docs/superpowers/plans/2026-05-09-compiler-emitted-bindings-constructors.md`, task 7) — replaces hand-written `<Kernel>Bindings { ... }` literals at every non-fold dispatch site across 9 runtimes with `from_context_with_extras()` calls. Each runtime now builds one `KernelBindingsContext` + `AgentBuffers` aggregate per tick and threads it into each kernel; per-kernel fixture-specific buffers ride small `*Extras` structs.

Runtimes migrated:
- abilities_runtime, auction_runtime, bartering_runtime — added empty `PackedAbilityRegistryGpu` placeholder (no abilities, but the constructor signature requires the field).
- boids_runtime — added empty `EventRing` + `PackedAbilityRegistryGpu` placeholders (boids has neither).
- boss_fight_runtime — biggest collapse, ~150 lines of stat + registry plumbing per chronicle kernel reduced to a shared 12-field AgentBuffers ctx.
- apply_ability_smoke_runtime, apply_ability_chronicle_consumer_runtime, apply_ability_verb_smoke_runtime, apply_ability_verb_chronicle_consumer_runtime — switched their raw `event_ring_buf` + `event_tail_buf` fields to a shared `EventRing` since the compiler-emitted constructor resolves `event_ring` / `event_tail` exclusively through `ctx.event_ring.ring()` / `ctx.event_ring.tail()` (no extras fall-through for those names).

LOC delta: **+19 net** (+578 insertions, -559 deletions). Chronicle-kernel collapses on boss_fight + apply_ability_* (each saves ~25 lines per kernel) approximately balance the per-runtime ctx-construction floor.

ViewFold (`fold_*`) kernels remain hand-written per the plan — the compiler doesn't emit `from_context` constructors for them.

## Test plan

- [x] `cargo build --release` — clean.
- [x] `cargo test -p engine --release --test schema_hash` — both pass (P2: schema hash unchanged).
- [x] `cargo test -p abilities_runtime --release` — pass.
- [x] `cargo test -p apply_ability_chronicle_consumer_runtime --release` — pass (2 closed-loop pins).
- [x] `cargo test -p apply_ability_smoke_runtime --release` — pass (parity sweep + 17 chronicle pins).
- [x] `cargo test -p apply_ability_verb_chronicle_consumer_runtime --release` — pass.
- [x] `cargo test -p apply_ability_verb_smoke_runtime --release` — pass.
- [x] `cargo test -p auction_runtime --release` — pass.
- [x] `cargo test -p bartering_runtime --release` — pass.
- [x] `cargo test -p boids_runtime --release` — pass (2 unit tests).
- [x] `cargo test -p boss_fight_runtime --release` — pass (5 unit tests including `hero_stun_locks_boss` cascade).

## Constitution alignment

- P1 Compiler-First: PASS — using compiler-emitted constructors.
- P2 Schema-Hash: PASS — unchanged.
- P5 Determinism: PASS — pure refactor.
- P10 No Runtime Panic: PASS — type-checked at compile time; missing agent buffers surface as `expect("kernel binds X but the runtime didn't supply ctx.state.X")` clear errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)