### PR TITLE
refactor(runtimes): migrate Phase 4 batch 4/5 to compiler-emitted Bindings constructors

### DIFF
--- a/crates/predator_prey_real_runtime/src/lib.rs
+++ b/crates/predator_prey_real_runtime/src/lib.rs
@@ -54,7 +54,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Discriminant value the WGSL emits for the first-declared entity
 /// (`Wolf`). Matches the `creature_type == Wolf` lowering — entity
@@ -169,6 +171,12 @@ pub struct PredatorPreyRealState {
     sheepgraze_cfg_buf: wgpu::Buffer,
     energydecay_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -478,6 +486,12 @@ impl PredatorPreyRealState {
         let starved_total_cfg_buf =
             make_view_cfg("predator_prey_real_runtime::starved_total_cfg");
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "predator_prey_real_runtime",
+        );
+
         Self {
             gpu,
             agent_pos_buf,
@@ -502,6 +516,7 @@ impl PredatorPreyRealState {
             sheepgraze_cfg_buf,
             energydecay_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count: SLOT_CAP,
@@ -924,11 +939,32 @@ impl CompiledSim for PredatorPreyRealState {
             bytemuck::bytes_of(&wolfhunt_cfg),
         );
 
-        let count_b = spatial_build_hash_count::SpatialBuildHashCountBindings {
-            agent_pos: &self.agent_pos_buf,
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct. Standard SoA columns
+        // (pos/hp/alive) flow through ctx.state; agent_hunger and
+        // agent_creature_type are not standard so they ride extras.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.agent_pos_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
+        let count_extras = spatial_build_hash_count::SpatialBuildHashCountExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             cfg: &self.wolfhunt_cfg_buf,
         };
+        let count_b =
+            spatial_build_hash_count::SpatialBuildHashCountBindings::from_context_with_extras(
+                &ctx,
+                &count_extras,
+            );
         dispatch::dispatch_spatial_build_hash_count(
             &mut self.cache,
             &count_b,
@@ -936,12 +972,17 @@ impl CompiledSim for PredatorPreyRealState {
             &mut encoder,
             SLOT_CAP,
         );
-        let scan_local_b = spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings {
+        let scan_local_extras = spatial_build_hash_scan_local::SpatialBuildHashScanLocalExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             spatial_chunk_sums: &self.spatial_chunk_sums,
             cfg: &self.wolfhunt_cfg_buf,
         };
+        let scan_local_b =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings::from_context_with_extras(
+                &ctx,
+                &scan_local_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_local(
             &mut self.cache,
             &scan_local_b,
@@ -949,10 +990,15 @@ impl CompiledSim for PredatorPreyRealState {
             &mut encoder,
             SLOT_CAP,
         );
-        let scan_carry_b = spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings {
+        let scan_carry_extras = spatial_build_hash_scan_carry::SpatialBuildHashScanCarryExtras {
             spatial_chunk_sums: &self.spatial_chunk_sums,
             cfg: &self.wolfhunt_cfg_buf,
         };
+        let scan_carry_b =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings::from_context_with_extras(
+                &ctx,
+                &scan_carry_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_carry(
             &mut self.cache,
             &scan_carry_b,
@@ -960,12 +1006,17 @@ impl CompiledSim for PredatorPreyRealState {
             &mut encoder,
             SLOT_CAP,
         );
-        let scan_add_b = spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings {
+        let scan_add_extras = spatial_build_hash_scan_add::SpatialBuildHashScanAddExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             spatial_chunk_sums: &self.spatial_chunk_sums,
             cfg: &self.wolfhunt_cfg_buf,
         };
+        let scan_add_b =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings::from_context_with_extras(
+                &ctx,
+                &scan_add_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_add(
             &mut self.cache,
             &scan_add_b,
@@ -973,13 +1024,17 @@ impl CompiledSim for PredatorPreyRealState {
             &mut encoder,
             SLOT_CAP,
         );
-        let scatter_b = spatial_build_hash_scatter::SpatialBuildHashScatterBindings {
-            agent_pos: &self.agent_pos_buf,
+        let scatter_extras = spatial_build_hash_scatter::SpatialBuildHashScatterExtras {
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.wolfhunt_cfg_buf,
         };
+        let scatter_b =
+            spatial_build_hash_scatter::SpatialBuildHashScatterBindings::from_context_with_extras(
+                &ctx,
+                &scatter_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scatter(
             &mut self.cache,
             &scatter_b,
@@ -989,17 +1044,17 @@ impl CompiledSim for PredatorPreyRealState {
         );
 
         // (3) WolfHunt — body-form spatial walk. Emits Damaged events.
-        let wolfhunt_b = physics_WolfHunt::PhysicsWolfHuntBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.agent_pos_buf,
-            agent_alive: &self.agent_alive_buf,
+        let wolfhunt_extras = physics_WolfHunt::PhysicsWolfHuntExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.wolfhunt_cfg_buf,
         };
+        let wolfhunt_b = physics_WolfHunt::PhysicsWolfHuntBindings::from_context_with_extras(
+            &ctx,
+            &wolfhunt_extras,
+        );
         dispatch::dispatch_physics_wolfhunt(
             &mut self.cache,
             &wolfhunt_b,
@@ -1022,14 +1077,14 @@ impl CompiledSim for PredatorPreyRealState {
             0,
             bytemuck::bytes_of(&applykill_cfg),
         );
-        let applykill_b = physics_ApplyKill::PhysicsApplyKillBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let applykill_extras = physics_ApplyKill::PhysicsApplyKillExtras {
             agent_hunger: &self.agent_hunger_buf,
             cfg: &self.applykill_cfg_buf,
         };
+        let applykill_b = physics_ApplyKill::PhysicsApplyKillBindings::from_context_with_extras(
+            &ctx,
+            &applykill_extras,
+        );
         dispatch::dispatch_physics_applykill(
             &mut self.cache,
             &applykill_b,
@@ -1050,12 +1105,15 @@ impl CompiledSim for PredatorPreyRealState {
             0,
             bytemuck::bytes_of(&sheepgraze_cfg),
         );
-        let sheepgraze_b = physics_SheepGraze::PhysicsSheepGrazeBindings {
-            agent_alive: &self.agent_alive_buf,
+        let sheepgraze_extras = physics_SheepGraze::PhysicsSheepGrazeExtras {
             agent_hunger: &self.agent_hunger_buf,
             agent_creature_type: &self.agent_creature_type_buf,
             cfg: &self.sheepgraze_cfg_buf,
         };
+        let sheepgraze_b = physics_SheepGraze::PhysicsSheepGrazeBindings::from_context_with_extras(
+            &ctx,
+            &sheepgraze_extras,
+        );
         dispatch::dispatch_physics_sheepgraze(
             &mut self.cache,
             &sheepgraze_b,
@@ -1076,13 +1134,15 @@ impl CompiledSim for PredatorPreyRealState {
             0,
             bytemuck::bytes_of(&energydecay_cfg),
         );
-        let energydecay_b = physics_EnergyDecay::PhysicsEnergyDecayBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_alive: &self.agent_alive_buf,
+        let energydecay_extras = physics_EnergyDecay::PhysicsEnergyDecayExtras {
             agent_hunger: &self.agent_hunger_buf,
             cfg: &self.energydecay_cfg_buf,
         };
+        let energydecay_b =
+            physics_EnergyDecay::PhysicsEnergyDecayBindings::from_context_with_extras(
+                &ctx,
+                &energydecay_extras,
+            );
         dispatch::dispatch_physics_energydecay(
             &mut self.cache,
             &energydecay_b,
@@ -1101,12 +1161,14 @@ impl CompiledSim for PredatorPreyRealState {
         self.gpu
             .queue
             .write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_b = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_b = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_b,

--- a/crates/predator_prey_runtime/src/lib.rs
+++ b/crates/predator_prey_runtime/src/lib.rs
@@ -32,7 +32,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// 16-byte WGSL `vec3<f32>` interop type. Same shape as the one in
 /// `boids_runtime`; duplicated here rather than re-exported to keep
@@ -116,6 +118,12 @@ pub struct PredatorPreyState {
     /// Wolf (odd → Wolf) at init time.
     hare_count: u32,
     wolf_count: u32,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -318,6 +326,12 @@ impl PredatorPreyState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "predator_prey_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -334,6 +348,7 @@ impl PredatorPreyState {
             predator_focus,
             predator_focus_cfg_buf,
             predator_focus_decay_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -502,14 +517,33 @@ impl CompiledSim for PredatorPreyState {
         // fold dispatch.
         self.event_ring.clear_tail_in(&mut encoder);
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct. `agent_pos` is a standard
+        // SoA column; `agent_vel` and `agent_creature_type` are not, so
+        // they flow through extras.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) MoveHare — no event_ring/event_tail bindings (Hares
         // don't emit). Reads creature_type, pos, vel; writes pos.
-        let hare_bindings = physics_MoveHare::PhysicsMoveHareBindings {
-            agent_pos: &self.pos_buf,
+        let hare_extras = physics_MoveHare::PhysicsMoveHareExtras {
             agent_creature_type: &self.creature_type_buf,
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let hare_bindings =
+            physics_MoveHare::PhysicsMoveHareBindings::from_context_with_extras(
+                &ctx,
+                &hare_extras,
+            );
         dispatch::dispatch_physics_movehare(
             &mut self.cache,
             &hare_bindings,
@@ -521,14 +555,16 @@ impl CompiledSim for PredatorPreyState {
         // (2) MoveWolf — same shape as MoveHare PLUS event_ring +
         // event_tail bindings (the body's `emit Killed { … }` writes
         // to those via atomicAdd-to-tail + atomicStore-to-ring).
-        let wolf_bindings = physics_MoveWolf::PhysicsMoveWolfBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
+        let wolf_extras = physics_MoveWolf::PhysicsMoveWolfExtras {
             agent_creature_type: &self.creature_type_buf,
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let wolf_bindings =
+            physics_MoveWolf::PhysicsMoveWolfBindings::from_context_with_extras(
+                &ctx,
+                &wolf_extras,
+            );
         dispatch::dispatch_physics_movewolf(
             &mut self.cache,
             &wolf_bindings,
@@ -544,12 +580,14 @@ impl CompiledSim for PredatorPreyState {
         // so this write currently runs but isn't consumed; left in
         // the chain so the args buffer is kept warm for the
         // future indirect-dispatch wire-up.
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,
@@ -613,10 +651,15 @@ impl CompiledSim for PredatorPreyState {
             0,
             bytemuck::bytes_of(&kc_decay_cfg),
         );
-        let kc_decay_bindings = decay_kill_count::DecayKillCountBindings {
+        let kc_decay_extras = decay_kill_count::DecayKillCountExtras {
             view_storage_primary: self.kill_count.primary(),
             cfg: &self.kill_count_decay_cfg_buf,
         };
+        let kc_decay_bindings =
+            decay_kill_count::DecayKillCountBindings::from_context_with_extras(
+                &ctx,
+                &kc_decay_extras,
+            );
         dispatch::dispatch_decay_kill_count(
             &mut self.cache,
             &kc_decay_bindings,
@@ -658,10 +701,15 @@ impl CompiledSim for PredatorPreyState {
             0,
             bytemuck::bytes_of(&pf_decay_cfg),
         );
-        let pf_decay_bindings = decay_predator_focus::DecayPredatorFocusBindings {
+        let pf_decay_extras = decay_predator_focus::DecayPredatorFocusExtras {
             view_storage_primary: self.predator_focus.primary(),
             cfg: &self.predator_focus_decay_cfg_buf,
         };
+        let pf_decay_bindings =
+            decay_predator_focus::DecayPredatorFocusBindings::from_context_with_extras(
+                &ctx,
+                &pf_decay_extras,
+            );
         // pair_map decay: dispatch covers `slot_count` (= agent_cap²)
         // threads — one per (k1, k2) slot — so the anchor multiplier
         // touches every pair, not just the diagonal `agent_cap` slots.

--- a/crates/quest_arc_real_runtime/src/lib.rs
+++ b/crates/quest_arc_real_runtime/src/lib.rs
@@ -44,7 +44,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture state for the quest arc.
 pub struct QuestArcRealState {
@@ -90,6 +92,12 @@ pub struct QuestArcRealState {
     apply_stage_cfg_buf: wgpu::Buffer,
     apply_complete_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -264,6 +272,12 @@ impl QuestArcRealState {
                 usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "quest_arc_real_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -297,6 +311,7 @@ impl QuestArcRealState {
             apply_stage_cfg_buf,
             apply_complete_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -366,6 +381,20 @@ impl CompiledSim for QuestArcRealState {
             0, scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round — 5 PerPair kernels, one per verb. Each
         // writes its own mask_<N>_bitmap. mask_k=1u (TODO task-5.7
         // in the compiler), so the per-pair grid degenerates to one
@@ -382,12 +411,13 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_mask_verb_acceptquest(
             &mut self.cache,
-            &mask_verb_AcceptQuest::MaskVerbAcceptQuestBindings {
-                agent_alive: &self.agent_alive_buf,
-                agent_mana: &self.agent_mana_buf,
-                mask_0_bitmap: &self.mask_0_bitmap_buf,
-                cfg: &self.mask_accept_cfg_buf,
-            },
+            &mask_verb_AcceptQuest::MaskVerbAcceptQuestBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_AcceptQuest::MaskVerbAcceptQuestExtras {
+                    mask_0_bitmap: &self.mask_0_bitmap_buf,
+                    cfg: &self.mask_accept_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -399,12 +429,13 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_mask_verb_huntmonster(
             &mut self.cache,
-            &mask_verb_HuntMonster::MaskVerbHuntMonsterBindings {
-                agent_alive: &self.agent_alive_buf,
-                agent_mana: &self.agent_mana_buf,
-                mask_1_bitmap: &self.mask_1_bitmap_buf,
-                cfg: &self.mask_hunt_cfg_buf,
-            },
+            &mask_verb_HuntMonster::MaskVerbHuntMonsterBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_HuntMonster::MaskVerbHuntMonsterExtras {
+                    mask_1_bitmap: &self.mask_1_bitmap_buf,
+                    cfg: &self.mask_hunt_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -416,12 +447,13 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_mask_verb_collectitem(
             &mut self.cache,
-            &mask_verb_CollectItem::MaskVerbCollectItemBindings {
-                agent_alive: &self.agent_alive_buf,
-                agent_mana: &self.agent_mana_buf,
-                mask_2_bitmap: &self.mask_2_bitmap_buf,
-                cfg: &self.mask_collect_cfg_buf,
-            },
+            &mask_verb_CollectItem::MaskVerbCollectItemBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_CollectItem::MaskVerbCollectItemExtras {
+                    mask_2_bitmap: &self.mask_2_bitmap_buf,
+                    cfg: &self.mask_collect_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -433,12 +465,13 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_mask_verb_returnhome(
             &mut self.cache,
-            &mask_verb_ReturnHome::MaskVerbReturnHomeBindings {
-                agent_alive: &self.agent_alive_buf,
-                agent_mana: &self.agent_mana_buf,
-                mask_3_bitmap: &self.mask_3_bitmap_buf,
-                cfg: &self.mask_return_cfg_buf,
-            },
+            &mask_verb_ReturnHome::MaskVerbReturnHomeBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_ReturnHome::MaskVerbReturnHomeExtras {
+                    mask_3_bitmap: &self.mask_3_bitmap_buf,
+                    cfg: &self.mask_return_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -450,12 +483,13 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_mask_verb_completequest(
             &mut self.cache,
-            &mask_verb_CompleteQuest::MaskVerbCompleteQuestBindings {
-                agent_alive: &self.agent_alive_buf,
-                agent_mana: &self.agent_mana_buf,
-                mask_4_bitmap: &self.mask_4_bitmap_buf,
-                cfg: &self.mask_complete_cfg_buf,
-            },
+            &mask_verb_CompleteQuest::MaskVerbCompleteQuestBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_CompleteQuest::MaskVerbCompleteQuestExtras {
+                    mask_4_bitmap: &self.mask_4_bitmap_buf,
+                    cfg: &self.mask_complete_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -470,17 +504,18 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_scoring(
             &mut self.cache,
-            &scoring::ScoringBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                mask_0_bitmap: &self.mask_0_bitmap_buf,
-                mask_1_bitmap: &self.mask_1_bitmap_buf,
-                mask_2_bitmap: &self.mask_2_bitmap_buf,
-                mask_3_bitmap: &self.mask_3_bitmap_buf,
-                mask_4_bitmap: &self.mask_4_bitmap_buf,
-                scoring_output: &self.scoring_output_buf,
-                cfg: &self.scoring_cfg_buf,
-            },
+            &scoring::ScoringBindings::from_context_with_extras(
+                &ctx,
+                &scoring::ScoringExtras {
+                    mask_0_bitmap: &self.mask_0_bitmap_buf,
+                    mask_1_bitmap: &self.mask_1_bitmap_buf,
+                    mask_2_bitmap: &self.mask_2_bitmap_buf,
+                    mask_3_bitmap: &self.mask_3_bitmap_buf,
+                    mask_4_bitmap: &self.mask_4_bitmap_buf,
+                    scoring_output: &self.scoring_output_buf,
+                    cfg: &self.scoring_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -494,11 +529,12 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_physics_verb_chronicle_acceptquest(
             &mut self.cache,
-            &physics_verb_chronicle_AcceptQuest::PhysicsVerbChronicleAcceptQuestBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_accept_cfg_buf,
-            },
+            &physics_verb_chronicle_AcceptQuest::PhysicsVerbChronicleAcceptQuestBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_AcceptQuest::PhysicsVerbChronicleAcceptQuestExtras {
+                    cfg: &self.chronicle_accept_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -510,11 +546,12 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_physics_verb_chronicle_huntmonster(
             &mut self.cache,
-            &physics_verb_chronicle_HuntMonster::PhysicsVerbChronicleHuntMonsterBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_hunt_cfg_buf,
-            },
+            &physics_verb_chronicle_HuntMonster::PhysicsVerbChronicleHuntMonsterBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_HuntMonster::PhysicsVerbChronicleHuntMonsterExtras {
+                    cfg: &self.chronicle_hunt_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -526,11 +563,12 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_physics_verb_chronicle_collectitem(
             &mut self.cache,
-            &physics_verb_chronicle_CollectItem::PhysicsVerbChronicleCollectItemBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_collect_cfg_buf,
-            },
+            &physics_verb_chronicle_CollectItem::PhysicsVerbChronicleCollectItemBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_CollectItem::PhysicsVerbChronicleCollectItemExtras {
+                    cfg: &self.chronicle_collect_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -542,11 +580,12 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_physics_verb_chronicle_returnhome(
             &mut self.cache,
-            &physics_verb_chronicle_ReturnHome::PhysicsVerbChronicleReturnHomeBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_return_cfg_buf,
-            },
+            &physics_verb_chronicle_ReturnHome::PhysicsVerbChronicleReturnHomeBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_ReturnHome::PhysicsVerbChronicleReturnHomeExtras {
+                    cfg: &self.chronicle_return_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -558,11 +597,12 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_physics_verb_chronicle_completequest(
             &mut self.cache,
-            &physics_verb_chronicle_CompleteQuest::PhysicsVerbChronicleCompleteQuestBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_complete_cfg_buf,
-            },
+            &physics_verb_chronicle_CompleteQuest::PhysicsVerbChronicleCompleteQuestBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_CompleteQuest::PhysicsVerbChronicleCompleteQuestExtras {
+                    cfg: &self.chronicle_complete_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -577,12 +617,12 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_physics_applystageadvance(
             &mut self.cache,
-            &physics_ApplyStageAdvance::PhysicsApplyStageAdvanceBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_mana: &self.agent_mana_buf,
-                cfg: &self.apply_stage_cfg_buf,
-            },
+            &physics_ApplyStageAdvance::PhysicsApplyStageAdvanceBindings::from_context_with_extras(
+                &ctx,
+                &physics_ApplyStageAdvance::PhysicsApplyStageAdvanceExtras {
+                    cfg: &self.apply_stage_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -596,12 +636,12 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_physics_applyquestcompleted(
             &mut self.cache,
-            &physics_ApplyQuestCompleted::PhysicsApplyQuestCompletedBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_mana: &self.agent_mana_buf,
-                cfg: &self.apply_complete_cfg_buf,
-            },
+            &physics_ApplyQuestCompleted::PhysicsApplyQuestCompletedBindings::from_context_with_extras(
+                &ctx,
+                &physics_ApplyQuestCompleted::PhysicsApplyQuestCompletedExtras {
+                    cfg: &self.apply_complete_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -614,12 +654,13 @@ impl CompiledSim for QuestArcRealState {
         );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
-            &seed_indirect_0::SeedIndirect0Bindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                indirect_args_0: self.event_ring.indirect_args_0(),
-                cfg: &self.seed_cfg_buf,
-            },
+            &seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx,
+                &seed_indirect_0::SeedIndirect0Extras {
+                    indirect_args_0: self.event_ring.indirect_args_0(),
+                    cfg: &self.seed_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 

--- a/crates/quest_probe_runtime/src/lib.rs
+++ b/crates/quest_probe_runtime/src/lib.rs
@@ -57,7 +57,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::EventRing;
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 
 /// Per-fixture state for the quest probe. Owns:
 ///   - Agent SoA (`alive` only — the producer rule reads no other field)
@@ -90,6 +92,12 @@ pub struct QuestProbeState {
     // -- Per-kernel cfg uniforms --
     physics_cfg_buf: wgpu::Buffer,
     fold_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -171,6 +179,12 @@ impl QuestProbeState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "quest_probe_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -181,6 +195,7 @@ impl QuestProbeState {
             progress_dirty: false,
             physics_cfg_buf,
             fold_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -246,6 +261,19 @@ impl CompiledSim for QuestProbeState {
         // (1) Per-tick clear of event_tail.
         self.event_ring.clear_tail_in(&mut encoder);
 
+        // Shared once per tick; the only non-fold dispatch consumes
+        // this immediately.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) physics_ProgressAndComplete — per-Adventurer; emits
         // one `ProgressTick { agent: self, quest: 0 }` per tick when
         // `self.alive`. No agent SoA reads beyond `alive`.
@@ -259,13 +287,15 @@ impl CompiledSim for QuestProbeState {
         self.gpu
             .queue
             .write_buffer(&self.physics_cfg_buf, 0, bytemuck::bytes_of(&physics_cfg));
-        let physics_bindings =
-            physics_ProgressAndComplete::PhysicsProgressAndCompleteBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_alive: &self.agent_alive_buf,
+        let physics_extras =
+            physics_ProgressAndComplete::PhysicsProgressAndCompleteExtras {
                 cfg: &self.physics_cfg_buf,
             };
+        let physics_bindings =
+            physics_ProgressAndComplete::PhysicsProgressAndCompleteBindings::from_context_with_extras(
+                &ctx,
+                &physics_extras,
+            );
         dispatch::dispatch_physics_progressandcomplete(
             &mut self.cache,
             &physics_bindings,

--- a/crates/scripted_battle_runtime/src/lib.rs
+++ b/crates/scripted_battle_runtime/src/lib.rs
@@ -44,7 +44,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture state for the scripted_battle.
 #[allow(dead_code)]
@@ -92,6 +94,12 @@ pub struct ScriptedBattleState {
     chronicle_forage_aftermath_cfg_buf: wgpu::Buffer,
     apply_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -319,6 +327,12 @@ impl ScriptedBattleState {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "scripted_battle_runtime",
+        );
+
         Self {
             gpu,
             agent_hp_buf,
@@ -347,6 +361,7 @@ impl ScriptedBattleState {
             chronicle_forage_aftermath_cfg_buf,
             apply_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -498,6 +513,23 @@ impl CompiledSim for ScriptedBattleState {
             0, scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct. Fold kernels still use
+        // hand-written `Bindings { ... }` literals — the compiler
+        // doesn't emit `from_context` constructors for them.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round — fused PerPair kernel.
         let mask_cfg = fused_mask_verb_ForagePeaceful::FusedMaskVerbForagePeacefulCfg {
             agent_cap: self.agent_count,
@@ -507,15 +539,18 @@ impl CompiledSim for ScriptedBattleState {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_ForagePeaceful::FusedMaskVerbForagePeacefulBindings {
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let mask_extras = fused_mask_verb_ForagePeaceful::FusedMaskVerbForagePeacefulExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
             mask_3_bitmap: &self.mask_3_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_ForagePeaceful::FusedMaskVerbForagePeacefulBindings::from_context_with_extras(
+                &ctx,
+                &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_foragepeaceful(
             &mut self.cache, &mask_bindings, &self.gpu.device, &mut encoder,
             self.agent_count * self.agent_count,
@@ -530,10 +565,7 @@ impl CompiledSim for ScriptedBattleState {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
@@ -541,6 +573,8 @@ impl CompiledSim for ScriptedBattleState {
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -553,11 +587,14 @@ impl CompiledSim for ScriptedBattleState {
         self.gpu.queue.write_buffer(
             &self.chronicle_forage_peaceful_cfg_buf, 0, bytemuck::bytes_of(&fp_cfg),
         );
-        let fp_bindings = physics_verb_chronicle_ForagePeaceful::PhysicsVerbChronicleForagePeacefulBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let fp_extras = physics_verb_chronicle_ForagePeaceful::PhysicsVerbChronicleForagePeacefulExtras {
             cfg: &self.chronicle_forage_peaceful_cfg_buf,
         };
+        let fp_bindings =
+            physics_verb_chronicle_ForagePeaceful::PhysicsVerbChronicleForagePeacefulBindings::from_context_with_extras(
+                &ctx,
+                &fp_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_foragepeaceful(
             &mut self.cache, &fp_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -569,11 +606,14 @@ impl CompiledSim for ScriptedBattleState {
         self.gpu.queue.write_buffer(
             &self.chronicle_villager_strike_cfg_buf, 0, bytemuck::bytes_of(&vs_cfg),
         );
-        let vs_bindings = physics_verb_chronicle_VillagerStrike::PhysicsVerbChronicleVillagerStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let vs_extras = physics_verb_chronicle_VillagerStrike::PhysicsVerbChronicleVillagerStrikeExtras {
             cfg: &self.chronicle_villager_strike_cfg_buf,
         };
+        let vs_bindings =
+            physics_verb_chronicle_VillagerStrike::PhysicsVerbChronicleVillagerStrikeBindings::from_context_with_extras(
+                &ctx,
+                &vs_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_villagerstrike(
             &mut self.cache, &vs_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -585,11 +625,14 @@ impl CompiledSim for ScriptedBattleState {
         self.gpu.queue.write_buffer(
             &self.chronicle_enemy_strike_cfg_buf, 0, bytemuck::bytes_of(&es_cfg),
         );
-        let es_bindings = physics_verb_chronicle_EnemyStrike::PhysicsVerbChronicleEnemyStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let es_extras = physics_verb_chronicle_EnemyStrike::PhysicsVerbChronicleEnemyStrikeExtras {
             cfg: &self.chronicle_enemy_strike_cfg_buf,
         };
+        let es_bindings =
+            physics_verb_chronicle_EnemyStrike::PhysicsVerbChronicleEnemyStrikeBindings::from_context_with_extras(
+                &ctx,
+                &es_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_enemystrike(
             &mut self.cache, &es_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -601,11 +644,14 @@ impl CompiledSim for ScriptedBattleState {
         self.gpu.queue.write_buffer(
             &self.chronicle_forage_aftermath_cfg_buf, 0, bytemuck::bytes_of(&fa_cfg),
         );
-        let fa_bindings = physics_verb_chronicle_ForageAftermath::PhysicsVerbChronicleForageAftermathBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let fa_extras = physics_verb_chronicle_ForageAftermath::PhysicsVerbChronicleForageAftermathExtras {
             cfg: &self.chronicle_forage_aftermath_cfg_buf,
         };
+        let fa_bindings =
+            physics_verb_chronicle_ForageAftermath::PhysicsVerbChronicleForageAftermathBindings::from_context_with_extras(
+                &ctx,
+                &fa_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_forageaftermath(
             &mut self.cache, &fa_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -620,13 +666,14 @@ impl CompiledSim for ScriptedBattleState {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings =
+            physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings::from_context_with_extras(
+                &ctx,
+                &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage_and_applyheal(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -641,12 +688,14 @@ impl CompiledSim for ScriptedBattleState {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/stdlib_math_probe_runtime/src/lib.rs
+++ b/crates/stdlib_math_probe_runtime/src/lib.rs
@@ -21,7 +21,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture state for the stdlib math probe. Owns:
 ///   - Agent SoA (alive only — pos/vel are declaration-only here)
@@ -52,6 +54,12 @@ pub struct StdlibMathProbeState {
     // -- Per-kernel cfg uniforms --
     physics_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -144,6 +152,12 @@ impl StdlibMathProbeState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "stdlib_math_probe_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -153,6 +167,7 @@ impl StdlibMathProbeState {
             sampled_count_cfg_buf,
             physics_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -197,6 +212,14 @@ impl CompiledSim for StdlibMathProbeState {
         self.event_ring
             .clear_ring_headers_in(&self.gpu, &mut encoder, self.agent_count);
 
+        // Shared once per tick; rebuilt around `note_emits` because it
+        // borrows `self.event_ring` immutably.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            pos_buf: Some(&self.agent_pos_buf),
+            ..Default::default()
+        };
+
         // (2) physics_SampleAndBucket — reads agent_alive. For each
         // alive agent: runs the math/rng `let` chain, computes the
         // bucket via `rng.action() % 4u`, and emits Sampled{ agent,
@@ -210,20 +233,29 @@ impl CompiledSim for StdlibMathProbeState {
         self.gpu
             .queue
             .write_buffer(&self.physics_cfg_buf, 0, bytemuck::bytes_of(&physics_cfg));
-        let physics_bindings = physics_SampleAndBucket::PhysicsSampleAndBucketBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.agent_pos_buf,
-            agent_alive: &self.agent_alive_buf,
-            cfg: &self.physics_cfg_buf,
-        };
-        dispatch::dispatch_physics_sampleandbucket(
-            &mut self.cache,
-            &physics_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count,
-        );
+        {
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
+            };
+            let physics_extras = physics_SampleAndBucket::PhysicsSampleAndBucketExtras {
+                cfg: &self.physics_cfg_buf,
+            };
+            let physics_bindings =
+                physics_SampleAndBucket::PhysicsSampleAndBucketBindings::from_context_with_extras(
+                    &ctx,
+                    &physics_extras,
+                );
+            dispatch::dispatch_physics_sampleandbucket(
+                &mut self.cache,
+                &physics_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count,
+            );
+        }
         // Producer upper bound: at most one Sampled per agent per
         // tick. Records the bound on the host-side ring estimator so
         // downstream consumers can size `event_count` from
@@ -241,19 +273,30 @@ impl CompiledSim for StdlibMathProbeState {
         self.gpu
             .queue
             .write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            indirect_args_0: self.event_ring.indirect_args_0(),
-            cfg: &self.seed_cfg_buf,
-        };
-        dispatch::dispatch_seed_indirect_0(
-            &mut self.cache,
-            &seed_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count,
-        );
+        {
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
+            };
+            let seed_extras = seed_indirect_0::SeedIndirect0Extras {
+                indirect_args_0: self.event_ring.indirect_args_0(),
+                cfg: &self.seed_cfg_buf,
+            };
+            let seed_bindings =
+                seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                    &ctx,
+                    &seed_extras,
+                );
+            dispatch::dispatch_seed_indirect_0(
+                &mut self.cache,
+                &seed_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count,
+            );
+        }
 
         // (4) fold_sampled_count — per-handler tag-filter on Sampled
         // (kind = 1u), atomic RMW into per-agent primary view

--- a/crates/stochastic_probe_runtime/src/lib.rs
+++ b/crates/stochastic_probe_runtime/src/lib.rs
@@ -75,7 +75,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture state for the stochastic probe. Owns:
 ///   - Agent SoA (alive only — pos/vel are declaration-only here)
@@ -99,6 +101,12 @@ pub struct StochasticProbeState {
     // -- Per-kernel cfg uniforms --
     physics_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -177,6 +185,12 @@ impl StochasticProbeState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "stochastic_probe_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -185,6 +199,7 @@ impl StochasticProbeState {
             activations_cfg_buf,
             physics_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -234,6 +249,13 @@ impl CompiledSim for StochasticProbeState {
         self.event_ring
             .clear_ring_headers_in(&self.gpu, &mut encoder, self.agent_count);
 
+        // Shared once per tick; rebuilt around `note_emits` because it
+        // borrows `self.event_ring` immutably.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+
         // (2) physics_MaybeFire — reads agent_alive. For each alive
         // agent: draws rng.action(), gates `(draw % 100) < 30`,
         // emits Activated{ agent=self, amount=1.0 } into the event
@@ -247,19 +269,29 @@ impl CompiledSim for StochasticProbeState {
         self.gpu
             .queue
             .write_buffer(&self.physics_cfg_buf, 0, bytemuck::bytes_of(&physics_cfg));
-        let physics_bindings = physics_MaybeFire::PhysicsMaybeFireBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_alive: &self.agent_alive_buf,
-            cfg: &self.physics_cfg_buf,
-        };
-        dispatch::dispatch_physics_maybefire(
-            &mut self.cache,
-            &physics_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count,
-        );
+        {
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
+            };
+            let physics_extras = physics_MaybeFire::PhysicsMaybeFireExtras {
+                cfg: &self.physics_cfg_buf,
+            };
+            let physics_bindings =
+                physics_MaybeFire::PhysicsMaybeFireBindings::from_context_with_extras(
+                    &ctx,
+                    &physics_extras,
+                );
+            dispatch::dispatch_physics_maybefire(
+                &mut self.cache,
+                &physics_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count,
+            );
+        }
         // Producer upper bound: at most one Activated per agent per
         // tick. Records the bound on the host-side ring estimator so
         // downstream consumers can size `event_count` from
@@ -277,19 +309,30 @@ impl CompiledSim for StochasticProbeState {
         self.gpu
             .queue
             .write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            indirect_args_0: self.event_ring.indirect_args_0(),
-            cfg: &self.seed_cfg_buf,
-        };
-        dispatch::dispatch_seed_indirect_0(
-            &mut self.cache,
-            &seed_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count,
-        );
+        {
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
+            };
+            let seed_extras = seed_indirect_0::SeedIndirect0Extras {
+                indirect_args_0: self.event_ring.indirect_args_0(),
+                cfg: &self.seed_cfg_buf,
+            };
+            let seed_bindings =
+                seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                    &ctx,
+                    &seed_extras,
+                );
+            dispatch::dispatch_seed_indirect_0(
+                &mut self.cache,
+                &seed_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count,
+            );
+        }
 
         // (4) fold_activations — per-handler tag-filter on Activated
         // (kind = 1u), atomic RMW into per-agent primary view

--- a/crates/swarm_storm_runtime/src/lib.rs
+++ b/crates/swarm_storm_runtime/src/lib.rs
@@ -15,7 +15,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, bytemuck::Pod, bytemuck::Zeroable)]
@@ -65,6 +67,12 @@ pub struct SwarmStormState {
     /// rate (0.85) before the per-event fold lands. The kernel reads
     /// `cfg.agent_cap` for the early-return.
     recent_pulse_intensity_decay_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     pos_cache: Vec<Vec3>,
@@ -208,6 +216,12 @@ impl SwarmStormState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "swarm_storm_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -221,6 +235,7 @@ impl SwarmStormState {
             recent_pulse_intensity,
             recent_pulse_intensity_cfg_buf,
             recent_pulse_intensity_decay_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -296,15 +311,31 @@ impl CompiledSim for SwarmStormState {
 
         self.event_ring.clear_tail_in(&mut encoder);
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct. `agent_vel` is not a
+        // standard SoA column so it flows through extras as
+        // `agent_vel`.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            alive_buf: Some(&self.alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) PulseAndDrift — emits 4 Pulse events per alive agent.
-        let bindings = physics_PulseAndDrift::PhysicsPulseAndDriftBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
-            agent_alive: &self.alive_buf,
+        let extras = physics_PulseAndDrift::PhysicsPulseAndDriftExtras {
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let bindings = physics_PulseAndDrift::PhysicsPulseAndDriftBindings::from_context_with_extras(
+            &ctx,
+            &extras,
+        );
         dispatch::dispatch_physics_pulseanddrift(
             &mut self.cache,
             &bindings,
@@ -313,12 +344,14 @@ impl CompiledSim for SwarmStormState {
             self.agent_count,
         );
 
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,
@@ -401,11 +434,16 @@ impl CompiledSim for SwarmStormState {
             0,
             bytemuck::bytes_of(&rpi_decay_cfg),
         );
-        let rpi_decay_bindings =
-            decay_recent_pulse_intensity::DecayRecentPulseIntensityBindings {
+        let rpi_decay_extras =
+            decay_recent_pulse_intensity::DecayRecentPulseIntensityExtras {
                 view_storage_primary: self.recent_pulse_intensity.primary(),
                 cfg: &self.recent_pulse_intensity_decay_cfg_buf,
             };
+        let rpi_decay_bindings =
+            decay_recent_pulse_intensity::DecayRecentPulseIntensityBindings::from_context_with_extras(
+                &ctx,
+                &rpi_decay_extras,
+            );
         dispatch::dispatch_decay_recent_pulse_intensity(
             &mut self.cache,
             &rpi_decay_bindings,

--- a/crates/tactical_horde_500_runtime/src/lib.rs
+++ b/crates/tactical_horde_500_runtime/src/lib.rs
@@ -47,7 +47,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::PackedAbilityRegistry;
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-team / per-role agent populations. 50+50+400=500 per team,
 /// 1000 total. Same role split as mass_battle_100v100 scaled by 5×
@@ -123,6 +125,12 @@ pub struct TacticalHorde500State {
     chronicle_blue_heal_cfg_buf: wgpu::Buffer,
     apply_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -344,6 +352,12 @@ impl TacticalHorde500State {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&engine::ability::AbilityRegistry::new()),
+            &gpu,
+            "tactical_horde_500_runtime",
+        );
+
         Self {
             gpu,
             agent_hp_buf,
@@ -374,6 +388,7 @@ impl TacticalHorde500State {
             chronicle_blue_heal_cfg_buf,
             apply_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -547,6 +562,21 @@ impl CompiledSim for TacticalHorde500State {
             0, scoring_output_bytes.max(16),
         );
 
+        // Shared once per tick; each non-fold dispatch below adds only
+        // its fixture-specific extras struct.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            level_buf: Some(&self.agent_level_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) Mask round — fused PerPair kernel writes ALL 6 mask
         // bitmaps. Dispatches `agent_cap × agent_cap` threads (=
         // 1000×1000 = 1 000 000 at full scale); the kernel internally
@@ -559,9 +589,7 @@ impl CompiledSim for TacticalHorde500State {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_RedStrike::FusedMaskVerbRedStrikeBindings {
-            agent_alive: &self.agent_alive_buf,
-            agent_level: &self.agent_level_buf,
+        let mask_extras = fused_mask_verb_RedStrike::FusedMaskVerbRedStrikeExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
@@ -570,6 +598,11 @@ impl CompiledSim for TacticalHorde500State {
             mask_5_bitmap: &self.mask_5_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_RedStrike::FusedMaskVerbRedStrikeBindings::from_context_with_extras(
+                &ctx,
+                &mask_extras,
+            );
         dispatch::dispatch_fused_mask_verb_redstrike(
             &mut self.cache, &mask_bindings, &self.gpu.device, &mut encoder,
             self.agent_count * self.agent_count,
@@ -586,11 +619,7 @@ impl CompiledSim for TacticalHorde500State {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_level: &self.agent_level_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
@@ -600,6 +629,8 @@ impl CompiledSim for TacticalHorde500State {
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -615,11 +646,14 @@ impl CompiledSim for TacticalHorde500State {
             event_count: agent_count, tick: tick_u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.chronicle_red_strike_cfg_buf, 0, bytemuck::bytes_of(&cfg));
-        let bindings = physics_verb_chronicle_RedStrike::PhysicsVerbChronicleRedStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let extras = physics_verb_chronicle_RedStrike::PhysicsVerbChronicleRedStrikeExtras {
             cfg: &self.chronicle_red_strike_cfg_buf,
         };
+        let bindings =
+            physics_verb_chronicle_RedStrike::PhysicsVerbChronicleRedStrikeBindings::from_context_with_extras(
+                &ctx,
+                &extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_redstrike(
             &mut self.cache, &bindings, &self.gpu.device, &mut encoder, agent_count,
         );
@@ -628,11 +662,14 @@ impl CompiledSim for TacticalHorde500State {
             event_count: agent_count, tick: tick_u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.chronicle_blue_strike_cfg_buf, 0, bytemuck::bytes_of(&cfg));
-        let bindings = physics_verb_chronicle_BlueStrike::PhysicsVerbChronicleBlueStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let extras = physics_verb_chronicle_BlueStrike::PhysicsVerbChronicleBlueStrikeExtras {
             cfg: &self.chronicle_blue_strike_cfg_buf,
         };
+        let bindings =
+            physics_verb_chronicle_BlueStrike::PhysicsVerbChronicleBlueStrikeBindings::from_context_with_extras(
+                &ctx,
+                &extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_bluestrike(
             &mut self.cache, &bindings, &self.gpu.device, &mut encoder, agent_count,
         );
@@ -641,11 +678,14 @@ impl CompiledSim for TacticalHorde500State {
             event_count: agent_count, tick: tick_u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.chronicle_red_snipe_cfg_buf, 0, bytemuck::bytes_of(&cfg));
-        let bindings = physics_verb_chronicle_RedSnipe::PhysicsVerbChronicleRedSnipeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let extras = physics_verb_chronicle_RedSnipe::PhysicsVerbChronicleRedSnipeExtras {
             cfg: &self.chronicle_red_snipe_cfg_buf,
         };
+        let bindings =
+            physics_verb_chronicle_RedSnipe::PhysicsVerbChronicleRedSnipeBindings::from_context_with_extras(
+                &ctx,
+                &extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_redsnipe(
             &mut self.cache, &bindings, &self.gpu.device, &mut encoder, agent_count,
         );
@@ -654,11 +694,14 @@ impl CompiledSim for TacticalHorde500State {
             event_count: agent_count, tick: tick_u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.chronicle_blue_snipe_cfg_buf, 0, bytemuck::bytes_of(&cfg));
-        let bindings = physics_verb_chronicle_BlueSnipe::PhysicsVerbChronicleBlueSnipeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let extras = physics_verb_chronicle_BlueSnipe::PhysicsVerbChronicleBlueSnipeExtras {
             cfg: &self.chronicle_blue_snipe_cfg_buf,
         };
+        let bindings =
+            physics_verb_chronicle_BlueSnipe::PhysicsVerbChronicleBlueSnipeBindings::from_context_with_extras(
+                &ctx,
+                &extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_bluesnipe(
             &mut self.cache, &bindings, &self.gpu.device, &mut encoder, agent_count,
         );
@@ -667,11 +710,14 @@ impl CompiledSim for TacticalHorde500State {
             event_count: agent_count, tick: tick_u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.chronicle_red_heal_cfg_buf, 0, bytemuck::bytes_of(&cfg));
-        let bindings = physics_verb_chronicle_RedHeal::PhysicsVerbChronicleRedHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let extras = physics_verb_chronicle_RedHeal::PhysicsVerbChronicleRedHealExtras {
             cfg: &self.chronicle_red_heal_cfg_buf,
         };
+        let bindings =
+            physics_verb_chronicle_RedHeal::PhysicsVerbChronicleRedHealBindings::from_context_with_extras(
+                &ctx,
+                &extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_redheal(
             &mut self.cache, &bindings, &self.gpu.device, &mut encoder, agent_count,
         );
@@ -680,11 +726,14 @@ impl CompiledSim for TacticalHorde500State {
             event_count: agent_count, tick: tick_u32, seed: 0, agent_cap: 0,
         };
         self.gpu.queue.write_buffer(&self.chronicle_blue_heal_cfg_buf, 0, bytemuck::bytes_of(&cfg));
-        let bindings = physics_verb_chronicle_BlueHeal::PhysicsVerbChronicleBlueHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let extras = physics_verb_chronicle_BlueHeal::PhysicsVerbChronicleBlueHealExtras {
             cfg: &self.chronicle_blue_heal_cfg_buf,
         };
+        let bindings =
+            physics_verb_chronicle_BlueHeal::PhysicsVerbChronicleBlueHealBindings::from_context_with_extras(
+                &ctx,
+                &extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_blueheal(
             &mut self.cache, &bindings, &self.gpu.device, &mut encoder, agent_count,
         );
@@ -698,13 +747,14 @@ impl CompiledSim for TacticalHorde500State {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings =
+            physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings::from_context_with_extras(
+                &ctx,
+                &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage_and_applyheal(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -719,12 +769,14 @@ impl CompiledSim for TacticalHorde500State {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx,
+            &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,


### PR DESCRIPTION
## Summary

Replaces hand-written `Bindings { ... }` literals at every non-fold dispatch site across 9 runtimes with `from_context_with_extras()` calls. One of the final 2 parallel batches in Phase 4 of the compiler-emitted bindings constructors plan.

Migrated runtimes (touched only `src/lib.rs`):
- `predator_prey_real_runtime` (10 non-fold sites including 5 spatial counting-sort kernels)
- `predator_prey_runtime` (5 non-fold sites including 2 decay kernels)
- `quest_arc_real_runtime` (14 non-fold sites)
- `quest_probe_runtime` (1 non-fold site)
- `scripted_battle_runtime` (8 non-fold sites)
- `stdlib_math_probe_runtime` (2 non-fold sites; uses note_emits ctx-rebuild)
- `stochastic_probe_runtime` (2 non-fold sites; uses note_emits ctx-rebuild)
- `swarm_storm_runtime` (3 non-fold sites including 1 decay kernel)
- `tactical_horde_500_runtime` (10 non-fold sites)

## Notes

- All 9 runtimes were ability-less; each gains a 1-time empty `PackedAbilityRegistryGpu` placeholder (matches batch 1/2/3 precedent).
- 2 of 9 runtimes (stochastic_probe, stdlib_math_probe) needed the `note_emits` ctx-rebuild block pattern from batch 2's diplomacy_probe.
- 3 decay kernels migrated successfully (`decay_kill_count`, `decay_predator_focus`, `decay_recent_pulse_intensity`) — `view_storage_primary` flows through extras.
- LOC delta: +406 net.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test -p engine --release --test schema_hash` passes (P2: schema unchanged)
- [x] All 9 runtime test suites green (`predator_prey: 9 passed; swarm_storm: 4 passed; rest: 0 lib tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)