### PR TITLE
refactor(runtimes): migrate Phase 4 batch 5/5 to compiler-emitted Bindings constructors

### DIFF
--- a/crates/tactical_squad_5v5_runtime/src/lib.rs
+++ b/crates/tactical_squad_5v5_runtime/src/lib.rs
@@ -49,7 +49,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 mod binding_check;
 
@@ -828,9 +828,29 @@ impl CompiledSim for TacticalSquad5v5State {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = fused_mask_verb_Strike::FusedMaskVerbStrikeBindings {
-            agent_alive: &self.agent_alive_buf,
-            agent_level: &self.agent_level_buf,
+        // Shared per-tick context — many standard SoA columns. The
+        // `event_ring` is borrowed immutably; safe here because
+        // `step()` doesn't call `note_emits` on the ring.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            max_hp_buf: Some(&self.agent_max_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            level_buf: Some(&self.agent_level_buf),
+            attack_damage_buf: Some(&self.agent_attack_damage_buf),
+            ability_power_buf: Some(&self.agent_ability_power_buf),
+            armor_buf: Some(&self.agent_armor_buf),
+            magic_resist_buf: Some(&self.agent_magic_resist_buf),
+            move_speed_buf: Some(&self.agent_move_speed_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let mask_extras = fused_mask_verb_Strike::FusedMaskVerbStrikeExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
@@ -845,6 +865,10 @@ impl CompiledSim for TacticalSquad5v5State {
             mask_4_bitmap: &self.mask_4_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            fused_mask_verb_Strike::FusedMaskVerbStrikeBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         // PAIR DISPATCH: agent_count * agent_count = 100 threads (10 × 10).
         // The dispatch helper takes a "logical work count" and
         // computes `(count + 63) / 64` workgroups; passing
@@ -869,15 +893,7 @@ impl CompiledSim for TacticalSquad5v5State {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            // The score expression `if target.alive { ... } else { ... }`
-            // adds `agent_alive` to the scoring kernel's binding set —
-            // without it the if-branch's `target.alive` predicate has
-            // nothing to read.
-            agent_alive: &self.agent_alive_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             mask_1_bitmap: &self.mask_1_bitmap_buf,
             mask_2_bitmap: &self.mask_2_bitmap_buf,
@@ -891,22 +907,10 @@ impl CompiledSim for TacticalSquad5v5State {
             mask_4_bitmap: &self.mask_4_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
-            // Wave 1.5#7 follow-on (predicate-aware scoring,
-            // 2026-05-07): scoring kernel now inlines per-effect when-
-            // predicate eval; same SoA + agent stat columns as the
-            // chronicle dispatcher.
-            ability_registry_when_pred_binder:  &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field:   &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op:      &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_mana:          &self.agent_mana_buf,
         };
+        let scoring_bindings = scoring::ScoringBindings::from_context_with_extras(
+            &ctx, &scoring_extras,
+        );
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -927,32 +931,13 @@ impl CompiledSim for TacticalSquad5v5State {
         self.gpu.queue.write_buffer(
             &self.chronicle_strike_cfg_buf, 0, bytemuck::bytes_of(&strike_cfg),
         );
-        let strike_bindings = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp:            &self.agent_hp_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana:          &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
+        let strike_extras = physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeExtras {
             cfg: &self.chronicle_strike_cfg_buf,
         };
+        let strike_bindings =
+            physics_verb_chronicle_Strike::PhysicsVerbChronicleStrikeBindings::from_context_with_extras(
+                &ctx, &strike_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_strike(
             &mut self.cache, &strike_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -968,32 +953,13 @@ impl CompiledSim for TacticalSquad5v5State {
         self.gpu.queue.write_buffer(
             &self.chronicle_snipe_cfg_buf, 0, bytemuck::bytes_of(&snipe_cfg),
         );
-        let snipe_bindings = physics_verb_chronicle_Snipe::PhysicsVerbChronicleSnipeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp:            &self.agent_hp_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana:          &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
+        let snipe_extras = physics_verb_chronicle_Snipe::PhysicsVerbChronicleSnipeExtras {
             cfg: &self.chronicle_snipe_cfg_buf,
         };
+        let snipe_bindings =
+            physics_verb_chronicle_Snipe::PhysicsVerbChronicleSnipeBindings::from_context_with_extras(
+                &ctx, &snipe_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_snipe(
             &mut self.cache, &snipe_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -1019,32 +985,13 @@ impl CompiledSim for TacticalSquad5v5State {
         self.gpu.queue.write_buffer(
             &self.chronicle_concussive_blow_cfg_buf, 0, bytemuck::bytes_of(&concussive_blow_cfg),
         );
-        let concussive_blow_bindings = physics_verb_chronicle_ConcussiveBlow::PhysicsVerbChronicleConcussiveBlowBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp:            &self.agent_hp_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana:          &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
+        let concussive_blow_extras = physics_verb_chronicle_ConcussiveBlow::PhysicsVerbChronicleConcussiveBlowExtras {
             cfg: &self.chronicle_concussive_blow_cfg_buf,
         };
+        let concussive_blow_bindings =
+            physics_verb_chronicle_ConcussiveBlow::PhysicsVerbChronicleConcussiveBlowBindings::from_context_with_extras(
+                &ctx, &concussive_blow_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_concussiveblow(
             &mut self.cache, &concussive_blow_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -1062,11 +1009,13 @@ impl CompiledSim for TacticalSquad5v5State {
         self.gpu.queue.write_buffer(
             &self.chronicle_heal_cfg_buf, 0, bytemuck::bytes_of(&heal_cfg),
         );
-        let heal_bindings = physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let heal_extras = physics_verb_chronicle_Heal::PhysicsVerbChronicleHealExtras {
             cfg: &self.chronicle_heal_cfg_buf,
         };
+        let heal_bindings =
+            physics_verb_chronicle_Heal::PhysicsVerbChronicleHealBindings::from_context_with_extras(
+                &ctx, &heal_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_heal(
             &mut self.cache, &heal_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -1092,32 +1041,13 @@ impl CompiledSim for TacticalSquad5v5State {
         self.gpu.queue.write_buffer(
             &self.chronicle_squad_heal_cfg_buf, 0, bytemuck::bytes_of(&squad_heal_cfg),
         );
-        let squad_heal_bindings = physics_verb_chronicle_SquadHeal::PhysicsVerbChronicleSquadHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp:            &self.agent_hp_buf,
-            agent_max_hp:        &self.agent_max_hp_buf,
-            agent_move_speed:    &self.agent_move_speed_buf,
-            agent_armor:         &self.agent_armor_buf,
-            agent_magic_resist:  &self.agent_magic_resist_buf,
-            agent_attack_damage: &self.agent_attack_damage_buf,
-            agent_ability_power: &self.agent_ability_power_buf,
-            agent_mana:          &self.agent_mana_buf,
-            ability_registry_effect_kinds: &self.registry_gpu.effect_kinds,
-            ability_registry_effect_payload_a: &self.registry_gpu.effect_payload_a,
-            ability_registry_effect_payload_b: &self.registry_gpu.effect_payload_b,
-            ability_registry_scaling_stat_refs: &self.registry_gpu.scaling_stat_refs,
-            ability_registry_scaling_percents: &self.registry_gpu.scaling_percents,
-            ability_registry_nested_effect_kinds: &self.registry_gpu.nested_effect_kinds,
-            ability_registry_nested_effect_payload_a: &self.registry_gpu.nested_effect_payload_a,
-            ability_registry_nested_effect_payload_b: &self.registry_gpu.nested_effect_payload_b,
-            ability_registry_when_pred_binder: &self.registry_gpu.when_pred_binder,
-            ability_registry_when_pred_field: &self.registry_gpu.when_pred_field,
-            ability_registry_when_pred_op: &self.registry_gpu.when_pred_op,
-            ability_registry_when_pred_literal: &self.registry_gpu.when_pred_literal,
-            ability_registry_chances:           &self.registry_gpu.chances,
+        let squad_heal_extras = physics_verb_chronicle_SquadHeal::PhysicsVerbChronicleSquadHealExtras {
             cfg: &self.chronicle_squad_heal_cfg_buf,
         };
+        let squad_heal_bindings =
+            physics_verb_chronicle_SquadHeal::PhysicsVerbChronicleSquadHealBindings::from_context_with_extras(
+                &ctx, &squad_heal_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_squadheal(
             &mut self.cache, &squad_heal_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -1150,15 +1080,15 @@ impl CompiledSim for TacticalSquad5v5State {
             &self.apply_chronicle_cfg_buf, 0,
             bytemuck::bytes_of(&apply_chronicle_cfg),
         );
-        let apply_chronicle_bindings =
-            physics_ApplyDamageFromChronicle_and_ApplyStunFromChronicle_and_ApplyHealFromChronicle::PhysicsApplyDamageFromChronicleAndApplyStunFromChronicleAndApplyHealFromChronicleBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_max_hp: &self.agent_max_hp_buf,
+        let apply_chronicle_extras =
+            physics_ApplyDamageFromChronicle_and_ApplyStunFromChronicle_and_ApplyHealFromChronicle::PhysicsApplyDamageFromChronicleAndApplyStunFromChronicleAndApplyHealFromChronicleExtras {
                 agent_stun_expires_at_tick: &self.agent_stun_expires_at_tick_buf,
                 cfg: &self.apply_chronicle_cfg_buf,
             };
+        let apply_chronicle_bindings =
+            physics_ApplyDamageFromChronicle_and_ApplyStunFromChronicle_and_ApplyHealFromChronicle::PhysicsApplyDamageFromChronicleAndApplyStunFromChronicleAndApplyHealFromChronicleBindings::from_context_with_extras(
+                &ctx, &apply_chronicle_extras,
+            );
         dispatch::dispatch_physics_applydamagefromchronicle_and_applystunfromchronicle_and_applyhealfromchronicle(
             &mut self.cache, &apply_chronicle_bindings,
             &self.gpu.device, &mut encoder, event_count_estimate,
@@ -1172,13 +1102,13 @@ impl CompiledSim for TacticalSquad5v5State {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings =
+            physics_ApplyDamage_and_ApplyHeal::PhysicsApplyDamageAndApplyHealBindings::from_context_with_extras(
+                &ctx, &apply_extras,
+            );
         dispatch::dispatch_physics_applydamage_and_applyheal(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -1193,12 +1123,13 @@ impl CompiledSim for TacticalSquad5v5State {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx, &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/target_chaser_runtime/src/lib.rs
+++ b/crates/target_chaser_runtime/src/lib.rs
@@ -11,6 +11,9 @@
 //! cross-agent target read actually moves bytes through the SoA
 //! at runtime.
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::{AbilityRegistry, PackedAbilityRegistry};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext};
 use engine::ids::AgentId;
 use engine::rng::per_agent_u32;
 use engine::sim_trait::CompiledSim;
@@ -58,6 +61,17 @@ pub struct TargetChaserState {
     engaged_with_buf: wgpu::Buffer,
     cfg_buf: wgpu::Buffer,
     pos_staging: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::event_ring`] field — this fixture has no
+    /// chronicle events, but the compiler-emitted constructor signature
+    /// requires the context to expose one.
+    event_ring: EventRing,
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     pos_cache: Vec<Vec3>,
@@ -155,6 +169,13 @@ impl TargetChaserState {
             mapped_at_creation: false,
         });
 
+        let event_ring = EventRing::new(&gpu, "target_chaser_runtime");
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&AbilityRegistry::new()),
+            &gpu,
+            "target_chaser_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -163,6 +184,8 @@ impl TargetChaserState {
             engaged_with_buf,
             cfg_buf,
             pos_staging,
+            event_ring,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -220,13 +243,26 @@ impl CompiledSim for TargetChaserState {
                 label: Some("target_chaser_runtime::step"),
             });
 
-        let bindings = physics_ChaseTarget::PhysicsChaseTargetBindings {
-            agent_pos: &self.pos_buf,
-            agent_alive: &self.alive_buf,
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            alive_buf: Some(&self.alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_ChaseTarget::PhysicsChaseTargetExtras {
             agent_engaged_with: &self.engaged_with_buf,
             agent_vel: &self.vel_buf,
             cfg: &self.cfg_buf,
         };
+        let bindings =
+            physics_ChaseTarget::PhysicsChaseTargetBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_chasetarget(
             &mut self.cache,
             &bindings,

--- a/crates/tom_probe_runtime/src/lib.rs
+++ b/crates/tom_probe_runtime/src/lib.rs
@@ -59,6 +59,8 @@
 //! every alive Knower; every off-diagonal `beliefs_flags(i, j != i)
 //! = 0u`.
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::{AbilityRegistry, PackedAbilityRegistry};
 use engine::sim_trait::CompiledSim;
 use engine::GpuContext;
 use glam::Vec3;
@@ -66,7 +68,10 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{bgl_storage, bgl_uniform, EventRing, EVENT_STRIDE_U32};
+use engine::gpu::{
+    bgl_storage, bgl_uniform, AgentBuffers, EventRing, KernelBindingsContext,
+    EVENT_STRIDE_U32,
+};
 
 /// Chronicle record stride in u32 words. Matches
 /// `engine::gpu::EVENT_STRIDE_U32` and
@@ -246,6 +251,12 @@ pub struct TomProbeState {
     /// consumer (`physics_ApplyDisguise`). Reads `cfg.tick` so the
     /// rule's `world.tick + duration` math lands at the right epoch.
     apply_disguise_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -453,6 +464,12 @@ impl TomProbeState {
             "tom_probe_runtime::physics_ApplyDisguise_cfg",
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&AbilityRegistry::new()),
+            &gpu,
+            "tom_probe_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -505,6 +522,7 @@ impl TomProbeState {
             apply_decoy_cfg_buf,
             apply_erase_belief_cfg_buf,
             apply_disguise_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             decay_gpu,
             tick: 0,
@@ -905,20 +923,31 @@ impl TomProbeState {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("tom_probe_runtime::observe::encoder"),
                 });
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.agent_pos_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_ApplyObserveBeliefUpdate::PhysicsApplyObserveBeliefUpdateExtras {
+            agent_disguise_expires_at_tick: &self.agent_disguise_expires_at_tick_buf,
+            agent_disguise_fake_type: &self.agent_disguise_fake_type_buf,
+            agent_creature_type: &self.agent_creature_type_buf,
+            beliefs_pos: &self.beliefs_pos_primary,
+            beliefs_type: &self.beliefs_type_primary,
+            beliefs_tick: &self.beliefs_tick_primary,
+            beliefs_confidence: &self.beliefs_confidence_primary,
+            cfg: &self.apply_observe_cfg_buf,
+        };
         let bindings =
-            physics_ApplyObserveBeliefUpdate::PhysicsApplyObserveBeliefUpdateBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_pos: &self.agent_pos_buf,
-                agent_creature_type: &self.agent_creature_type_buf,
-                agent_disguise_expires_at_tick: &self.agent_disguise_expires_at_tick_buf,
-                agent_disguise_fake_type: &self.agent_disguise_fake_type_buf,
-                beliefs_pos: &self.beliefs_pos_primary,
-                beliefs_type: &self.beliefs_type_primary,
-                beliefs_tick: &self.beliefs_tick_primary,
-                beliefs_confidence: &self.beliefs_confidence_primary,
-                cfg: &self.apply_observe_cfg_buf,
-            };
+            physics_ApplyObserveBeliefUpdate::PhysicsApplyObserveBeliefUpdateBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_applyobservebeliefupdate(
             &mut self.cache,
             &bindings,
@@ -979,9 +1008,17 @@ impl TomProbeState {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("tom_probe_runtime::scry::encoder"),
                 });
-        let bindings = physics_ApplyScryBeliefUpdate::PhysicsApplyScryBeliefUpdateBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_ApplyScryBeliefUpdate::PhysicsApplyScryBeliefUpdateExtras {
             beliefs_pos: &self.beliefs_pos_primary,
             beliefs_type: &self.beliefs_type_primary,
             beliefs_tick: &self.beliefs_tick_primary,
@@ -990,6 +1027,10 @@ impl TomProbeState {
             beliefs_flags: &self.beliefs_flags_primary,
             cfg: &self.apply_scry_cfg_buf,
         };
+        let bindings =
+            physics_ApplyScryBeliefUpdate::PhysicsApplyScryBeliefUpdateBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_applyscrybeliefupdate(
             &mut self.cache,
             &bindings,
@@ -1057,9 +1098,17 @@ impl TomProbeState {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("tom_probe_runtime::reveal::encoder"),
                 });
-        let bindings = physics_ApplyRevealBeliefUpdate::PhysicsApplyRevealBeliefUpdateBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_ApplyRevealBeliefUpdate::PhysicsApplyRevealBeliefUpdateExtras {
             beliefs_pos: &self.beliefs_pos_primary,
             beliefs_type: &self.beliefs_type_primary,
             beliefs_tick: &self.beliefs_tick_primary,
@@ -1068,6 +1117,10 @@ impl TomProbeState {
             beliefs_flags: &self.beliefs_flags_primary,
             cfg: &self.apply_reveal_cfg_buf,
         };
+        let bindings =
+            physics_ApplyRevealBeliefUpdate::PhysicsApplyRevealBeliefUpdateBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_applyrevealbeliefupdate(
             &mut self.cache,
             &bindings,
@@ -1136,15 +1189,27 @@ impl TomProbeState {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("tom_probe_runtime::decoy::encoder"),
                 });
-        let bindings = physics_ApplyDecoyBeliefUpdate::PhysicsApplyDecoyBeliefUpdateBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_ApplyDecoyBeliefUpdate::PhysicsApplyDecoyBeliefUpdateExtras {
             beliefs_pos: &self.beliefs_pos_primary,
             beliefs_type: &self.beliefs_type_primary,
             beliefs_tick: &self.beliefs_tick_primary,
             beliefs_confidence: &self.beliefs_confidence_primary,
             cfg: &self.apply_decoy_cfg_buf,
         };
+        let bindings =
+            physics_ApplyDecoyBeliefUpdate::PhysicsApplyDecoyBeliefUpdateBindings::from_context_with_extras(
+                &ctx, &extras,
+            );
         dispatch::dispatch_physics_applydecoybeliefupdate(
             &mut self.cache,
             &bindings,
@@ -1208,9 +1273,17 @@ impl TomProbeState {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("tom_probe_runtime::erase_belief::encoder"),
                 });
-        let bindings = physics_ApplyEraseBeliefUpdate_and_ApplyDisguise::PhysicsApplyEraseBeliefUpdateAndApplyDisguiseBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_ApplyEraseBeliefUpdate_and_ApplyDisguise::PhysicsApplyEraseBeliefUpdateAndApplyDisguiseExtras {
             agent_disguise_expires_at_tick: &self.agent_disguise_expires_at_tick_buf,
             agent_disguise_fake_type: &self.agent_disguise_fake_type_buf,
             beliefs_pos: &self.beliefs_pos_primary,
@@ -1221,6 +1294,9 @@ impl TomProbeState {
             beliefs_flags: &self.beliefs_flags_primary,
             cfg: &self.apply_erase_belief_cfg_buf,
         };
+        let bindings = physics_ApplyEraseBeliefUpdate_and_ApplyDisguise::PhysicsApplyEraseBeliefUpdateAndApplyDisguiseBindings::from_context_with_extras(
+            &ctx, &extras,
+        );
         dispatch::dispatch_physics_applyerasebeliefupdate_and_applydisguise(
             &mut self.cache,
             &bindings,
@@ -1284,9 +1360,17 @@ impl TomProbeState {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("tom_probe_runtime::disguise::encoder"),
                 });
-        let bindings = physics_ApplyEraseBeliefUpdate_and_ApplyDisguise::PhysicsApplyEraseBeliefUpdateAndApplyDisguiseBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let extras = physics_ApplyEraseBeliefUpdate_and_ApplyDisguise::PhysicsApplyEraseBeliefUpdateAndApplyDisguiseExtras {
             agent_disguise_expires_at_tick: &self.agent_disguise_expires_at_tick_buf,
             agent_disguise_fake_type: &self.agent_disguise_fake_type_buf,
             beliefs_pos: &self.beliefs_pos_primary,
@@ -1297,6 +1381,9 @@ impl TomProbeState {
             beliefs_flags: &self.beliefs_flags_primary,
             cfg: &self.apply_disguise_cfg_buf,
         };
+        let bindings = physics_ApplyEraseBeliefUpdate_and_ApplyDisguise::PhysicsApplyEraseBeliefUpdateAndApplyDisguiseBindings::from_context_with_extras(
+            &ctx, &extras,
+        );
         dispatch::dispatch_physics_applyerasebeliefupdate_and_applydisguise(
             &mut self.cache,
             &bindings,
@@ -1480,20 +1567,35 @@ impl CompiledSim for TomProbeState {
             0,
             bytemuck::bytes_of(&physics_cfg),
         );
-        let physics_bindings =
-            physics_WhatIBelieve::PhysicsWhatIBelieveBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_alive: &self.agent_alive_buf,
+        // The physics_bindings/`ctx` are constructed in a fresh scope
+        // so `ctx`'s immutable borrow of `self.event_ring` ends before
+        // `self.event_ring.note_emits()` (mutable borrow) below.
+        {
+            let agent_buffers = AgentBuffers {
+                alive_buf: Some(&self.agent_alive_buf),
+                ..Default::default()
+            };
+            let ctx = KernelBindingsContext {
+                state: &agent_buffers,
+                event_ring: &self.event_ring,
+                registry: &self.registry_gpu,
+                voxel_grid: None,
+            };
+            let physics_extras = physics_WhatIBelieve::PhysicsWhatIBelieveExtras {
                 cfg: &self.physics_cfg_buf,
             };
-        dispatch::dispatch_physics_whatibelieve(
-            &mut self.cache,
-            &physics_bindings,
-            &self.gpu.device,
-            &mut encoder,
-            self.agent_count,
-        );
+            let physics_bindings =
+                physics_WhatIBelieve::PhysicsWhatIBelieveBindings::from_context_with_extras(
+                    &ctx, &physics_extras,
+                );
+            dispatch::dispatch_physics_whatibelieve(
+                &mut self.cache,
+                &physics_bindings,
+                &self.gpu.device,
+                &mut encoder,
+                self.agent_count,
+            );
+        }
         self.event_ring.note_emits(self.agent_count);
 
         // (3) fold_beliefs_flags — folds BeliefAcquired into flags.

--- a/crates/tower_defense_runtime/src/lib.rs
+++ b/crates/tower_defense_runtime/src/lib.rs
@@ -54,7 +54,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::{AbilityRegistry, PackedAbilityRegistry};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 // ---- Slot layout constants (wired into both DSL semantics and
 //      runtime initialization). The .sim's mana role-bands depend on
@@ -153,6 +155,12 @@ pub struct TowerDefenseState {
     apply_damage_cfg_buf: wgpu::Buffer,
     march_enemies_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -379,6 +387,12 @@ impl TowerDefenseState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&AbilityRegistry::new()),
+            &gpu,
+            "tower_defense_runtime",
+        );
+
         Self {
             gpu,
             agent_pos_buf,
@@ -401,6 +415,7 @@ impl TowerDefenseState {
             apply_damage_cfg_buf,
             march_enemies_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             base_hp: BASE_HP,
             last_base_damage_total: 0.0,
@@ -621,13 +636,31 @@ impl CompiledSim for TowerDefenseState {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = mask_verb_Shoot::MaskVerbShootBindings {
-            agent_pos: &self.agent_pos_buf,
-            agent_alive: &self.agent_alive_buf,
-            agent_mana: &self.agent_mana_buf,
+        // Shared per-tick context — `pos`, `alive`, `hp`, `mana` are
+        // the standard SoA columns this fixture owns. `event_ring` is
+        // borrowed immutably; safe here because `step()` doesn't call
+        // `note_emits` on the ring.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.agent_pos_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let mask_extras = mask_verb_Shoot::MaskVerbShootExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            mask_verb_Shoot::MaskVerbShootBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         // GAP WORKAROUND (compiler kernel.rs:3243): the PerPair mask
         // body emits `let mask_0_k = cfg.agent_cap;` (was `1u`), so
         // each thread visits one (agent, candidate) pair. We must
@@ -655,14 +688,14 @@ impl CompiledSim for TowerDefenseState {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.agent_pos_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings = scoring::ScoringBindings::from_context_with_extras(
+            &ctx, &scoring_extras,
+        );
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -675,11 +708,13 @@ impl CompiledSim for TowerDefenseState {
         self.gpu.queue.write_buffer(
             &self.chronicle_shoot_cfg_buf, 0, bytemuck::bytes_of(&shoot_cfg),
         );
-        let shoot_bindings = physics_verb_chronicle_Shoot::PhysicsVerbChronicleShootBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let shoot_extras = physics_verb_chronicle_Shoot::PhysicsVerbChronicleShootExtras {
             cfg: &self.chronicle_shoot_cfg_buf,
         };
+        let shoot_bindings =
+            physics_verb_chronicle_Shoot::PhysicsVerbChronicleShootBindings::from_context_with_extras(
+                &ctx, &shoot_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_shoot(
             &mut self.cache, &shoot_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -693,14 +728,13 @@ impl CompiledSim for TowerDefenseState {
         self.gpu.queue.write_buffer(
             &self.march_enemies_cfg_buf, 0, bytemuck::bytes_of(&march_cfg),
         );
-        let march_bindings = physics_MarchEnemies::PhysicsMarchEnemiesBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.agent_pos_buf,
-            agent_alive: &self.agent_alive_buf,
-            agent_mana: &self.agent_mana_buf,
+        let march_extras = physics_MarchEnemies::PhysicsMarchEnemiesExtras {
             cfg: &self.march_enemies_cfg_buf,
         };
+        let march_bindings =
+            physics_MarchEnemies::PhysicsMarchEnemiesBindings::from_context_with_extras(
+                &ctx, &march_extras,
+            );
         dispatch::dispatch_physics_marchenemies(
             &mut self.cache, &march_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -714,13 +748,12 @@ impl CompiledSim for TowerDefenseState {
         self.gpu.queue.write_buffer(
             &self.apply_damage_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyDamage::PhysicsApplyDamageBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let apply_extras = physics_ApplyDamage::PhysicsApplyDamageExtras {
             cfg: &self.apply_damage_cfg_buf,
         };
+        let apply_bindings = physics_ApplyDamage::PhysicsApplyDamageBindings::from_context_with_extras(
+            &ctx, &apply_extras,
+        );
         dispatch::dispatch_physics_applydamage(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -733,12 +766,13 @@ impl CompiledSim for TowerDefenseState {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx, &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/trade_market_real_runtime/src/lib.rs
+++ b/crates/trade_market_real_runtime/src/lib.rs
@@ -55,6 +55,8 @@
 //! the seller writes in the chronicle. Same shape as duel_1v1's
 //! deferred "cycle in read/write graph" warning.
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::{AbilityRegistry, PackedAbilityRegistry};
 use engine::sim_trait::CompiledSim;
 use engine::GpuContext;
 use glam::Vec3;
@@ -62,7 +64,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 pub const NUM_TRADERS: u32 = 50;
 pub const NUM_GOODS: u32 = 10;
@@ -127,6 +129,12 @@ pub struct TradeMarketRealState {
     chronicle_buy_cfg_buf: wgpu::Buffer,
     apply_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -333,6 +341,12 @@ impl TradeMarketRealState {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&AbilityRegistry::new()),
+            &gpu,
+            "trade_market_real_runtime",
+        );
+
         Self {
             gpu,
             agent_hp_buf,
@@ -355,6 +369,7 @@ impl TradeMarketRealState {
             chronicle_buy_cfg_buf,
             apply_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -499,14 +514,31 @@ impl CompiledSim for TradeMarketRealState {
         self.gpu.queue.write_buffer(
             &self.mask_cfg_buf, 0, bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = mask_verb_Buy::MaskVerbBuyBindings {
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
-            agent_mana: &self.agent_mana_buf,
+        // Shared per-tick context — `hp`, `alive`, `mana` are the
+        // standard SoA columns this fixture owns. `event_ring` is
+        // borrowed immutably; safe here because `step()` doesn't call
+        // `note_emits` on the ring.
+        let agent_buffers = AgentBuffers {
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+        let mask_extras = mask_verb_Buy::MaskVerbBuyExtras {
             trade_good_base_price: &self.trade_good_base_price_buf,
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            mask_verb_Buy::MaskVerbBuyBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         // PerPair dispatch: (agent, candidate) pairs. Today the mask
         // kernel hardcodes mask_k=1u (TODO task-5.7), so only cand=0
         // is checked. For the trade market this means the mask
@@ -593,15 +625,14 @@ impl CompiledSim for TradeMarketRealState {
         self.gpu.queue.write_buffer(
             &self.scoring_cfg_buf, 0, bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_mana: &self.agent_mana_buf,
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_0_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings = scoring::ScoringBindings::from_context_with_extras(
+            &ctx, &scoring_extras,
+        );
         dispatch::dispatch_scoring(
             &mut self.cache, &scoring_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -615,12 +646,13 @@ impl CompiledSim for TradeMarketRealState {
         self.gpu.queue.write_buffer(
             &self.chronicle_buy_cfg_buf, 0, bytemuck::bytes_of(&chronicle_cfg),
         );
-        let chronicle_bindings = physics_verb_chronicle_Buy::PhysicsVerbChronicleBuyBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
+        let chronicle_extras = physics_verb_chronicle_Buy::PhysicsVerbChronicleBuyExtras {
             cfg: &self.chronicle_buy_cfg_buf,
         };
+        let chronicle_bindings =
+            physics_verb_chronicle_Buy::PhysicsVerbChronicleBuyBindings::from_context_with_extras(
+                &ctx, &chronicle_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_buy(
             &mut self.cache, &chronicle_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,
@@ -636,14 +668,12 @@ impl CompiledSim for TradeMarketRealState {
         self.gpu.queue.write_buffer(
             &self.apply_cfg_buf, 0, bytemuck::bytes_of(&apply_cfg),
         );
-        let apply_bindings = physics_ApplyTrade::PhysicsApplyTradeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
-            agent_mana: &self.agent_mana_buf,
+        let apply_extras = physics_ApplyTrade::PhysicsApplyTradeExtras {
             cfg: &self.apply_cfg_buf,
         };
+        let apply_bindings = physics_ApplyTrade::PhysicsApplyTradeBindings::from_context_with_extras(
+            &ctx, &apply_extras,
+        );
         dispatch::dispatch_physics_applytrade(
             &mut self.cache, &apply_bindings, &self.gpu.device, &mut encoder,
             event_count_estimate,
@@ -657,12 +687,13 @@ impl CompiledSim for TradeMarketRealState {
         self.gpu.queue.write_buffer(
             &self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx, &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_bindings, &self.gpu.device, &mut encoder,
             self.agent_count,

--- a/crates/trade_market_runtime/src/lib.rs
+++ b/crates/trade_market_runtime/src/lib.rs
@@ -61,6 +61,8 @@
 //!     from the verb chronicle. Per-slot grows by 1.0 per tick =
 //!     100.0 after 100 ticks.
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::{AbilityRegistry, PackedAbilityRegistry};
 use engine::ids::AgentId;
 use engine::rng::per_agent_u32;
 use engine::sim_trait::CompiledSim;
@@ -70,7 +72,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, bytemuck::Pod, bytemuck::Zeroable)]
@@ -145,6 +147,12 @@ pub struct TradeMarketState {
     // -- hub_volume (f32 no decay) --
     hub_volume: ViewStorage,
     hub_volume_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
     pos_cache: Vec<Vec3>,
@@ -425,6 +433,12 @@ impl TradeMarketState {
             },
         );
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&AbilityRegistry::new()),
+            &gpu,
+            "trade_market_runtime",
+        );
+
         Self {
             gpu,
             pos_buf,
@@ -455,6 +469,7 @@ impl TradeMarketState {
             trader_volume_decay_cfg_buf,
             hub_volume,
             hub_volume_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             pos_cache: pos_host,
             dirty: false,
@@ -596,14 +611,33 @@ impl CompiledSim for TradeMarketState {
             bytemuck::bytes_of(&physics_cfg),
         );
 
+        // Shared per-tick context — `pos` + `alive` are the standard
+        // SoA columns this fixture owns. `event_ring` is borrowed
+        // immutably; safe here because `step()` doesn't call
+        // `note_emits` on the ring.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.pos_buf),
+            alive_buf: Some(&self.alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (1) Spatial-hash counting sort (5 phases). Same shape as
         // particle_collision_runtime — sort agents into 27-cell grid
         // for the body-form spatial walk in WanderAndTrade.
-        let count_b = spatial_build_hash_count::SpatialBuildHashCountBindings {
-            agent_pos: &self.pos_buf,
+        let count_extras = spatial_build_hash_count::SpatialBuildHashCountExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             cfg: &self.physics_cfg_buf,
         };
+        let count_b =
+            spatial_build_hash_count::SpatialBuildHashCountBindings::from_context_with_extras(
+                &ctx, &count_extras,
+            );
         dispatch::dispatch_spatial_build_hash_count(
             &mut self.cache,
             &count_b,
@@ -611,13 +645,17 @@ impl CompiledSim for TradeMarketState {
             &mut encoder,
             self.agent_count,
         );
-        let scan_local_b =
-            spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings {
+        let scan_local_extras =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalExtras {
                 spatial_grid_offsets: &self.spatial_grid_offsets,
                 spatial_grid_starts: &self.spatial_grid_starts,
                 spatial_chunk_sums: &self.spatial_chunk_sums,
                 cfg: &self.physics_cfg_buf,
             };
+        let scan_local_b =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings::from_context_with_extras(
+                &ctx, &scan_local_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_local(
             &mut self.cache,
             &scan_local_b,
@@ -625,11 +663,15 @@ impl CompiledSim for TradeMarketState {
             &mut encoder,
             self.agent_count,
         );
-        let scan_carry_b =
-            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings {
+        let scan_carry_extras =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryExtras {
                 spatial_chunk_sums: &self.spatial_chunk_sums,
                 cfg: &self.physics_cfg_buf,
             };
+        let scan_carry_b =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings::from_context_with_extras(
+                &ctx, &scan_carry_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_carry(
             &mut self.cache,
             &scan_carry_b,
@@ -637,12 +679,17 @@ impl CompiledSim for TradeMarketState {
             &mut encoder,
             self.agent_count,
         );
-        let scan_add_b = spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings {
-            spatial_grid_offsets: &self.spatial_grid_offsets,
-            spatial_grid_starts: &self.spatial_grid_starts,
-            spatial_chunk_sums: &self.spatial_chunk_sums,
-            cfg: &self.physics_cfg_buf,
-        };
+        let scan_add_extras =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddExtras {
+                spatial_grid_offsets: &self.spatial_grid_offsets,
+                spatial_grid_starts: &self.spatial_grid_starts,
+                spatial_chunk_sums: &self.spatial_chunk_sums,
+                cfg: &self.physics_cfg_buf,
+            };
+        let scan_add_b =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings::from_context_with_extras(
+                &ctx, &scan_add_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_add(
             &mut self.cache,
             &scan_add_b,
@@ -650,13 +697,16 @@ impl CompiledSim for TradeMarketState {
             &mut encoder,
             self.agent_count,
         );
-        let scatter_b = spatial_build_hash_scatter::SpatialBuildHashScatterBindings {
-            agent_pos: &self.pos_buf,
+        let scatter_extras = spatial_build_hash_scatter::SpatialBuildHashScatterExtras {
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.physics_cfg_buf,
         };
+        let scatter_b =
+            spatial_build_hash_scatter::SpatialBuildHashScatterBindings::from_context_with_extras(
+                &ctx, &scatter_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scatter(
             &mut self.cache,
             &scatter_b,
@@ -676,11 +726,13 @@ impl CompiledSim for TradeMarketState {
             0,
             bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_b = mask_verb_ExecuteTrade::MaskVerbExecuteTradeBindings {
-            agent_alive: &self.alive_buf,
+        let mask_extras = mask_verb_ExecuteTrade::MaskVerbExecuteTradeExtras {
             mask_0_bitmap: &self.mask_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_b = mask_verb_ExecuteTrade::MaskVerbExecuteTradeBindings::from_context_with_extras(
+            &ctx, &mask_extras,
+        );
         dispatch::dispatch_mask_verb_executetrade(
             &mut self.cache,
             &mask_b,
@@ -699,13 +751,14 @@ impl CompiledSim for TradeMarketState {
             0,
             bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_b = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_b = scoring::ScoringBindings::from_context_with_extras(
+            &ctx, &scoring_extras,
+        );
         dispatch::dispatch_scoring(
             &mut self.cache,
             &scoring_b,
@@ -731,12 +784,14 @@ impl CompiledSim for TradeMarketState {
             0,
             bytemuck::bytes_of(&chronicle_cfg),
         );
-        let chronicle_b =
-            physics_verb_chronicle_ExecuteTrade::PhysicsVerbChronicleExecuteTradeBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
+        let chronicle_extras =
+            physics_verb_chronicle_ExecuteTrade::PhysicsVerbChronicleExecuteTradeExtras {
                 cfg: &self.chronicle_cfg_buf,
             };
+        let chronicle_b =
+            physics_verb_chronicle_ExecuteTrade::PhysicsVerbChronicleExecuteTradeBindings::from_context_with_extras(
+                &ctx, &chronicle_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_executetrade(
             &mut self.cache,
             &chronicle_b,
@@ -749,17 +804,17 @@ impl CompiledSim for TradeMarketState {
         // walk. Per alive agent: integrate position, then walk the
         // 27-cell neighbourhood; per candidate emit one PriceObserved
         // (kind=2u) AND one PriceGossip (kind=3u).
-        let physics_b = physics_WanderAndTrade::PhysicsWanderAndTradeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.pos_buf,
-            agent_alive: &self.alive_buf,
+        let physics_extras = physics_WanderAndTrade::PhysicsWanderAndTradeExtras {
             agent_vel: &self.vel_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.physics_cfg_buf,
         };
+        let physics_b =
+            physics_WanderAndTrade::PhysicsWanderAndTradeBindings::from_context_with_extras(
+                &ctx, &physics_extras,
+            );
         dispatch::dispatch_physics_wanderandtrade(
             &mut self.cache,
             &physics_b,
@@ -769,12 +824,13 @@ impl CompiledSim for TradeMarketState {
         );
 
         // (5) seed_indirect_0 — keeps indirect-args buffer warm.
-        let seed_b = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.physics_cfg_buf,
         };
+        let seed_b = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx, &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_b,
@@ -848,10 +904,13 @@ impl CompiledSim for TradeMarketState {
             0,
             bytemuck::bytes_of(&tv_decay_cfg),
         );
-        let tv_decay_b = decay_trader_volume::DecayTraderVolumeBindings {
+        let tv_decay_extras = decay_trader_volume::DecayTraderVolumeExtras {
             view_storage_primary: self.trader_volume.primary(),
             cfg: &self.trader_volume_decay_cfg_buf,
         };
+        let tv_decay_b = decay_trader_volume::DecayTraderVolumeBindings::from_context_with_extras(
+            &ctx, &tv_decay_extras,
+        );
         dispatch::dispatch_decay_trader_volume(
             &mut self.cache,
             &tv_decay_b,

--- a/crates/trophic_3tier_runtime/src/lib.rs
+++ b/crates/trophic_3tier_runtime/src/lib.rs
@@ -61,7 +61,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::{AbilityRegistry, PackedAbilityRegistry};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Discriminant for the first-declared entity (Grass).
 pub const CT_GRASS: u32 = 0;
@@ -176,6 +178,12 @@ pub struct Trophic3TierState {
     applystrike_cfg_buf: wgpu::Buffer,
     energydecay_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -475,6 +483,12 @@ impl Trophic3TierState {
             make_view_cfg("trophic_3tier_runtime::prey_killed_total_cfg");
         let starved_total_cfg_buf = make_view_cfg("trophic_3tier_runtime::starved_total_cfg");
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&AbilityRegistry::new()),
+            &gpu,
+            "trophic_3tier_runtime",
+        );
+
         Self {
             gpu,
             agent_pos_buf,
@@ -500,6 +514,7 @@ impl Trophic3TierState {
             applystrike_cfg_buf,
             energydecay_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count: SLOT_CAP,
@@ -914,64 +929,100 @@ impl CompiledSim for Trophic3TierState {
             bytemuck::bytes_of(&grass_eat_cfg),
         );
 
-        let count_b = spatial_build_hash_count::SpatialBuildHashCountBindings {
-            agent_pos: &self.agent_pos_buf,
+        // Shared per-tick context — `pos`, `hp`, `alive` are the
+        // standard SoA columns this fixture owns. `event_ring` is
+        // borrowed immutably; safe here because `step()` doesn't call
+        // `note_emits` on the ring.
+        let agent_buffers = AgentBuffers {
+            pos_buf: Some(&self.agent_pos_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
+        let count_extras = spatial_build_hash_count::SpatialBuildHashCountExtras {
             spatial_grid_offsets: &self.spatial_grid_offsets,
             cfg: &self.grass_eat_cfg_buf,
         };
+        let count_b =
+            spatial_build_hash_count::SpatialBuildHashCountBindings::from_context_with_extras(
+                &ctx, &count_extras,
+            );
         dispatch::dispatch_spatial_build_hash_count(
             &mut self.cache, &count_b, &self.gpu.device, &mut encoder, SLOT_CAP,
         );
-        let scan_local_b = spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings {
-            spatial_grid_offsets: &self.spatial_grid_offsets,
-            spatial_grid_starts: &self.spatial_grid_starts,
-            spatial_chunk_sums: &self.spatial_chunk_sums,
-            cfg: &self.grass_eat_cfg_buf,
-        };
+        let scan_local_extras =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalExtras {
+                spatial_grid_offsets: &self.spatial_grid_offsets,
+                spatial_grid_starts: &self.spatial_grid_starts,
+                spatial_chunk_sums: &self.spatial_chunk_sums,
+                cfg: &self.grass_eat_cfg_buf,
+            };
+        let scan_local_b =
+            spatial_build_hash_scan_local::SpatialBuildHashScanLocalBindings::from_context_with_extras(
+                &ctx, &scan_local_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_local(
             &mut self.cache, &scan_local_b, &self.gpu.device, &mut encoder, SLOT_CAP,
         );
-        let scan_carry_b = spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings {
-            spatial_chunk_sums: &self.spatial_chunk_sums,
-            cfg: &self.grass_eat_cfg_buf,
-        };
+        let scan_carry_extras =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryExtras {
+                spatial_chunk_sums: &self.spatial_chunk_sums,
+                cfg: &self.grass_eat_cfg_buf,
+            };
+        let scan_carry_b =
+            spatial_build_hash_scan_carry::SpatialBuildHashScanCarryBindings::from_context_with_extras(
+                &ctx, &scan_carry_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_carry(
             &mut self.cache, &scan_carry_b, &self.gpu.device, &mut encoder, SLOT_CAP,
         );
-        let scan_add_b = spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings {
-            spatial_grid_offsets: &self.spatial_grid_offsets,
-            spatial_grid_starts: &self.spatial_grid_starts,
-            spatial_chunk_sums: &self.spatial_chunk_sums,
-            cfg: &self.grass_eat_cfg_buf,
-        };
+        let scan_add_extras =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddExtras {
+                spatial_grid_offsets: &self.spatial_grid_offsets,
+                spatial_grid_starts: &self.spatial_grid_starts,
+                spatial_chunk_sums: &self.spatial_chunk_sums,
+                cfg: &self.grass_eat_cfg_buf,
+            };
+        let scan_add_b =
+            spatial_build_hash_scan_add::SpatialBuildHashScanAddBindings::from_context_with_extras(
+                &ctx, &scan_add_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scan_add(
             &mut self.cache, &scan_add_b, &self.gpu.device, &mut encoder, SLOT_CAP,
         );
-        let scatter_b = spatial_build_hash_scatter::SpatialBuildHashScatterBindings {
-            agent_pos: &self.agent_pos_buf,
+        let scatter_extras = spatial_build_hash_scatter::SpatialBuildHashScatterExtras {
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.grass_eat_cfg_buf,
         };
+        let scatter_b =
+            spatial_build_hash_scatter::SpatialBuildHashScatterBindings::from_context_with_extras(
+                &ctx, &scatter_extras,
+            );
         dispatch::dispatch_spatial_build_hash_scatter(
             &mut self.cache, &scatter_b, &self.gpu.device, &mut encoder, SLOT_CAP,
         );
 
         // (3) GrassRegrow + HerbivoreEat (fused). Emits Eat events for
         //     herbivore→grass neighbour pairs.
-        let grass_eat_b = physics_GrassRegrow_and_HerbivoreEat::PhysicsGrassRegrowAndHerbivoreEatBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.agent_pos_buf,
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let grass_eat_extras = physics_GrassRegrow_and_HerbivoreEat::PhysicsGrassRegrowAndHerbivoreEatExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.grass_eat_cfg_buf,
         };
+        let grass_eat_b = physics_GrassRegrow_and_HerbivoreEat::PhysicsGrassRegrowAndHerbivoreEatBindings::from_context_with_extras(
+            &ctx, &grass_eat_extras,
+        );
         dispatch::dispatch_physics_grassregrow_and_herbivoreeat(
             &mut self.cache, &grass_eat_b, &self.gpu.device, &mut encoder, SLOT_CAP,
         );
@@ -987,14 +1038,13 @@ impl CompiledSim for Trophic3TierState {
         self.gpu.queue.write_buffer(
             &self.applyeat_cfg_buf, 0, bytemuck::bytes_of(&applyeat_cfg),
         );
-        let applyeat_b = physics_ApplyEat::PhysicsApplyEatBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let applyeat_extras = physics_ApplyEat::PhysicsApplyEatExtras {
             agent_hunger: &self.agent_hunger_buf,
             cfg: &self.applyeat_cfg_buf,
         };
+        let applyeat_b = physics_ApplyEat::PhysicsApplyEatBindings::from_context_with_extras(
+            &ctx, &applyeat_extras,
+        );
         dispatch::dispatch_physics_applyeat(
             &mut self.cache, &applyeat_b, &self.gpu.device, &mut encoder, event_count_estimate,
         );
@@ -1009,17 +1059,17 @@ impl CompiledSim for Trophic3TierState {
         self.gpu.queue.write_buffer(
             &self.carnhunt_cfg_buf, 0, bytemuck::bytes_of(&carnhunt_cfg),
         );
-        let carnhunt_b = physics_CarnivoreHunt::PhysicsCarnivoreHuntBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_pos: &self.agent_pos_buf,
-            agent_alive: &self.agent_alive_buf,
+        let carnhunt_extras = physics_CarnivoreHunt::PhysicsCarnivoreHuntExtras {
             agent_creature_type: &self.agent_creature_type_buf,
             spatial_grid_cells: &self.spatial_grid_cells,
             spatial_grid_offsets: &self.spatial_grid_offsets,
             spatial_grid_starts: &self.spatial_grid_starts,
             cfg: &self.carnhunt_cfg_buf,
         };
+        let carnhunt_b =
+            physics_CarnivoreHunt::PhysicsCarnivoreHuntBindings::from_context_with_extras(
+                &ctx, &carnhunt_extras,
+            );
         dispatch::dispatch_physics_carnivorehunt(
             &mut self.cache, &carnhunt_b, &self.gpu.device, &mut encoder, SLOT_CAP,
         );
@@ -1034,14 +1084,14 @@ impl CompiledSim for Trophic3TierState {
         self.gpu.queue.write_buffer(
             &self.applystrike_cfg_buf, 0, bytemuck::bytes_of(&applystrike_cfg),
         );
-        let applystrike_b = physics_ApplyStrike::PhysicsApplyStrikeBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_hp: &self.agent_hp_buf,
-            agent_alive: &self.agent_alive_buf,
+        let applystrike_extras = physics_ApplyStrike::PhysicsApplyStrikeExtras {
             agent_hunger: &self.agent_hunger_buf,
             cfg: &self.applystrike_cfg_buf,
         };
+        let applystrike_b =
+            physics_ApplyStrike::PhysicsApplyStrikeBindings::from_context_with_extras(
+                &ctx, &applystrike_extras,
+            );
         dispatch::dispatch_physics_applystrike(
             &mut self.cache, &applystrike_b, &self.gpu.device, &mut encoder, event_count_estimate,
         );
@@ -1056,14 +1106,15 @@ impl CompiledSim for Trophic3TierState {
         self.gpu.queue.write_buffer(
             &self.energydecay_cfg_buf, 0, bytemuck::bytes_of(&energydecay_cfg),
         );
-        let energydecay_b = physics_EnergyDecay::PhysicsEnergyDecayBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
-            agent_alive: &self.agent_alive_buf,
+        let energydecay_extras = physics_EnergyDecay::PhysicsEnergyDecayExtras {
             agent_hunger: &self.agent_hunger_buf,
             agent_creature_type: &self.agent_creature_type_buf,
             cfg: &self.energydecay_cfg_buf,
         };
+        let energydecay_b =
+            physics_EnergyDecay::PhysicsEnergyDecayBindings::from_context_with_extras(
+                &ctx, &energydecay_extras,
+            );
         dispatch::dispatch_physics_energydecay(
             &mut self.cache, &energydecay_b, &self.gpu.device, &mut encoder, SLOT_CAP,
         );
@@ -1076,12 +1127,13 @@ impl CompiledSim for Trophic3TierState {
             _pad: 0,
         };
         self.gpu.queue.write_buffer(&self.seed_cfg_buf, 0, bytemuck::bytes_of(&seed_cfg));
-        let seed_b = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_b = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx, &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache, &seed_b, &self.gpu.device, &mut encoder, SLOT_CAP,
         );

--- a/crates/verb_probe_runtime/src/lib.rs
+++ b/crates/verb_probe_runtime/src/lib.rs
@@ -45,6 +45,8 @@
 //! Observable: with `faith_step = 1.0`, every alive slot's faith
 //! value should equal the tick count (e.g. `100.0` after 100 ticks).
 
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::{AbilityRegistry, PackedAbilityRegistry};
 use engine::sim_trait::CompiledSim;
 use engine::GpuContext;
 use glam::Vec3;
@@ -52,7 +54,7 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, bytemuck::Pod, bytemuck::Zeroable)]
@@ -111,6 +113,12 @@ pub struct VerbProbeState {
     seed_cfg_buf: wgpu::Buffer,
     #[allow(dead_code)]
     snapshot_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -223,6 +231,12 @@ impl VerbProbeState {
                 usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&AbilityRegistry::new()),
+            &gpu,
+            "verb_probe_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -238,6 +252,7 @@ impl VerbProbeState {
             chronicle_cfg_buf,
             seed_cfg_buf,
             snapshot_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -286,6 +301,21 @@ impl CompiledSim for VerbProbeState {
             mask_bytes.max(4),
         );
 
+        // Shared per-tick context — `alive` is the only standard SoA
+        // column this fixture owns. `event_ring` is borrowed
+        // immutably; safe here because `step()` doesn't call
+        // `note_emits` on the ring.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         // (2) mask_verb_Pray — reads agent_alive, atomicOrs into
         // mask_0_bitmap.
         let mask_cfg = mask_verb_Pray::MaskVerbPrayCfg {
@@ -298,11 +328,14 @@ impl CompiledSim for VerbProbeState {
             0,
             bytemuck::bytes_of(&mask_cfg),
         );
-        let mask_bindings = mask_verb_Pray::MaskVerbPrayBindings {
-            agent_alive: &self.agent_alive_buf,
+        let mask_extras = mask_verb_Pray::MaskVerbPrayExtras {
             mask_0_bitmap: &self.mask_bitmap_buf,
             cfg: &self.mask_cfg_buf,
         };
+        let mask_bindings =
+            mask_verb_Pray::MaskVerbPrayBindings::from_context_with_extras(
+                &ctx, &mask_extras,
+            );
         dispatch::dispatch_mask_verb_pray(
             &mut self.cache,
             &mask_bindings,
@@ -323,13 +356,13 @@ impl CompiledSim for VerbProbeState {
             0,
             bytemuck::bytes_of(&scoring_cfg),
         );
-        let scoring_bindings = scoring::ScoringBindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let scoring_extras = scoring::ScoringExtras {
             mask_0_bitmap: &self.mask_bitmap_buf,
             scoring_output: &self.scoring_output_buf,
             cfg: &self.scoring_cfg_buf,
         };
+        let scoring_bindings =
+            scoring::ScoringBindings::from_context_with_extras(&ctx, &scoring_extras);
         dispatch::dispatch_scoring(
             &mut self.cache,
             &scoring_bindings,
@@ -366,12 +399,14 @@ impl CompiledSim for VerbProbeState {
             0,
             bytemuck::bytes_of(&chronicle_cfg),
         );
-        let chronicle_bindings =
-            physics_verb_chronicle_Pray::PhysicsVerbChroniclePrayBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
+        let chronicle_extras =
+            physics_verb_chronicle_Pray::PhysicsVerbChroniclePrayExtras {
                 cfg: &self.chronicle_cfg_buf,
             };
+        let chronicle_bindings =
+            physics_verb_chronicle_Pray::PhysicsVerbChroniclePrayBindings::from_context_with_extras(
+                &ctx, &chronicle_extras,
+            );
         dispatch::dispatch_physics_verb_chronicle_pray(
             &mut self.cache,
             &chronicle_bindings,
@@ -392,12 +427,13 @@ impl CompiledSim for VerbProbeState {
             0,
             bytemuck::bytes_of(&seed_cfg),
         );
-        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings {
-            event_ring: self.event_ring.ring(),
-            event_tail: self.event_ring.tail(),
+        let seed_extras = seed_indirect_0::SeedIndirect0Extras {
             indirect_args_0: self.event_ring.indirect_args_0(),
             cfg: &self.seed_cfg_buf,
         };
+        let seed_bindings = seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+            &ctx, &seed_extras,
+        );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
             &seed_bindings,

--- a/crates/village_day_cycle_runtime/src/lib.rs
+++ b/crates/village_day_cycle_runtime/src/lib.rs
@@ -55,7 +55,9 @@ use wgpu::util::DeviceExt;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-use engine::gpu::{EventRing, ViewStorage};
+use engine::ability::registry_gpu::PackedAbilityRegistryGpu;
+use engine::ability::{AbilityRegistry, PackedAbilityRegistry};
+use engine::gpu::{AgentBuffers, EventRing, KernelBindingsContext, ViewStorage};
 
 /// Per-fixture state for the village day cycle.
 pub struct VillageDayCycleState {
@@ -115,6 +117,12 @@ pub struct VillageDayCycleState {
     apply_eat_cfg_buf: wgpu::Buffer,
     apply_decay_cfg_buf: wgpu::Buffer,
     seed_cfg_buf: wgpu::Buffer,
+
+    /// Empty placeholder for the shared
+    /// [`KernelBindingsContext::registry`] field — this fixture has no
+    /// abilities, but the compiler-emitted constructor signature requires
+    /// the context to expose one.
+    registry_gpu: PackedAbilityRegistryGpu,
 
     cache: dispatch::KernelCache,
 
@@ -321,6 +329,12 @@ impl VillageDayCycleState {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let registry_gpu = PackedAbilityRegistryGpu::upload(
+            &PackedAbilityRegistry::pack(&AbilityRegistry::new()),
+            &gpu,
+            "village_day_cycle_runtime",
+        );
+
         Self {
             gpu,
             agent_alive_buf,
@@ -360,6 +374,7 @@ impl VillageDayCycleState {
             apply_eat_cfg_buf,
             apply_decay_cfg_buf,
             seed_cfg_buf,
+            registry_gpu,
             cache: dispatch::KernelCache::default(),
             tick: 0,
             agent_count,
@@ -494,6 +509,23 @@ impl CompiledSim for VillageDayCycleState {
         // thread per agent. Each row gates on its own phase window
         // (`tick % 100`) plus a per-row cooldown (`tick % {3,4,5,10,2}`).
 
+        // Shared per-tick context — `alive`, `hp`, `mana` are the
+        // standard SoA columns this fixture owns. `event_ring` is
+        // borrowed immutably; safe here because `step()` doesn't call
+        // `note_emits` on the ring.
+        let agent_buffers = AgentBuffers {
+            alive_buf: Some(&self.agent_alive_buf),
+            hp_buf: Some(&self.agent_hp_buf),
+            mana_buf: Some(&self.agent_mana_buf),
+            ..Default::default()
+        };
+        let ctx = KernelBindingsContext {
+            state: &agent_buffers,
+            event_ring: &self.event_ring,
+            registry: &self.registry_gpu,
+            voxel_grid: None,
+        };
+
         let mask_cfg_work = mask_verb_WorkHarvest::MaskVerbWorkHarvestCfg {
             agent_cap: self.agent_count, tick, seed: 0, _pad: 0,
         };
@@ -502,11 +534,13 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_mask_verb_workharvest(
             &mut self.cache,
-            &mask_verb_WorkHarvest::MaskVerbWorkHarvestBindings {
-                agent_alive: &self.agent_alive_buf,
-                mask_0_bitmap: &self.mask_0_bitmap_buf,
-                cfg: &self.mask_work_cfg_buf,
-            },
+            &mask_verb_WorkHarvest::MaskVerbWorkHarvestBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_WorkHarvest::MaskVerbWorkHarvestExtras {
+                    mask_0_bitmap: &self.mask_0_bitmap_buf,
+                    cfg: &self.mask_work_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -518,12 +552,13 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_mask_verb_tradefood(
             &mut self.cache,
-            &mask_verb_TradeFood::MaskVerbTradeFoodBindings {
-                agent_alive: &self.agent_alive_buf,
-                agent_mana: &self.agent_mana_buf,
-                mask_1_bitmap: &self.mask_1_bitmap_buf,
-                cfg: &self.mask_trade_cfg_buf,
-            },
+            &mask_verb_TradeFood::MaskVerbTradeFoodBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_TradeFood::MaskVerbTradeFoodExtras {
+                    mask_1_bitmap: &self.mask_1_bitmap_buf,
+                    cfg: &self.mask_trade_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -535,12 +570,13 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_mask_verb_eatfood(
             &mut self.cache,
-            &mask_verb_EatFood::MaskVerbEatFoodBindings {
-                agent_alive: &self.agent_alive_buf,
-                agent_mana: &self.agent_mana_buf,
-                mask_2_bitmap: &self.mask_2_bitmap_buf,
-                cfg: &self.mask_eat_cfg_buf,
-            },
+            &mask_verb_EatFood::MaskVerbEatFoodBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_EatFood::MaskVerbEatFoodExtras {
+                    mask_2_bitmap: &self.mask_2_bitmap_buf,
+                    cfg: &self.mask_eat_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -552,11 +588,13 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_mask_verb_rest(
             &mut self.cache,
-            &mask_verb_Rest::MaskVerbRestBindings {
-                agent_alive: &self.agent_alive_buf,
-                mask_3_bitmap: &self.mask_3_bitmap_buf,
-                cfg: &self.mask_rest_cfg_buf,
-            },
+            &mask_verb_Rest::MaskVerbRestBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_Rest::MaskVerbRestExtras {
+                    mask_3_bitmap: &self.mask_3_bitmap_buf,
+                    cfg: &self.mask_rest_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -568,11 +606,13 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_mask_verb_drainenergy(
             &mut self.cache,
-            &mask_verb_DrainEnergy::MaskVerbDrainEnergyBindings {
-                agent_alive: &self.agent_alive_buf,
-                mask_4_bitmap: &self.mask_4_bitmap_buf,
-                cfg: &self.mask_drain_cfg_buf,
-            },
+            &mask_verb_DrainEnergy::MaskVerbDrainEnergyBindings::from_context_with_extras(
+                &ctx,
+                &mask_verb_DrainEnergy::MaskVerbDrainEnergyExtras {
+                    mask_4_bitmap: &self.mask_4_bitmap_buf,
+                    cfg: &self.mask_drain_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -589,17 +629,18 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_scoring(
             &mut self.cache,
-            &scoring::ScoringBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                mask_0_bitmap: &self.mask_0_bitmap_buf,
-                mask_1_bitmap: &self.mask_1_bitmap_buf,
-                mask_2_bitmap: &self.mask_2_bitmap_buf,
-                mask_3_bitmap: &self.mask_3_bitmap_buf,
-                mask_4_bitmap: &self.mask_4_bitmap_buf,
-                scoring_output: &self.scoring_output_buf,
-                cfg: &self.scoring_cfg_buf,
-            },
+            &scoring::ScoringBindings::from_context_with_extras(
+                &ctx,
+                &scoring::ScoringExtras {
+                    mask_0_bitmap: &self.mask_0_bitmap_buf,
+                    mask_1_bitmap: &self.mask_1_bitmap_buf,
+                    mask_2_bitmap: &self.mask_2_bitmap_buf,
+                    mask_3_bitmap: &self.mask_3_bitmap_buf,
+                    mask_4_bitmap: &self.mask_4_bitmap_buf,
+                    scoring_output: &self.scoring_output_buf,
+                    cfg: &self.scoring_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 
@@ -613,11 +654,12 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_physics_verb_chronicle_workharvest(
             &mut self.cache,
-            &physics_verb_chronicle_WorkHarvest::PhysicsVerbChronicleWorkHarvestBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_work_cfg_buf,
-            },
+            &physics_verb_chronicle_WorkHarvest::PhysicsVerbChronicleWorkHarvestBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_WorkHarvest::PhysicsVerbChronicleWorkHarvestExtras {
+                    cfg: &self.chronicle_work_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -629,11 +671,12 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_physics_verb_chronicle_tradefood(
             &mut self.cache,
-            &physics_verb_chronicle_TradeFood::PhysicsVerbChronicleTradeFoodBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_trade_cfg_buf,
-            },
+            &physics_verb_chronicle_TradeFood::PhysicsVerbChronicleTradeFoodBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_TradeFood::PhysicsVerbChronicleTradeFoodExtras {
+                    cfg: &self.chronicle_trade_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -645,11 +688,12 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_physics_verb_chronicle_eatfood(
             &mut self.cache,
-            &physics_verb_chronicle_EatFood::PhysicsVerbChronicleEatFoodBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_eat_cfg_buf,
-            },
+            &physics_verb_chronicle_EatFood::PhysicsVerbChronicleEatFoodBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_EatFood::PhysicsVerbChronicleEatFoodExtras {
+                    cfg: &self.chronicle_eat_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -661,11 +705,12 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_physics_verb_chronicle_rest(
             &mut self.cache,
-            &physics_verb_chronicle_Rest::PhysicsVerbChronicleRestBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_rest_cfg_buf,
-            },
+            &physics_verb_chronicle_Rest::PhysicsVerbChronicleRestBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_Rest::PhysicsVerbChronicleRestExtras {
+                    cfg: &self.chronicle_rest_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -677,11 +722,12 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_physics_verb_chronicle_drainenergy(
             &mut self.cache,
-            &physics_verb_chronicle_DrainEnergy::PhysicsVerbChronicleDrainEnergyBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                cfg: &self.chronicle_drain_cfg_buf,
-            },
+            &physics_verb_chronicle_DrainEnergy::PhysicsVerbChronicleDrainEnergyBindings::from_context_with_extras(
+                &ctx,
+                &physics_verb_chronicle_DrainEnergy::PhysicsVerbChronicleDrainEnergyExtras {
+                    cfg: &self.chronicle_drain_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -694,12 +740,12 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_physics_applywork(
             &mut self.cache,
-            &physics_ApplyWork::PhysicsApplyWorkBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_mana: &self.agent_mana_buf,
-                cfg: &self.apply_work_cfg_buf,
-            },
+            &physics_ApplyWork::PhysicsApplyWorkBindings::from_context_with_extras(
+                &ctx,
+                &physics_ApplyWork::PhysicsApplyWorkExtras {
+                    cfg: &self.apply_work_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -712,13 +758,12 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_physics_applytrade(
             &mut self.cache,
-            &physics_ApplyTrade::PhysicsApplyTradeBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_mana: &self.agent_mana_buf,
-                cfg: &self.apply_trade_cfg_buf,
-            },
+            &physics_ApplyTrade::PhysicsApplyTradeBindings::from_context_with_extras(
+                &ctx,
+                &physics_ApplyTrade::PhysicsApplyTradeExtras {
+                    cfg: &self.apply_trade_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -731,13 +776,12 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_physics_applyeat(
             &mut self.cache,
-            &physics_ApplyEat::PhysicsApplyEatBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_mana: &self.agent_mana_buf,
-                cfg: &self.apply_eat_cfg_buf,
-            },
+            &physics_ApplyEat::PhysicsApplyEatBindings::from_context_with_extras(
+                &ctx,
+                &physics_ApplyEat::PhysicsApplyEatExtras {
+                    cfg: &self.apply_eat_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -751,13 +795,12 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_physics_applyenergydecay(
             &mut self.cache,
-            &physics_ApplyEnergyDecay::PhysicsApplyEnergyDecayBindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                agent_hp: &self.agent_hp_buf,
-                agent_alive: &self.agent_alive_buf,
-                cfg: &self.apply_decay_cfg_buf,
-            },
+            &physics_ApplyEnergyDecay::PhysicsApplyEnergyDecayBindings::from_context_with_extras(
+                &ctx,
+                &physics_ApplyEnergyDecay::PhysicsApplyEnergyDecayExtras {
+                    cfg: &self.apply_decay_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, event_count_estimate,
         );
 
@@ -770,12 +813,13 @@ impl CompiledSim for VillageDayCycleState {
         );
         dispatch::dispatch_seed_indirect_0(
             &mut self.cache,
-            &seed_indirect_0::SeedIndirect0Bindings {
-                event_ring: self.event_ring.ring(),
-                event_tail: self.event_ring.tail(),
-                indirect_args_0: self.event_ring.indirect_args_0(),
-                cfg: &self.seed_cfg_buf,
-            },
+            &seed_indirect_0::SeedIndirect0Bindings::from_context_with_extras(
+                &ctx,
+                &seed_indirect_0::SeedIndirect0Extras {
+                    indirect_args_0: self.event_ring.indirect_args_0(),
+                    cfg: &self.seed_cfg_buf,
+                },
+            ),
             &self.gpu.device, &mut encoder, self.agent_count,
         );
 


### PR DESCRIPTION
## Summary

Phase 4 batch 5 of 5 of the [compiler-emitted Bindings constructors plan](docs/superpowers/plans/2026-05-09-compiler-emitted-bindings-constructors.md).

Replaces hand-written `Bindings { ... }` literals at every non-fold dispatch site across **9 runtime crates** with `from_context_with_extras()` calls. Builds one `KernelBindingsContext` + `AgentBuffers` aggregate per tick (or per scope-block where `note_emits` boundaries require it) and threads it into each kernel; per-kernel fixture-specific buffers ride small `*Extras` structs.

**Migrated runtimes (this PR):**
- `tactical_squad_5v5_runtime` (12 sites; fused mask, scoring, 5 verb chronicles, fused apply_chronicle, apply, seed; 2 fold)
- `target_chaser_runtime` (1 site; physics_ChaseTarget)
- `tom_probe_runtime` (8 sites; physics_WhatIBelieve in step + 6 standalone applies; 1 fold)
- `tower_defense_runtime` (6 non-fold; 2 fold)
- `trade_market_real_runtime` (5 non-fold; 2 fold)
- `trade_market_runtime` (11 non-fold including 5 spatial counting-sort + 1 decay; 3 fold)
- `trophic_3tier_runtime` (11 non-fold including 5 spatial; 3 fold)
- `verb_probe_runtime` (4 non-fold; 1 fold)
- `village_day_cycle_runtime` (16 non-fold; 4 fold)

**LOC delta**: +325 net (+751 / -426). Net positive because 8/9 runtimes gain a one-time `registry_gpu` field + setup. Big per-site wins land in tactical_squad_5v5 (-122 net — chronicle bindings collapse ~22 lines of registry/agent fields per dispatch into a single `cfg`-only Extras across 4 chronicle dispatches). Future per-buffer additions (new agent SoA columns) accrue zero lines per migrated runtime.

**ViewFold (`fold_*`) kernels remain hand-written** per the plan — the compiler doesn't emit `from_context` constructors for them. **Decay kernels ARE migratable** per the batch 2 finding — `decay_trader_volume` in trade_market_runtime joins the migration.

**Empty placeholders**: 8/9 runtimes had no `PackedAbilityRegistryGpu` field; they now upload an empty `AbilityRegistry::new()` placeholder since `KernelBindingsContext` requires one even though no kernel binds `ability_registry_*`. `target_chaser` additionally gains an empty `EventRing` placeholder. Same pattern as batch 1 boids/2 flocking.

**`note_emits` ctx-rebuild**: 1 of 9 runtimes (tom_probe) needed the scope-block pattern from batch 2's diplomacy_probe migration — `physics_WhatIBelieve` dispatch sits in its own block so `ctx`'s immutable borrow of `&self.event_ring` drops before the subsequent `self.event_ring.note_emits(N)` mutable borrow.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test -p engine --release --test schema_hash` — P2 schema hash unchanged
- [x] `cargo test -p <crate> --release` for all 9 runtimes — all green
  - **Pre-existing failure**: `tactical_squad_5v5_runtime::viz_tests::squad_heal_recovers_friendly_hp` fails identically on `main` (same hp=110 readback before and after this refactor) — unrelated to the binding constructor migration.

## Constitution alignment

- P1 Compiler-First: PASS — using compiler-emitted constructors.
- P2 Schema-Hash: PASS — unchanged.
- P5 Determinism: PASS — pure refactor.
- P10 No Runtime Panic: PASS — type-checked at compile time; missing agent buffers surface as `expect("kernel binds X but the runtime didn't supply ctx.state.X")` clear errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)