### PR TITLE
test(plan-g/g5): CastBegin parity arm in apply_program_sweep

### DIFF
--- a/crates/apply_ability_smoke_runtime/tests/parity_apply_program_sweep.rs
+++ b/crates/apply_ability_smoke_runtime/tests/parity_apply_program_sweep.rs
@@ -1084,6 +1084,36 @@ fn build_sweep() -> Vec<(&'static str, AbilityProgram, CasterStats)> {
         CasterStats::default(),
     ));
 
+    // 48. Firebolt-shape — Plan G G2.3 deferred-cast initiation.
+    //     Caster begins a 3-tick cast at the target. The dispatcher
+    //     writes a 5-payload-word chronicle record (kind=77) with
+    //     payload_a packing (ability_id=7 in low 16 bits |
+    //     duration_ticks=30 in high 16 bits) and payload_b packing
+    //     (target_x_q8=256 in low 16 bits | target_y_q8=-512 in high
+    //     16 bits, both u16-reinterpreted). The chronicle's actor +
+    //     target slots are the runtime caster + target. Both backends
+    //     emit byte-equal records via the parity sweep's sort + memcmp
+    //     pin. This entry extends the matrix to 48 abilities and
+    //     locks in Plan G's CastBegin (variant 46) cross-backend
+    //     parity. The downstream busy SoA write + deferred resolution
+    //     are per-fixture sim concerns (firebolt_probe.sim) — not in
+    //     scope for the apply_program parity sweep.
+    out.push((
+        "FireboltCastBegin",
+        AbilityProgram::new_single_target(
+            8.0,
+            Gate { cooldown_ticks: 50, hostile_only: true, line_of_sight: false },
+            [EffectOp::CastBegin {
+                ability_id:     7,
+                duration_ticks: 30,
+                target_slot:    0,
+                target_x_q8:    256,
+                target_y_q8:    -512,
+            }],
+        ),
+        CasterStats::default(),
+    ));
+
     out
 }
 


### PR DESCRIPTION
Plan G G5 — extends the cross-backend parity sweep at `apply_ability_smoke_runtime/tests/parity_apply_program_sweep.rs` with a CastBegin entry (the 48th ability shape). Locks in P3 parity for Plan G's deferred-cast initiation across CPU oracle (`apply_program`) and GPU dispatcher (WGSL `apply_ability` emit, kind=46 → 77).

## What's tested

The sweep runs `apply_event_to_chronicle_record` (the CPU chronicle reference encoder) on every emitted ApplyEvent and memcmp's the result against the GPU's `event_ring`. With G2.3's CastBegin chronicle arm in place there, adding the program here was a one-statement extension.

The new arm exercises:
* payload_a packing: `ability_id=7` (low 16) | `duration_ticks=30` (high 16)
* payload_b packing: `target_x_q8=256` (u16 low) | `target_y_q8=-512` (u16 high) — sign-preserving for negative q8
* Runtime caster + target slots (chronicle's actor + target fields)

Byte-identical CPU/GPU output across the full record. Sweep matrix: 47 → 48 abilities; test runtime ~20s.

## What this CLOSES

Plan G's P3 obligation for the CastBegin EffectOp. Cross-backend parity is now end-to-end provable on real GPU.

## What this does NOT close

The per-fixture busy SoA write + ResolveBusy + InterruptCastOnDamage rules (firebolt_probe.sim, firebolt_interrupt_probe.sim) aren't part of the apply_program parity surface — they're per-fixture sim consumers downstream of the chronicle. Their parity is verified separately by the per-runtime behavioural pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)