### PR TITLE
refactor(runtimes): migrate Phase 4 batch 2/5 to compiler-emitted Bindings constructors

### DIFF
--- a/crates/cooldown_probe_runtime/src/lib.rs
+++ b/crates/cooldown_probe_runtime/src/lib.rs
@@ -46,7 +46,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture state for the cooldown probe. Owns:
 ///   - Agent SoA (alive + cooldown_next_ready_tick — two buffers)
@@ -74,6 +76,12 @@ pub struct CooldownProbeState {
     // -- Per-kernel cfg uniforms --
     physics_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -158,6 +166,12 @@ impl CooldownProbeState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "cooldown_probe_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -167,6 +181,7 @@ impl CooldownProbeState {
             activations_cfg_buf,
             physics_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -205,6 +220,19 @@ impl CompiledSim for CooldownProbeState {
         // (1) Per-tick clear of event_tail.
         self.event_ring.clear_tail_in(&mut encoder);
 
+        // Shared once per tick; each dispatch below adds only its
+        // fixture-specific extras struct.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) physics_CheckAndCast — reads agent_alive + agent_cooldown_
         // next_ready_tick. For each alive agent: if `tick >= ready_at`,
         // emits ActivationLogged{ caster=self, activated=1.0 } into the
@@ -217,13 +245,15 @@ impl CompiledSim for CooldownProbeState {
         self.gpu
             .queue
             .write_buffer(&self.physics_cfg_buf, 0, bytemuck::bytes_of(&physics_cfg));
-        let physics_bindings = physics_CheckAndCast::PhysicsCheckAndCastBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_alive: &self.agent_alive_buf,
+        let physics_extras = physics_CheckAndCast::PhysicsCheckAndCastExtras {
             agent_cooldown_next_ready_tick: &self.agent_cooldown_next_ready_tick_buf,
             cfg: &self.physics_cfg_buf,
         };
+        let physics_bindings =
+            physics_CheckAndCast::PhysicsCheckAndCastBindings::from_context_with_extras(
+                &ctx,
+                &physics_extras,
+            );
         dispatch::dispatch_physics_checkandcast(
             &mut self.cache,
             &physics_bindings,
@@ -243,12 +273,14 @@ impl CompiledSim for CooldownProbeState {
         self.gpu
             .queue
             .write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,

--- a/crates/crowd_navigation_runtime/src/lib.rs
+++ b/crates/crowd_navigation_runtime/src/lib.rs
@@ -8,6 +8,8 @@
 //! memberships + leader-driven goal updates, and the utility-
 //! backend scoring rows from the design target.
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
 use engine::ids::AgentId;
 use engine::rng::per_agent_u32;
 use engine::sim_trait::CompiledSim;
@@ -17,7 +19,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, bytemuck::Pod, bytemuck::Zeroable)]
@@ -58,6 +60,12 @@ pub struct CrowdNavigationState {
     /// [`Self::stuck_counts`].
     stuck_count: ViewStorage,
     stuck_count_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     pos_cache: Vec<Vec3>,
@@ -154,6 +162,12 @@ impl CrowdNavigationState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "crowd_navigation_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -163,6 +177,7 @@ impl CrowdNavigationState {
             event_ring,
             stuck_count,
             stuck_count_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -230,16 +245,30 @@ impl CompiledSim for CrowdNavigationState {
         // Clear event_tail before producers run.
         self.event_ring.clear_tail_in(&mut encoder);
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) MoveWalker — emits Stuck { walker: self, ticks: 1 }
         // each tick. event_ring + event_tail bindings synthesized
         // by the binding-gen for any EventRing access.
-        let bindings = physics_MoveWalker::PhysicsMoveWalkerBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
+        let extras = physics_MoveWalker::PhysicsMoveWalkerExtras {
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let bindings =
+            physics_MoveWalker::PhysicsMoveWalkerBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_movewalker(
             &mut self.cache,
             &bindings,
@@ -249,12 +278,14 @@ impl CompiledSim for CrowdNavigationState {
         );
 
         // (2) seed_indirect_0 — keeps indirect-args buffer warm.
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,

--- a/crates/diplomacy_probe_runtime/src/lib.rs
+++ b/crates/diplomacy_probe_runtime/src/lib.rs
@@ -52,7 +52,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture state for the diplomacy probe. Owns:
 ///   - Diplomat SoA (alive only — pos/vel are declaration-only here)
@@ -108,6 +110,12 @@ pub struct DiplomacyProbeState {
     chronicle_propose_cfg_buf: wgpu::Buffer,
     chronicle_betray_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -324,6 +332,12 @@ impl DiplomacyProbeState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "diplomacy_probe_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -348,6 +362,7 @@ impl DiplomacyProbeState {
             chronicle_propose_cfg_buf,
             chronicle_betray_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -441,6 +456,16 @@ impl CompiledSim for DiplomacyProbeState {
             mask_bytes.max(4),
         );
 
+        // Shared agent buffer aggregate — `alive` is the only standard
+        // SoA column this fixture owns. The `KernelBindingsContext` is
+        // rebuilt before each `note_emits` boundary because the compiler-
+        // emitted constructors borrow `self.event_ring` immutably and
+        // `note_emits` requires `&mut self.event_ring`.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+
         // (2) ObserveAndAct — per-Diplomat; emits one Observed event
         // per tick into the ring (kind 1u). observer == target == self
         // placeholder routing (real spatial broadcast is a follow-up).
@@ -454,19 +479,29 @@ impl CompiledSim for DiplomacyProbeState {
             0,
             bytemuck::bytes_of(&observe_cfg),
         );
-        let observe_bindings = physics_ObserveAndAct::PhysicsObserveAndActBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_alive: &self.agent_alive_buf,
-            cfg: &self.observe_cfg_buf,
-        };
-        dispatch::dispatch_physics_observeandact(
-            &mut self.cache,
-            &observe_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count,
-        );
+        {
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
+            };
+            let observe_extras = physics_ObserveAndAct::PhysicsObserveAndActExtras {
+                cfg: &self.observe_cfg_buf,
+            };
+            let observe_bindings =
+                physics_ObserveAndAct::PhysicsObserveAndActBindings::from_context_with_extras(
+                    &ctx,
+                    &observe_extras,
+                );
+            dispatch::dispatch_physics_observeandact(
+                &mut self.cache,
+                &observe_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count,
+            );
+        }
         // ObserveAndAct's emit-Observed body adds one slot per alive
         // agent (worst case: all alive). The host-side EventRing tail
         // estimate tracks this so downstream chronicle / fold dispatches
@@ -488,48 +523,61 @@ impl CompiledSim for DiplomacyProbeState {
         self.gpu
             .queue
             .write_buffer(&self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg));
-        let mask_bindings =
-            fused_mask_verb_ProposeAlliance::FusedMaskVerbProposeAllianceBindings {
+        {
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
+            };
+            let mask_extras =
+                fused_mask_verb_ProposeAlliance::FusedMaskVerbProposeAllianceExtras {
+                    mask_0_bitmap: &self.mask_0_bitmap_buf,
+                    mask_1_bitmap: &self.mask_1_bitmap_buf,
+                    cfg: &self.mask_cfg_buf,
+                };
+            let mask_bindings =
+                fused_mask_verb_ProposeAlliance::FusedMaskVerbProposeAllianceBindings::from_context_with_extras(
+                    &ctx,
+                    &mask_extras,
+                );
+            dispatch::dispatch_fused_mask_verb_proposealliance(
+                &mut self.cache,
+                &mask_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count,
+            );
+
+            // (4) Scoring — argmax over the 2 competing rows. Mask gates
+            // filter out masked-out rows, so whichever verb's predicate
+            // is true wins. Emits one ActionSelected (kind 4u) per agent.
+            let scoring_cfg = scoring::ScoringCfg {
+                agent_cap: self.agent_count,
+                tick: self.tick as u32,
+                seed: 0, _pad: 0,
+            };
+            self.gpu.queue.write_buffer(
+                &self.scoring_cfg_buf,
+                0,
+                bytemuck::bytes_of(&scoring_cfg),
+            );
+            let scoring_extras = scoring::ScoringExtras {
                 mask_0_bitmap: &self.mask_0_bitmap_buf,
                 mask_1_bitmap: &self.mask_1_bitmap_buf,
-                cfg: &self.mask_cfg_buf,
+                scoring_output: &self.scoring_output_buf,
+                cfg: &self.scoring_cfg_buf,
             };
-        dispatch::dispatch_fused_mask_verb_proposealliance(
-            &mut self.cache,
-            &mask_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count,
-        );
-
-        // (4) Scoring — argmax over the 2 competing rows. Mask gates
-        // filter out masked-out rows, so whichever verb's predicate
-        // is true wins. Emits one ActionSelected (kind 4u) per agent.
-        let scoring_cfg = scoring::ScoringCfg {
-            agent_cap: self.agent_count,
-            tick: self.tick as u32,
-            seed: 0, _pad: 0,
-        };
-        self.gpu.queue.write_buffer(
-            &self.scoring_cfg_buf,
-            0,
-            bytemuck::bytes_of(&scoring_cfg),
-        );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            mask_0_bitmap: &self.mask_0_bitmap_buf,
-            mask_1_bitmap: &self.mask_1_bitmap_buf,
-            scoring_output: &self.scoring_output_buf,
-            cfg: &self.scoring_cfg_buf,
-        };
-        dispatch::dispatch_scoring(
-            &mut self.cache,
-            &scoring_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count,
-        );
+            let scoring_bindings =
+                scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
+            dispatch::dispatch_scoring(
+                &mut self.cache,
+                &scoring_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count,
+            );
+        }
 
         // (4b) Note that the scoring kernel emits one ActionSelected
         // per agent into the ring; bump the host-side EventRing tail
@@ -563,19 +611,30 @@ impl CompiledSim for DiplomacyProbeState {
             0,
             bytemuck::bytes_of(&propose_chronicle_cfg),
         );
-        let propose_chronicle_bindings =
-            physics_verb_chronicle_ProposeAlliance::PhysicsVerbChronicleProposeAllianceBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_propose_cfg_buf,
+        {
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
             };
-        dispatch::dispatch_physics_verb_chronicle_proposealliance(
-            &mut self.cache,
-            &propose_chronicle_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count.saturating_mul(2),
-        );
+            let propose_chronicle_extras =
+                physics_verb_chronicle_ProposeAlliance::PhysicsVerbChronicleProposeAllianceExtras {
+                    cfg: &self.chronicle_propose_cfg_buf,
+                };
+            let propose_chronicle_bindings =
+                physics_verb_chronicle_ProposeAlliance::PhysicsVerbChronicleProposeAllianceBindings::from_context_with_extras(
+                    &ctx,
+                    &propose_chronicle_extras,
+                );
+            dispatch::dispatch_physics_verb_chronicle_proposealliance(
+                &mut self.cache,
+                &propose_chronicle_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count.saturating_mul(2),
+            );
+        }
         // The ProposeAlliance chronicle's gate-passes slots produce
         // up to one AllianceProposed event per agent (whichever
         // ActionSelected matched `action_id == 0u`). Bump the tail
@@ -600,19 +659,30 @@ impl CompiledSim for DiplomacyProbeState {
             0,
             bytemuck::bytes_of(&betray_chronicle_cfg),
         );
-        let betray_chronicle_bindings =
-            physics_verb_chronicle_Betray::PhysicsVerbChronicleBetrayBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_betray_cfg_buf,
+        {
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
             };
-        dispatch::dispatch_physics_verb_chronicle_betray(
-            &mut self.cache,
-            &betray_chronicle_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count.saturating_mul(2),
-        );
+            let betray_chronicle_extras =
+                physics_verb_chronicle_Betray::PhysicsVerbChronicleBetrayExtras {
+                    cfg: &self.chronicle_betray_cfg_buf,
+                };
+            let betray_chronicle_bindings =
+                physics_verb_chronicle_Betray::PhysicsVerbChronicleBetrayBindings::from_context_with_extras(
+                    &ctx,
+                    &betray_chronicle_extras,
+                );
+            dispatch::dispatch_physics_verb_chronicle_betray(
+                &mut self.cache,
+                &betray_chronicle_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count.saturating_mul(2),
+            );
+        }
         // Betray chronicle's gate-passes slots produce up to one
         // Betrayed event per agent. Tail estimate after this round
         // covers everything the folds will see (Observed +
@@ -628,19 +698,29 @@ impl CompiledSim for DiplomacyProbeState {
         self.gpu
             .queue
             .write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            indirect_args_0: self.event_ring.indirect_args_0(),
-            cfg: &self.seed_cfg_buf,
-        };
-        dispatch::dispatch_seed_indirect_0(
-            &mut self.cache,
-            &seed_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count,
-        );
+        {
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
+            };
+            let seed_extras = seed_indirect_0::SeedIndirect0Extras {
+                indirect_args_0: self.event_ring.indirect_args_0(),
+                cfg: &self.seed_cfg_buf,
+            };
+            let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx,
+                &seed_extras,
+            );
+            dispatch::dispatch_seed_indirect_0(
+                &mut self.cache,
+                &seed_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count,
+            );
+        }
 
         // (8-10) Three folds reading the SAME ring, partitioned by
         // per-handler tag filter (kind 1u/2u/3u). event_count sourced

--- a/crates/duel_1v1_runtime/src/lib.rs
+++ b/crates/duel_1v1_runtime/src/lib.rs
@@ -55,7 +55,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture state for the duel.
 pub struct Duel1v1State {
@@ -107,6 +109,12 @@ pub struct Duel1v1State {
     chronicle_heal_cfg_buf: wgpu::Buffer,
     apply_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — duel_1v1's verbs use
+    /// inline emit, not the packed-ability path, but the compiler-emitted
+    /// constructor signature requires the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -281,6 +289,12 @@ impl Duel1v1State {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "duel_1v1_runtime",
+        );
+
         Self {
             gpu,
             agent_hp_buf,
@@ -305,6 +319,7 @@ impl Duel1v1State {
             chronicle_heal_cfg_buf,
             apply_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -463,15 +478,35 @@ impl CompiledSim for Duel1v1State {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_Strike::FusedMaskVerbStrikeBindings {
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
-            agent_mana: &self.agent_mana_buf,
+
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct. Fold kernels still use
+        // hand-written `Bindings { ... }` literals — the compiler
+        // doesn't emit `from_context` constructors for them.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
+        let mask_extras = fused_mask_verb_Strike::FusedMaskVerbStrikeExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_Strike::FusedMaskVerbStrikeBindings::from_context_with_extras(
+                &ctx,
+                &mask_extras,
+            );
         // PerPair mask kernel dispatches `agent_cap × agent_cap`
         // threads — every (actor, candidate) pair. The per-mask
         // body alias `mask_<ID>_k = cfg.agent_cap` (compiler change
@@ -495,16 +530,15 @@ impl CompiledSim for Duel1v1State {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -517,11 +551,14 @@ impl CompiledSim for Duel1v1State {
         self.gpu.queue.write_buffer(
             &self.chronicle_strike_cfg_buf, 0, bytemuck::bytes_of(&strike_cfg),
         );
-        let strike_bindings = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let strike_extras = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeExtras {
             cfg: &self.chronicle_strike_cfg_buf,
         };
+        let strike_bindings =
+            physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings::from_context_with_extras(
+                &ctx,
+                &strike_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_strike(
             &mut self.cache, &strike_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -534,11 +571,14 @@ impl CompiledSim for Duel1v1State {
         self.gpu.queue.write_buffer(
             &self.chronicle_spell_cfg_buf, 0, bytemuck::bytes_of(&spell_cfg),
         );
-        let spell_bindings = physics_verb_chronicle_Spell::PhysicsVerbChronicleSpellBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let spell_extras = physics_verb_chronicle_Spell::PhysicsVerbChronicleSpellExtras {
             cfg: &self.chronicle_spell_cfg_buf,
         };
+        let spell_bindings =
+            physics_verb_chronicle_Spell::PhysicsVerbChronicleSpellBindings::from_context_with_extras(
+                &ctx,
+                &spell_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_spell(
             &mut self.cache, &spell_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -551,11 +591,14 @@ impl CompiledSim for Duel1v1State {
         self.gpu.queue.write_buffer(
             &self.chronicle_heal_cfg_buf, 0, bytemuck::bytes_of(&heal_cfg),
         );
-        let heal_bindings = physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let heal_extras = physics_verb_chronicle_Heal::PhysicsVerbChronicleHealExtras {
             cfg: &self.chronicle_heal_cfg_buf,
         };
+        let heal_bindings =
+            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings::from_context_with_extras(
+                &ctx,
+                &heal_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_heal(
             &mut self.cache, &heal_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -575,13 +618,14 @@ impl CompiledSim for Duel1v1State {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings =
+            physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings::from_context_with_extras(
+                &ctx,
+                &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage_and_applyheal(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -596,12 +640,14 @@ impl CompiledSim for Duel1v1State {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/duel_abilities_runtime/src/lib.rs
+++ b/crates/duel_abilities_runtime/src/lib.rs
@@ -87,7 +87,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 mod binding_check;
 
@@ -1061,6 +1061,30 @@ impl CompiledSim for DuelAbilitiesState {
             0, scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct. Fold kernels still build
+        // hand-written `Bindings { ... }` literals — the compiler
+        // doesn't emit `from_context` constructors for them.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            shield_hp_buf: Some(&self.agent_shield_hp_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round.
         let mask_cfg = fused_mask_verb_Strike::FusedMaskVerbStrikeCfg {
             agent_cap: self.agent_count,
@@ -1080,9 +1104,7 @@ impl CompiledSim for DuelAbilitiesState {
         // `agents.stun_expires_at_tick(self) <= world.tick`. This is
         // the FIRST status-SoA field bound to the mask kernel — the
         // previous fixture had only purely-functional reads (hp, alive).
-        let mask_bindings = fused_mask_verb_Strike::FusedMaskVerbStrikeBindings {
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let mask_extras = fused_mask_verb_Strike::FusedMaskVerbStrikeExtras {
             agent_stun_expires_at_tick: &self.agent_stun_expires_at_tick_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
@@ -1094,6 +1116,11 @@ impl CompiledSim for DuelAbilitiesState {
             mask_7_bitmap: &self.mask_7_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_Strike::FusedMaskVerbStrikeBindings::from_context_with_extras(
+                &ctx,
+                &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_strike(
             &mut self.cache, &mask_bindings, &self.gpu.device, &mut encoder,
             self.agent_count * self.agent_count,
@@ -1114,10 +1141,7 @@ impl CompiledSim for DuelAbilitiesState {
         // agent_hp[candidate]. Without that pair iteration the
         // best_target slot stays at the 0xFFFFFFFF sentinel and the
         // chronicle's emitted Damaged event addresses an OOB slot.
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
@@ -1128,23 +1152,9 @@ impl CompiledSim for DuelAbilitiesState {
             mask_7_bitmap: &self.mask_7_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
-            // Wave 1.5#7 follow-on (predicate-aware scoring,
-            // 2026-05-07): the scoring kernel's per-row body inlines a
-            // predicate-eval gate using the same registry SoA columns
-            // and agent stat columns the chronicle dispatcher uses.
-            // See `cg::lower::driver::wire_scoring_predicate_reads`.
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1169,32 +1179,14 @@ impl CompiledSim for DuelAbilitiesState {
         self.gpu.queue.write_buffer(
             &self.chronicle_shieldup_cfg_buf, 0, bytemuck::bytes_of(&shieldup_cfg),
         );
-        let shieldup_bindings = physics_verb_chronicle_ShieldUp::PhysicsVerbChronicleShieldUpBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let shieldup_extras = physics_verb_chronicle_ShieldUp::PhysicsVerbChronicleShieldUpExtras {
             cfg: &self.chronicle_shieldup_cfg_buf,
         };
+        let shieldup_bindings =
+            physics_verb_chronicle_ShieldUp::PhysicsVerbChronicleShieldUpBindings::from_context_with_extras(
+                &ctx,
+                &shieldup_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_shieldup(
             &mut self.cache, &shieldup_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1211,32 +1203,14 @@ impl CompiledSim for DuelAbilitiesState {
         self.gpu.queue.write_buffer(
             &self.chronicle_mend_cfg_buf, 0, bytemuck::bytes_of(&mend_cfg),
         );
-        let mend_bindings = physics_verb_chronicle_Mend::PhysicsVerbChronicleMendBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let mend_extras = physics_verb_chronicle_Mend::PhysicsVerbChronicleMendExtras {
             cfg: &self.chronicle_mend_cfg_buf,
         };
+        let mend_bindings =
+            physics_verb_chronicle_Mend::PhysicsVerbChronicleMendBindings::from_context_with_extras(
+                &ctx,
+                &mend_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_mend(
             &mut self.cache, &mend_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1257,32 +1231,14 @@ impl CompiledSim for DuelAbilitiesState {
         self.gpu.queue.write_buffer(
             &self.chronicle_bleed_cfg_buf, 0, bytemuck::bytes_of(&bleed_cfg),
         );
-        let bleed_bindings = physics_verb_chronicle_Bleed::PhysicsVerbChronicleBleedBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let bleed_extras = physics_verb_chronicle_Bleed::PhysicsVerbChronicleBleedExtras {
             cfg: &self.chronicle_bleed_cfg_buf,
         };
+        let bleed_bindings =
+            physics_verb_chronicle_Bleed::PhysicsVerbChronicleBleedBindings::from_context_with_extras(
+                &ctx,
+                &bleed_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_bleed(
             &mut self.cache, &bleed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1303,32 +1259,14 @@ impl CompiledSim for DuelAbilitiesState {
         self.gpu.queue.write_buffer(
             &self.chronicle_reap_cfg_buf, 0, bytemuck::bytes_of(&reap_cfg),
         );
-        let reap_bindings = physics_verb_chronicle_Reap::PhysicsVerbChronicleReapBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let reap_extras = physics_verb_chronicle_Reap::PhysicsVerbChronicleReapExtras {
             cfg: &self.chronicle_reap_cfg_buf,
         };
+        let reap_bindings =
+            physics_verb_chronicle_Reap::PhysicsVerbChronicleReapBindings::from_context_with_extras(
+                &ctx,
+                &reap_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_reap(
             &mut self.cache, &reap_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1351,32 +1289,14 @@ impl CompiledSim for DuelAbilitiesState {
         self.gpu.queue.write_buffer(
             &self.chronicle_vampirize_cfg_buf, 0, bytemuck::bytes_of(&vampirize_cfg),
         );
-        let vampirize_bindings = physics_verb_chronicle_Vampirize::PhysicsVerbChronicleVampirizeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let vampirize_extras = physics_verb_chronicle_Vampirize::PhysicsVerbChronicleVampirizeExtras {
             cfg: &self.chronicle_vampirize_cfg_buf,
         };
+        let vampirize_bindings =
+            physics_verb_chronicle_Vampirize::PhysicsVerbChronicleVampirizeBindings::from_context_with_extras(
+                &ctx,
+                &vampirize_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_vampirize(
             &mut self.cache, &vampirize_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1399,32 +1319,14 @@ impl CompiledSim for DuelAbilitiesState {
         self.gpu.queue.write_buffer(
             &self.chronicle_fortify_cfg_buf, 0, bytemuck::bytes_of(&fortify_cfg),
         );
-        let fortify_bindings = physics_verb_chronicle_Fortify::PhysicsVerbChronicleFortifyBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let fortify_extras = physics_verb_chronicle_Fortify::PhysicsVerbChronicleFortifyExtras {
             cfg: &self.chronicle_fortify_cfg_buf,
         };
+        let fortify_bindings =
+            physics_verb_chronicle_Fortify::PhysicsVerbChronicleFortifyBindings::from_context_with_extras(
+                &ctx,
+                &fortify_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_fortify(
             &mut self.cache, &fortify_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1447,32 +1349,14 @@ impl CompiledSim for DuelAbilitiesState {
         self.gpu.queue.write_buffer(
             &self.chronicle_daze_cfg_buf, 0, bytemuck::bytes_of(&daze_cfg),
         );
-        let daze_bindings = physics_verb_chronicle_Daze::PhysicsVerbChronicleDazeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_hp:            &self.agent_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
+        let daze_extras = physics_verb_chronicle_Daze::PhysicsVerbChronicleDazeExtras {
             cfg: &self.chronicle_daze_cfg_buf,
         };
+        let daze_bindings =
+            physics_verb_chronicle_Daze::PhysicsVerbChronicleDazeBindings::from_context_with_extras(
+                &ctx,
+                &daze_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_daze(
             &mut self.cache, &daze_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -1500,11 +1384,15 @@ impl CompiledSim for DuelAbilitiesState {
             &self.apply_shield_from_chronicle_cfg_buf, 0,
             bytemuck::bytes_of(&apply_shield_from_chronicle_cfg),
         );
-        let apply_shield_from_chronicle_bindings = physics_ApplyShieldFromChronicle::PhysicsApplyShieldFromChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.apply_shield_from_chronicle_cfg_buf,
-        };
+        let apply_shield_from_chronicle_extras =
+            physics_ApplyShieldFromChronicle::PhysicsApplyShieldFromChronicleExtras {
+                cfg: &self.apply_shield_from_chronicle_cfg_buf,
+            };
+        let apply_shield_from_chronicle_bindings =
+            physics_ApplyShieldFromChronicle::PhysicsApplyShieldFromChronicleBindings::from_context_with_extras(
+                &ctx,
+                &apply_shield_from_chronicle_extras,
+            );
         dispatch::dispatch_physics_applyshieldfromchronicle(
             &mut self.cache, &apply_shield_from_chronicle_bindings,
             &self.gpu.device, &mut encoder, max_slots_per_tick,
@@ -1525,11 +1413,15 @@ impl CompiledSim for DuelAbilitiesState {
             &self.apply_heal_from_chronicle_cfg_buf, 0,
             bytemuck::bytes_of(&apply_heal_from_chronicle_cfg),
         );
-        let apply_heal_from_chronicle_bindings = physics_ApplyHealFromChronicle::PhysicsApplyHealFromChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.apply_heal_from_chronicle_cfg_buf,
-        };
+        let apply_heal_from_chronicle_extras =
+            physics_ApplyHealFromChronicle::PhysicsApplyHealFromChronicleExtras {
+                cfg: &self.apply_heal_from_chronicle_cfg_buf,
+            };
+        let apply_heal_from_chronicle_bindings =
+            physics_ApplyHealFromChronicle::PhysicsApplyHealFromChronicleBindings::from_context_with_extras(
+                &ctx,
+                &apply_heal_from_chronicle_extras,
+            );
         dispatch::dispatch_physics_applyhealfromchronicle(
             &mut self.cache, &apply_heal_from_chronicle_bindings,
             &self.gpu.device, &mut encoder, max_slots_per_tick,
@@ -1558,11 +1450,15 @@ impl CompiledSim for DuelAbilitiesState {
             &self.apply_stun_from_chronicle_cfg_buf, 0,
             bytemuck::bytes_of(&apply_stun_from_chronicle_cfg),
         );
-        let apply_stun_from_chronicle_bindings = physics_ApplyStunFromChronicle::PhysicsApplyStunFromChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.apply_stun_from_chronicle_cfg_buf,
-        };
+        let apply_stun_from_chronicle_extras =
+            physics_ApplyStunFromChronicle::PhysicsApplyStunFromChronicleExtras {
+                cfg: &self.apply_stun_from_chronicle_cfg_buf,
+            };
+        let apply_stun_from_chronicle_bindings =
+            physics_ApplyStunFromChronicle::PhysicsApplyStunFromChronicleBindings::from_context_with_extras(
+                &ctx,
+                &apply_stun_from_chronicle_extras,
+            );
         dispatch::dispatch_physics_applystunfromchronicle(
             &mut self.cache, &apply_stun_from_chronicle_bindings,
             &self.gpu.device, &mut encoder, max_slots_per_tick,
@@ -1593,11 +1489,15 @@ impl CompiledSim for DuelAbilitiesState {
             &self.apply_damage_from_self_damage_chronicle_cfg_buf, 0,
             bytemuck::bytes_of(&apply_damage_from_self_damage_chronicle_cfg),
         );
-        let apply_damage_from_self_damage_chronicle_bindings = physics_ApplyDamageFromSelfDamageChronicle::PhysicsApplyDamageFromSelfDamageChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.apply_damage_from_self_damage_chronicle_cfg_buf,
-        };
+        let apply_damage_from_self_damage_chronicle_extras =
+            physics_ApplyDamageFromSelfDamageChronicle::PhysicsApplyDamageFromSelfDamageChronicleExtras {
+                cfg: &self.apply_damage_from_self_damage_chronicle_cfg_buf,
+            };
+        let apply_damage_from_self_damage_chronicle_bindings =
+            physics_ApplyDamageFromSelfDamageChronicle::PhysicsApplyDamageFromSelfDamageChronicleBindings::from_context_with_extras(
+                &ctx,
+                &apply_damage_from_self_damage_chronicle_extras,
+            );
         dispatch::dispatch_physics_applydamagefromselfdamagechronicle(
             &mut self.cache, &apply_damage_from_self_damage_chronicle_bindings,
             &self.gpu.device, &mut encoder, max_slots_per_tick,
@@ -1628,11 +1528,15 @@ impl CompiledSim for DuelAbilitiesState {
             &self.apply_lifesteal_from_chronicle_cfg_buf, 0,
             bytemuck::bytes_of(&apply_lifesteal_from_chronicle_cfg),
         );
-        let apply_lifesteal_from_chronicle_bindings = physics_ApplyLifestealFromChronicle::PhysicsApplyLifestealFromChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.apply_lifesteal_from_chronicle_cfg_buf,
-        };
+        let apply_lifesteal_from_chronicle_extras =
+            physics_ApplyLifestealFromChronicle::PhysicsApplyLifestealFromChronicleExtras {
+                cfg: &self.apply_lifesteal_from_chronicle_cfg_buf,
+            };
+        let apply_lifesteal_from_chronicle_bindings =
+            physics_ApplyLifestealFromChronicle::PhysicsApplyLifestealFromChronicleBindings::from_context_with_extras(
+                &ctx,
+                &apply_lifesteal_from_chronicle_extras,
+            );
         dispatch::dispatch_physics_applylifestealfromchronicle(
             &mut self.cache, &apply_lifesteal_from_chronicle_bindings,
             &self.gpu.device, &mut encoder, max_slots_per_tick,
@@ -1664,11 +1568,15 @@ impl CompiledSim for DuelAbilitiesState {
             &self.apply_damagemod_from_chronicle_cfg_buf, 0,
             bytemuck::bytes_of(&apply_damagemod_from_chronicle_cfg),
         );
-        let apply_damagemod_from_chronicle_bindings = physics_ApplyDamageModFromChronicle::PhysicsApplyDamageModFromChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.apply_damagemod_from_chronicle_cfg_buf,
-        };
+        let apply_damagemod_from_chronicle_extras =
+            physics_ApplyDamageModFromChronicle::PhysicsApplyDamageModFromChronicleExtras {
+                cfg: &self.apply_damagemod_from_chronicle_cfg_buf,
+            };
+        let apply_damagemod_from_chronicle_bindings =
+            physics_ApplyDamageModFromChronicle::PhysicsApplyDamageModFromChronicleBindings::from_context_with_extras(
+                &ctx,
+                &apply_damagemod_from_chronicle_extras,
+            );
         dispatch::dispatch_physics_applydamagemodfromchronicle(
             &mut self.cache, &apply_damagemod_from_chronicle_bindings,
             &self.gpu.device, &mut encoder, max_slots_per_tick,
@@ -1705,11 +1613,15 @@ impl CompiledSim for DuelAbilitiesState {
             &self.apply_execute_from_chronicle_cfg_buf, 0,
             bytemuck::bytes_of(&apply_execute_from_chronicle_cfg),
         );
-        let apply_execute_from_chronicle_bindings = physics_ApplyExecuteFromChronicle::PhysicsApplyExecuteFromChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.apply_execute_from_chronicle_cfg_buf,
-        };
+        let apply_execute_from_chronicle_extras =
+            physics_ApplyExecuteFromChronicle::PhysicsApplyExecuteFromChronicleExtras {
+                cfg: &self.apply_execute_from_chronicle_cfg_buf,
+            };
+        let apply_execute_from_chronicle_bindings =
+            physics_ApplyExecuteFromChronicle::PhysicsApplyExecuteFromChronicleBindings::from_context_with_extras(
+                &ctx,
+                &apply_execute_from_chronicle_extras,
+            );
         dispatch::dispatch_physics_applyexecutefromchronicle(
             &mut self.cache, &apply_execute_from_chronicle_bindings,
             &self.gpu.device, &mut encoder, max_slots_per_tick,
@@ -1752,39 +1664,18 @@ impl CompiledSim for DuelAbilitiesState {
         // apply_ability dispatcher arm (verb_chronicle_Strike) walks
         // the registry to expand `apply_ability 1 by self target target`
         // into chronicle EffectDamageApplied writes.
-        let apply_heal_bindings = physics_ApplyHeal_and_ApplyShield_and_ApplyDefeat_and_ApplyLifestealActivation_and_ApplyDamageModActivation_and_ApplyStun_and_verb_chronicle_Strike::PhysicsApplyHealAndApplyShieldAndApplyDefeatAndApplyLifestealActivationAndApplyDamageModActivationAndApplyStunAndVerbChronicleStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
-            agent_shield_hp: &self.agent_shield_hp_buf,
+        let apply_heal_extras = physics_ApplyHeal_and_ApplyShield_and_ApplyDefeat_and_ApplyLifestealActivation_and_ApplyDamageModActivation_and_ApplyStun_and_verb_chronicle_Strike::PhysicsApplyHealAndApplyShieldAndApplyDefeatAndApplyLifestealActivationAndApplyDamageModActivationAndApplyStunAndVerbChronicleStrikeExtras {
             agent_stun_expires_at_tick: &self.agent_stun_expires_at_tick_buf,
             agent_lifesteal_frac_q8: &self.agent_lifesteal_frac_q8_buf,
             agent_lifesteal_expires_at_tick: &self.agent_lifesteal_expires_at_tick_buf,
             agent_damage_taken_mult_q8: &self.agent_damage_taken_mult_q8_buf,
             agent_damage_taken_mult_expires_at_tick: &self.agent_damage_taken_mult_expires_at_tick_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents:  &self.registry_gpu.scaling_percents,
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
             cfg: &self.chronicle_strike_cfg_buf,
         };
+        let apply_heal_bindings = physics_ApplyHeal_and_ApplyShield_and_ApplyDefeat_and_ApplyLifestealActivation_and_ApplyDamageModActivation_and_ApplyStun_and_verb_chronicle_Strike::PhysicsApplyHealAndApplyShieldAndApplyDefeatAndApplyLifestealActivationAndApplyDamageModActivationAndApplyStunAndVerbChronicleStrikeBindings::from_context_with_extras(
+            &ctx,
+            &apply_heal_extras,
+        );
         dispatch::dispatch_physics_applyheal_and_applyshield_and_applydefeat_and_applylifestealactivation_and_applydamagemodactivation_and_applystun_and_verb_chronicle_strike(
             &mut self.cache, &apply_heal_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -1810,11 +1701,15 @@ impl CompiledSim for DuelAbilitiesState {
             &self.apply_damage_from_chronicle_cfg_buf, 0,
             bytemuck::bytes_of(&apply_damage_from_chronicle_cfg),
         );
-        let apply_damage_from_chronicle_bindings = physics_ApplyDamageFromChronicle::PhysicsApplyDamageFromChronicleBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            cfg: &self.apply_damage_from_chronicle_cfg_buf,
-        };
+        let apply_damage_from_chronicle_extras =
+            physics_ApplyDamageFromChronicle::PhysicsApplyDamageFromChronicleExtras {
+                cfg: &self.apply_damage_from_chronicle_cfg_buf,
+            };
+        let apply_damage_from_chronicle_bindings =
+            physics_ApplyDamageFromChronicle::PhysicsApplyDamageFromChronicleBindings::from_context_with_extras(
+                &ctx,
+                &apply_damage_from_chronicle_extras,
+            );
         dispatch::dispatch_physics_applydamagefromchronicle(
             &mut self.cache, &apply_damage_from_chronicle_bindings,
             &self.gpu.device, &mut encoder, event_count_estimate,
@@ -1844,18 +1739,18 @@ impl CompiledSim for DuelAbilitiesState {
         self.gpu.queue.write_buffer(
             &self.apply_damage_cfg_buf, 0, bytemuck::bytes_of(&apply_damage_cfg),
         );
-        let apply_damage_bindings = physics_ApplyDamage::PhysicsApplyDamageBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
-            agent_shield_hp: &self.agent_shield_hp_buf,
+        let apply_damage_extras = physics_ApplyDamage::PhysicsApplyDamageExtras {
             agent_lifesteal_frac_q8: &self.agent_lifesteal_frac_q8_buf,
             agent_lifesteal_expires_at_tick: &self.agent_lifesteal_expires_at_tick_buf,
             agent_damage_taken_mult_q8: &self.agent_damage_taken_mult_q8_buf,
             agent_damage_taken_mult_expires_at_tick: &self.agent_damage_taken_mult_expires_at_tick_buf,
             cfg: &self.apply_damage_cfg_buf,
         };
+        let apply_damage_bindings =
+            physics_ApplyDamage::PhysicsApplyDamageBindings::from_context_with_extras(
+                &ctx,
+                &apply_damage_extras,
+            );
         dispatch::dispatch_physics_applydamage(
             &mut self.cache, &apply_damage_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -1870,12 +1765,14 @@ impl CompiledSim for DuelAbilitiesState {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/dungeon_crawl_runtime/src/lib.rs
+++ b/crates/dungeon_crawl_runtime/src/lib.rs
@@ -27,7 +27,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 pub const HERO_COUNT: u32 = 5;
 pub const HERO_HP: f32 = 400.0;
@@ -111,6 +113,12 @@ pub struct DungeonCrawlState {
     chronicle_heal_cfg_buf: wgpu::Buffer,
     apply_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — dungeon_crawl's verbs
+    /// use inline emit, not the packed-ability path, but the compiler-
+    /// emitted constructor signature requires the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -294,6 +302,12 @@ impl DungeonCrawlState {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "dungeon_crawl_runtime",
+        );
+
         let mut state = Self {
             gpu,
             agent_hp_buf,
@@ -318,6 +332,7 @@ impl DungeonCrawlState {
             chronicle_heal_cfg_buf,
             apply_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -547,15 +562,35 @@ impl CompiledSim for DungeonCrawlState {
             agent_cap: self.agent_count, tick: self.tick as u32, seed: 0, _pad: 0,
         };
         self.gpu.queue.write_buffer(&self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg));
-        let mask_bindings = fused_mask_verb_Strike::FusedMaskVerbStrikeBindings {
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
-            agent_mana: &self.agent_mana_buf,
+
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct. Fold kernels still build
+        // hand-written `Bindings { ... }` literals — the compiler doesn't
+        // emit `from_context` constructors for them.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
+        let mask_extras = fused_mask_verb_Strike::FusedMaskVerbStrikeExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_Strike::FusedMaskVerbStrikeBindings::from_context_with_extras(
+                &ctx,
+                &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_strike(
             &mut self.cache, &mask_bindings, &self.gpu.device, &mut encoder, self.agent_count,
         );
@@ -565,16 +600,15 @@ impl CompiledSim for DungeonCrawlState {
             agent_cap: self.agent_count, tick: self.tick as u32, seed: 0, _pad: 0,
         };
         self.gpu.queue.write_buffer(&self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg));
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder, self.agent_count,
         );
@@ -586,11 +620,14 @@ impl CompiledSim for DungeonCrawlState {
         self.gpu.queue.write_buffer(
             &self.chronicle_strike_cfg_buf, 0, bytemuck::bytes_of(&strike_cfg),
         );
-        let strike_bindings = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let strike_extras = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeExtras {
             cfg: &self.chronicle_strike_cfg_buf,
         };
+        let strike_bindings =
+            physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings::from_context_with_extras(
+                &ctx,
+                &strike_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_strike(
             &mut self.cache, &strike_bindings, &self.gpu.device, &mut encoder, self.agent_count,
         );
@@ -602,11 +639,14 @@ impl CompiledSim for DungeonCrawlState {
         self.gpu.queue.write_buffer(
             &self.chronicle_spell_cfg_buf, 0, bytemuck::bytes_of(&spell_cfg),
         );
-        let spell_bindings = physics_verb_chronicle_Spell::PhysicsVerbChronicleSpellBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let spell_extras = physics_verb_chronicle_Spell::PhysicsVerbChronicleSpellExtras {
             cfg: &self.chronicle_spell_cfg_buf,
         };
+        let spell_bindings =
+            physics_verb_chronicle_Spell::PhysicsVerbChronicleSpellBindings::from_context_with_extras(
+                &ctx,
+                &spell_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_spell(
             &mut self.cache, &spell_bindings, &self.gpu.device, &mut encoder, self.agent_count,
         );
@@ -618,11 +658,14 @@ impl CompiledSim for DungeonCrawlState {
         self.gpu.queue.write_buffer(
             &self.chronicle_heal_cfg_buf, 0, bytemuck::bytes_of(&heal_cfg),
         );
-        let heal_bindings = physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let heal_extras = physics_verb_chronicle_Heal::PhysicsVerbChronicleHealExtras {
             cfg: &self.chronicle_heal_cfg_buf,
         };
+        let heal_bindings =
+            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings::from_context_with_extras(
+                &ctx,
+                &heal_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_heal(
             &mut self.cache, &heal_bindings, &self.gpu.device, &mut encoder, self.agent_count,
         );
@@ -633,13 +676,14 @@ impl CompiledSim for DungeonCrawlState {
             event_count: event_count_estimate, tick: self.tick as u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg));
-        let apply_bindings = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings =
+            physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings::from_context_with_extras(
+                &ctx,
+                &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage_and_applyheal(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder, event_count_estimate,
         );
@@ -649,12 +693,14 @@ impl CompiledSim for DungeonCrawlState {
             agent_cap: self.agent_count, tick: self.tick as u32, seed: 0, _pad: 0,
         };
         self.gpu.queue.write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder, self.agent_count,
         );

--- a/crates/ecosystem_runtime/src/lib.rs
+++ b/crates/ecosystem_runtime/src/lib.rs
@@ -32,6 +32,8 @@
 //!   BOTH PlantEaten and HerbivoreEaten emits — see the GAP note at
 //!   the top of `ecosystem_app.rs` for details.
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
 use engine::ids::AgentId;
 use engine::rng::per_agent_u32;
 use engine::sim_trait::{AgentSnapshot, CompiledSim, VizGlyph};
@@ -41,7 +43,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// 16-byte WGSL `vec3<f32>` interop. Same shape as the predator_prey /
 /// swarm_storm runtimes use; duplicated here to keep each fixture-
@@ -118,6 +120,12 @@ pub struct EcosystemState {
     plant_count: u32,
     herbivore_count: u32,
     carnivore_count: u32,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     pos_cache: Vec<Vec3>,
@@ -340,6 +348,12 @@ impl EcosystemState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "ecosystem_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -360,6 +374,7 @@ impl EcosystemState {
             plant_count,
             herbivore_count,
             carnivore_count,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -506,14 +521,32 @@ impl CompiledSim for EcosystemState {
         // fold dispatch.
         self.event_ring.clear_tail_in(&mut encoder);
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct. (Fold kernels still build
+        // hand-written `Bindings { ... }` literals — the compiler
+        // doesn't emit `from_context` constructors for them.)
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) MovePlant — no event_ring/event_tail bindings (Plants
         // don't emit). Reads creature_type, pos, vel; writes pos.
-        let plant_bindings = physics_MovePlant::PhysicsMovePlantBindings {
-            agent_pos: &self.pos_buf,
+        let plant_extras = physics_MovePlant::PhysicsMovePlantExtras {
             agent_creature_type: &self.creature_type_buf,
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let plant_bindings =
+            physics_MovePlant::PhysicsMovePlantBindings::from_context_with_extras(
+                &ctx, &plant_extras,
+            );
         dispatch::dispatch_physics_moveplant(
             &mut self.cache,
             &plant_bindings,
@@ -525,14 +558,15 @@ impl CompiledSim for EcosystemState {
         // (2) MoveHerbivore — emits `PlantEaten { plant: self, by: self,
         // pos }` (kind tag = 1u in the WGSL emit body). Bindings include
         // event_ring + event_tail.
-        let herb_bindings = physics_MoveHerbivore::PhysicsMoveHerbivoreBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
+        let herb_extras = physics_MoveHerbivore::PhysicsMoveHerbivoreExtras {
             agent_creature_type: &self.creature_type_buf,
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let herb_bindings =
+            physics_MoveHerbivore::PhysicsMoveHerbivoreBindings::from_context_with_extras(
+                &ctx, &herb_extras,
+            );
         dispatch::dispatch_physics_moveherbivore(
             &mut self.cache,
             &herb_bindings,
@@ -543,14 +577,15 @@ impl CompiledSim for EcosystemState {
 
         // (3) MoveCarnivore — emits `HerbivoreEaten { prey: self, by:
         // self, pos }` (kind tag = 2u). Same shared ring / tail.
-        let carn_bindings = physics_MoveCarnivore::PhysicsMoveCarnivoreBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
+        let carn_extras = physics_MoveCarnivore::PhysicsMoveCarnivoreExtras {
             agent_creature_type: &self.creature_type_buf,
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let carn_bindings =
+            physics_MoveCarnivore::PhysicsMoveCarnivoreBindings::from_context_with_extras(
+                &ctx, &carn_extras,
+            );
         dispatch::dispatch_physics_movecarnivore(
             &mut self.cache,
             &carn_bindings,
@@ -561,12 +596,14 @@ impl CompiledSim for EcosystemState {
 
         // (4) seed_indirect_0 — keeps the indirect-args buffer warm
         // for the eventual dispatch_workgroups_indirect wire-up.
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,
@@ -594,10 +631,15 @@ impl CompiledSim for EcosystemState {
             0,
             bytemuck::bytes_of(&rb_decay_cfg),
         );
-        let rb_decay_bindings = decay_recent_browse::DecayRecentBrowseBindings {
+        let rb_decay_extras = decay_recent_browse::DecayRecentBrowseExtras {
             view_storage_primary: self.recent_browse.primary(),
             cfg: &self.recent_browse_decay_cfg_buf,
         };
+        let rb_decay_bindings =
+            decay_recent_browse::DecayRecentBrowseBindings::from_context_with_extras(
+                &ctx,
+                &rb_decay_extras,
+            );
         dispatch::dispatch_decay_recent_browse(
             &mut self.cache,
             &rb_decay_bindings,
@@ -652,10 +694,15 @@ impl CompiledSim for EcosystemState {
             0,
             bytemuck::bytes_of(&pp_decay_cfg),
         );
-        let pp_decay_bindings = decay_predator_pressure::DecayPredatorPressureBindings {
+        let pp_decay_extras = decay_predator_pressure::DecayPredatorPressureExtras {
             view_storage_primary: self.predator_pressure.primary(),
             cfg: &self.predator_pressure_decay_cfg_buf,
         };
+        let pp_decay_bindings =
+            decay_predator_pressure::DecayPredatorPressureBindings::from_context_with_extras(
+                &ctx,
+                &pp_decay_extras,
+            );
         dispatch::dispatch_decay_predator_pressure(
             &mut self.cache,
             &pp_decay_bindings,
@@ -703,10 +750,15 @@ impl CompiledSim for EcosystemState {
             0,
             bytemuck::bytes_of(&plp_decay_cfg),
         );
-        let plp_decay_bindings = decay_plant_pressure::DecayPlantPressureBindings {
+        let plp_decay_extras = decay_plant_pressure::DecayPlantPressureExtras {
             view_storage_primary: self.plant_pressure.primary(),
             cfg: &self.plant_pressure_decay_cfg_buf,
         };
+        let plp_decay_bindings =
+            decay_plant_pressure::DecayPlantPressureBindings::from_context_with_extras(
+                &ctx,
+                &plp_decay_extras,
+            );
         dispatch::dispatch_decay_plant_pressure(
             &mut self.cache,
             &plp_decay_bindings,

--- a/crates/flocking_skirmish_runtime/src/lib.rs
+++ b/crates/flocking_skirmish_runtime/src/lib.rs
@@ -18,6 +18,9 @@
 //!     chronicle (the duel_1v1 path)
 //!   - Per-team alive readback: count slots with hp > 0 per team
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 use engine::ids::AgentId;
 use engine::rng::per_agent_u32;
 use engine::sim_trait::CompiledSim;
@@ -69,6 +72,17 @@ pub struct FlockingSkirmishState {
     creature_type_buf: wgpu::Buffer,
     cfg_buf: wgpu::Buffer,
     pos_staging: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::event_ring`] field — this fixture has no
+    /// emitted events, but the compiler-emitted constructor signature
+    /// requires the context to expose one.
+    event_ring: EventRing,
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     /// Number of agents initialised as Red (creature_type = 0). Slots
     /// `[0..red_count)`. Set at construction; immutable thereafter.
@@ -213,6 +227,13 @@ impl FlockingSkirmishState {
             mapped_at_creation: false,
         });
 
+        let event_ring = EventRing::new(&gpu, "flocking_skirmish_runtime");
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "flocking_skirmish_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -221,6 +242,8 @@ impl FlockingSkirmishState {
             creature_type_buf,
             cfg_buf,
             pos_staging,
+            event_ring,
+            registry_gpu,
             red_count,
             blue_count,
             cache: dispatch::KernelCache::default(),
@@ -318,16 +341,31 @@ impl CompiledSim for FlockingSkirmishState {
         };
         self.gpu.queue.write_buffer(&self.cfg_buf, 0, bytemuck::bytes_of(&cfg));
 
+        // Shared once per tick; each per-team kernel adds only its
+        // fixture-specific extras (creature_type, vel, cfg).
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            hp_buf: Some(&self.hp_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) MoveRed — gated on creature_type == 0 inside the kernel.
         // Reads agent_pos, agent_vel, agent_hp, agent_creature_type;
         // writes pos, vel, hp.
-        let red_bindings = physics_MoveRed::PhysicsMoveRedBindings {
-            agent_pos: &self.pos_buf,
+        let red_extras = physics_MoveRed::PhysicsMoveRedExtras {
             agent_creature_type: &self.creature_type_buf,
             agent_vel: &self.vel_buf,
-            agent_hp: &self.hp_buf,
             cfg: &self.cfg_buf,
         };
+        let red_bindings = physics_MoveRed::PhysicsMoveRedBindings::from_context_with_extras(
+            &ctx, &red_extras,
+        );
         dispatch::dispatch_physics_movered(
             &mut self.cache,
             &red_bindings,
@@ -338,13 +376,14 @@ impl CompiledSim for FlockingSkirmishState {
 
         // (2) MoveBlue — gated on creature_type == 1. Same shape as
         // MoveRed; same buffer set.
-        let blue_bindings = physics_MoveBlue::PhysicsMoveBlueBindings {
-            agent_pos: &self.pos_buf,
+        let blue_extras = physics_MoveBlue::PhysicsMoveBlueExtras {
             agent_creature_type: &self.creature_type_buf,
             agent_vel: &self.vel_buf,
-            agent_hp: &self.hp_buf,
             cfg: &self.cfg_buf,
         };
+        let blue_bindings = physics_MoveBlue::PhysicsMoveBlueBindings::from_context_with_extras(
+            &ctx, &blue_extras,
+        );
         dispatch::dispatch_physics_moveblue(
             &mut self.cache,
             &blue_bindings,

--- a/crates/foraging_real_runtime/src/lib.rs
+++ b/crates/foraging_real_runtime/src/lib.rs
@@ -51,6 +51,8 @@
 //! After step(), CPU-side `process_births()` reads eat_count + alive,
 //! flips dead Ant slots back to alive=1 with reset state.
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
 use engine::sim_trait::{AgentSnapshot, CompiledSim, VizGlyph};
 use engine::GpuContext;
 use glam::Vec3;
@@ -58,7 +60,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Discriminant value the WGSL emits for the first-declared entity
 /// (`Ant`). Matches the `creature_type == Ant` lowering — entity
@@ -154,6 +156,12 @@ pub struct ForagingRealState {
     applyeat_cfg_buf: wgpu::Buffer,
     energydecay_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -425,6 +433,12 @@ impl ForagingRealState {
         let starved_count_cfg_buf = make_view_cfg("foraging_real_runtime::starved_count_cfg");
         let depleted_count_cfg_buf = make_view_cfg("foraging_real_runtime::depleted_count_cfg");
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "foraging_real_runtime",
+        );
+
         Self {
             gpu,
             agent_pos_buf,
@@ -450,6 +464,7 @@ impl ForagingRealState {
             applyeat_cfg_buf,
             energydecay_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count: SLOT_CAP,
@@ -743,11 +758,32 @@ impl CompiledSim for ForagingRealState {
             .queue
             .write_buffer(&self.antfeed_cfg_buf, 0, bytemuck::bytes_of(&antfeed_cfg));
 
-        let count_b = spatial_build_hash_count::SpatialBuildHashCountBindings {
-            agent_pos: &self.agent_pos_buf,
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct. Fold kernels still build
+        // hand-written `Bindings { ... }` literals — the compiler
+        // doesn't emit `from_context` constructors for them.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.agent_pos_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
+        let count_extras = spatial_build_hash_count::SpatialBuildHashCountExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             cfg: &self.antfeed_cfg_buf,
         };
+        let count_b =
+            spatial_build_hash_count::SpatialBuildHashCountBindings::from_context_with_extras(
+                &ctx,
+                &count_extras,
+            );
         dispatch::dispatch_spatial_build_hash_count(
             &mut self.cache,
             &count_b,
@@ -755,12 +791,17 @@ impl CompiledSim for ForagingRealState {
             &mut encoder,
             SLOT_CAP,
         );
-        let scan_local_b = spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings {
+        let scan_local_extras = spatial_build_hash_scan_local::SpatialBuildHashScanLocalExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             spatial_chunk_sums: &self.spatial_chunk_sums,
             cfg: &self.antfeed_cfg_buf,
         };
+        let scan_local_b =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings::from_context_with_extras(
+                &ctx,
+                &scan_local_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_local(
             &mut self.cache,
             &scan_local_b,
@@ -768,10 +809,15 @@ impl CompiledSim for ForagingRealState {
             &mut encoder,
             SLOT_CAP,
         );
-        let scan_carry_b = spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings {
+        let scan_carry_extras = spatial_build_hash_scan_carry::SpatialBuildHashScanCarryExtras {
             spatial_chunk_sums: &self.spatial_chunk_sums,
             cfg: &self.antfeed_cfg_buf,
         };
+        let scan_carry_b =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings::from_context_with_extras(
+                &ctx,
+                &scan_carry_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_carry(
             &mut self.cache,
             &scan_carry_b,
@@ -779,12 +825,17 @@ impl CompiledSim for ForagingRealState {
             &mut encoder,
             SLOT_CAP,
         );
-        let scan_add_b = spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings {
+        let scan_add_extras = spatial_build_hash_scan_add::SpatialBuildHashScanAddExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             spatial_chunk_sums: &self.spatial_chunk_sums,
             cfg: &self.antfeed_cfg_buf,
         };
+        let scan_add_b =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings::from_context_with_extras(
+                &ctx,
+                &scan_add_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_add(
             &mut self.cache,
             &scan_add_b,
@@ -792,13 +843,17 @@ impl CompiledSim for ForagingRealState {
             &mut encoder,
             SLOT_CAP,
         );
-        let scatter_b = spatial_build_hash_scatter::SpatialBuildHashScatterBindings {
-            agent_pos: &self.agent_pos_buf,
+        let scatter_extras = spatial_build_hash_scatter::SpatialBuildHashScatterExtras {
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.antfeed_cfg_buf,
         };
+        let scatter_b =
+            spatial_build_hash_scatter::SpatialBuildHashScatterBindings::from_context_with_extras(
+                &ctx,
+                &scatter_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scatter(
             &mut self.cache,
             &scatter_b,
@@ -813,17 +868,17 @@ impl CompiledSim for ForagingRealState {
         // the body doesn't reference `self.pos`; the binding is
         // surfaced via the Pos read added to
         // `collect_stmt_dependencies` for `ForEachNeighborBody`.
-        let antfeed_b = physics_AntFeed::PhysicsAntFeedBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.agent_pos_buf,
-            agent_alive: &self.agent_alive_buf,
+        let antfeed_extras = physics_AntFeed::PhysicsAntFeedExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.antfeed_cfg_buf,
         };
+        let antfeed_b = physics_AntFeed::PhysicsAntFeedBindings::from_context_with_extras(
+            &ctx,
+            &antfeed_extras,
+        );
         dispatch::dispatch_physics_antfeed(
             &mut self.cache,
             &antfeed_b,
@@ -844,14 +899,14 @@ impl CompiledSim for ForagingRealState {
         self.gpu
             .queue
             .write_buffer(&self.applyeat_cfg_buf, 0, bytemuck::bytes_of(&applyeat_cfg));
-        let applyeat_b = physics_ApplyEat::PhysicsApplyEatBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let applyeat_extras = physics_ApplyEat::PhysicsApplyEatExtras {
             agent_hunger: &self.agent_hunger_buf,
             cfg: &self.applyeat_cfg_buf,
         };
+        let applyeat_b = physics_ApplyEat::PhysicsApplyEatBindings::from_context_with_extras(
+            &ctx,
+            &applyeat_extras,
+        );
         dispatch::dispatch_physics_applyeat(
             &mut self.cache,
             &applyeat_b,
@@ -872,14 +927,16 @@ impl CompiledSim for ForagingRealState {
             0,
             bytemuck::bytes_of(&energydecay_cfg),
         );
-        let energydecay_b = physics_EnergyDecay::PhysicsEnergyDecayBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_alive: &self.agent_alive_buf,
+        let energydecay_extras = physics_EnergyDecay::PhysicsEnergyDecayExtras {
             agent_hunger: &self.agent_hunger_buf,
             agent_creature_type: &self.agent_creature_type_buf,
             cfg: &self.energydecay_cfg_buf,
         };
+        let energydecay_b =
+            physics_EnergyDecay::PhysicsEnergyDecayBindings::from_context_with_extras(
+                &ctx,
+                &energydecay_extras,
+            );
         dispatch::dispatch_physics_energydecay(
             &mut self.cache,
             &energydecay_b,
@@ -898,12 +955,14 @@ impl CompiledSim for ForagingRealState {
         self.gpu
             .queue
             .write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_b = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_b = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_b,


### PR DESCRIPTION
## Summary

- Migrates 9 runtimes (Phase 4 batch 2 of 5) to the compiler-emitted `Bindings::from_context_with_extras()` constructors. Replaces hand-written `Bindings { ... }` literals at every non-fold dispatch site.
- ViewFold (`fold_*`) kernels remain hand-written per the plan.
- Diplomacy required a per-block `ctx` rebuild to thread around `event_ring.note_emits()` mutable-borrow boundaries (5 block scopes, one per `note_emits` boundary).

Migrated runtimes (LOC delta in parens):
- cooldown_probe_runtime (+24)
- crowd_navigation_runtime (+22)
- diplomacy_probe_runtime (+121) - 6 non-fold sites + 5 ctx scopes
- duel_1v1_runtime (+47)
- duel_abilities_runtime (-188 net) - chronicle dispatch literals collapse from ~25 lines of registry/agent fields to a single `cfg`-only Extras struct, 8 chronicles times big savings
- dungeon_crawl_runtime (+47)
- ecosystem_runtime (+44) - includes 3 decay kernels
- flocking_skirmish_runtime (+24)
- foraging_real_runtime (+39) - includes 5 spatial counting-sort kernels

Net delta: +282 LOC. Future per-buffer additions accrue zero lines per migrated runtime.

8 of 9 runtimes gain an empty `PackedAbilityRegistryGpu` placeholder; flocking_skirmish also gains an empty `EventRing` placeholder. Same pattern batch 3/5 used.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test -p engine --release --test schema_hash` (P2: schema hash unchanged)
- [x] `cargo test -p <crate> --release` for all 9 runtimes - all green
  - duel_abilities: 15 passed
  - ecosystem: 2 passed
  - foraging_real: 2 passed, 1 ignored
  - cooldown_probe / crowd_navigation / diplomacy_probe / duel_1v1 / dungeon_crawl / flocking_skirmish: 0 tests (no lib tests defined)

Plan: `docs/superpowers/plans/2026-05-09-compiler-emitted-bindings-constructors.md` (task 7).

Constitution alignment: P1 (Compiler-First) PASS, P2 (Schema-Hash) PASS, P5 (Determinism) PASS, P10 (No Runtime Panic) PASS.

Generated with [Claude Code](https://claude.com/claude-code)