### PR TITLE
docs(plans): Plan H (threat stresstest) + Plan I (grammar tree walker)

### DIFF
--- a/docs/plans/h_threat_stresstest_design.md
+++ b/docs/plans/h_threat_stresstest_design.md
@@ -1,0 +1,124 @@
+# Plan H — Threat Stresstest + Scoring Effectiveness
+
+> Status: design. Implementation lands after Plan G G3 completes
+> (threats view + scoring primitives merged to main).
+
+## Goal
+
+Measure how much the threats infrastructure changes AI behaviour.
+Two threat lifetimes, each with different scoring impact:
+
+* **Short-term threats** — active casts (3-10 ticks, populated by
+  `EffectCastBeginApplied`, decay at cast resolution / interruption).
+  Usage: dodger AI moves out of telegraphed Firebolt zone.
+* **Long-term threats** — persistent grudges (10k+ ticks, populated
+  by `CompetitorObserved` / `AuctionLost` / `PriceUndercut` events,
+  decay slowly). Usage: merchant prioritizes raids on rival caravans
+  weeks after the grudge formed.
+
+The fixture proves the threats infrastructure scales across the
+short/long axis without bespoke code per use case.
+
+## Architectural Impact Statement
+
+* **P1 (Compiler-First):** PASS. Both threat shapes use the same
+  `@per_entity_ring(K)` storage hint with `@dispatch(per_agent_event_scan)`.
+  Per-fixture sim rules populate them; no `impl Rule` in
+  `crates/engine/src/handlers/`.
+* **P2 (Schema-Hash):** No bump. Reuses the threat-cell struct
+  layout from G3b. Decay timing is per-cell (`expires_at_tick`
+  field) — no new SoA columns.
+* **P3 (Cross-Backend Parity):** Tested via the `apply_program`
+  sweep + a new fold-body parity arm for the threats view's append
+  + decay primitives.
+* **P5 (Determinism):** Decay decisions are pure functions of
+  `(world.tick, cell.expires_at_tick)` — no RNG.
+* **P11 (Reduction Determinism):** Cursor's atomicAdd serializes
+  ring-slot allocation per writer; cell writes are non-atomic but
+  race-free because each (target, ring slot) gets exactly one
+  writer per tick.
+
+## Fixture shape
+
+`assets/sim/threat_stresstest.sim`:
+
+* **256 agents.** 64 casters (mid-cast bosses), 64 brawlers (active
+  threat producers), 64 merchants (long-term grudge holders), 64
+  observers (the AI being measured).
+* **Two threats views:**
+  * `cast_threats(observer: Agent)` — `@per_entity_ring(K = 8)`,
+    cells: `(zone_kind, center_x_q8, center_y_q8, radius_q8,
+    expires_at_tick, source)`. Populated by EffectCastBeginApplied
+    on every CASTER agent (busy_with_ability_id != 0). Decay at
+    `world.tick >= cell.expires_at_tick` — slot becomes
+    "inactive" but stays in ring until overwritten by a new
+    threat.
+  * `grudges(observer: Agent)` — `@per_entity_ring(K = 16)`,
+    cells: `(grudge_kind, target_agent, intensity_q8,
+    expires_at_tick)`. Populated by per-fixture `RecordGrudge`
+    rule that fires on `BargainBroken` / `OutbidSimulated` /
+    `MerchantSlightedSimulated` — 3 scripted event types simulating
+    "competitor identified", "lost auction", "underpriced by".
+* **Two scoring verbs:**
+  * `Dodge(self, target: Vec3)` — score reads
+    `cast_threats.intensity_at(target)`. Higher = stronger pressure
+    to dodge. Compares with and without the read to measure
+    behavioural delta.
+  * `RaidCaravan(self, target: Agent)` — score reads
+    `grudges.intensity_against(self, target.owner)`. Without
+    grudge data, base score is uniform across caravans; with
+    grudge data, the target weighting biases toward the agent's
+    rival.
+
+## Effectiveness measurements
+
+The fixture runs in two configurations:
+
+1. **Baseline (no threats):** verbs score with the threat reads
+   replaced by `0.0` constants. Agents make decisions blind to the
+   threat surface.
+2. **Threat-aware:** verbs score with the actual threat reads.
+
+For each configuration, drive the fixture for `T = 1024` ticks at
+the full 256-agent shape. Record per-tick, per-observer:
+
+* Verb decisions taken (which Dodge / RaidCaravan target).
+* Damage taken (for Dodge measurement).
+* Caravan-raid hit rate against rival vs random target (for
+  RaidCaravan measurement).
+
+Effectiveness metrics:
+
+* **Dodge delta:** mean damage taken per observer = baseline_dmg -
+  threat_aware_dmg. Expect threat_aware to take less damage if the
+  scoring + dodge mechanic actually translate cast_threats into
+  movement.
+* **Grudge delta:** ratio of caravan raids landing on the agent's
+  declared rival = threat_aware_rival_hits / total_raids -
+  baseline_rival_hits / total_raids. Expect threat_aware to raid
+  rivals more often than random.
+* **Scaling:** wall-clock time per tick at 256 agents. Plan H's
+  ring storage scales O(N×K) per view; verify both folds dispatch
+  in <2ms per tick at 256 agents.
+
+The numbers go into a `tests/threat_effectiveness.rs` integration
+test that runs both configurations and asserts the deltas are at
+least `MIN_DODGE_DELTA = 5%` damage reduction and `MIN_GRUDGE_DELTA = 30%`
+rival-bias increase. Failure means the scoring primitives don't
+actually translate threat data into behaviour change.
+
+## Implementation slices
+
+1. **H1 — Fixture authoring.** `assets/sim/threat_stresstest.sim`
+   with the 4 entity types + 2 threats views + 2 scoring verbs +
+   the 4 producer rules (DispatchCast, RecordCastBegin, RecordGrudge,
+   ResolveBusy).
+2. **H2 — Per-runtime crate.** `crates/threat_stresstest_runtime`
+   builds the .sim, exposes baseline vs threat-aware mode toggle,
+   readback APIs for damage taken + raid targets per agent.
+3. **H3 — Effectiveness integration test.** Drives both modes for
+   1024 ticks, computes the deltas, asserts the thresholds.
+4. **H4 — Performance pin.** Per-tick wall-clock measurement; budget
+   pin (e.g. 2ms / tick at 256 agents).
+
+H1+H2 ~3 hours; H3 ~1 hour; H4 ~30 min. Total 4-5 hours.

--- a/docs/plans/i_ability_grammar_tree_walker_design.md
+++ b/docs/plans/i_ability_grammar_tree_walker_design.md
@@ -1,0 +1,120 @@
+# Plan I — Ability-Grammar Tree Walker + Valid-Grammar Fuzzer
+
+> Status: design. Implementation lands after Plan H.
+
+## Goal
+
+A tree-walker that exhaustively traverses the `.ability` AST grammar,
+generates synthetic `.ability` files exercising every valid
+production, and asserts the full pipeline (parse → resolve → lower →
+emit → naga validate) accepts each one. Catches regressions where a
+grammar variant compiles but produces invalid output, OR where a new
+parser feature adds a production but the lowering / emit doesn't
+support it.
+
+The corpus we have today (`dataset/abilities/lol_heroes/*.ability` —
+172 files) covers historical `.ability` shapes but doesn't
+systematically exercise the grammar's ALL valid combinations. The
+tree-walker fills that gap.
+
+## Architectural Impact Statement
+
+* **P1 (Compiler-First):** PASS. The walker is a host-side test
+  harness; no runtime engine code paths are added.
+* **P2/P3/P5/P10:** N/A — the walker doesn't touch sim semantics.
+* **Coverage P:** every reachable AST production is exercised at
+  least once. Surfaces gaps where the grammar accepts a shape the
+  lowering rejects (a `LowerError::Unsupported*` variant).
+
+## Tree-walker design
+
+The grammar is defined by:
+* `crates/dsl_ast/src/ast.rs::AbilityDecl` (top-level production).
+* `crates/dsl_ast/src/ast.rs::AbilityHeader` (10+ header variants:
+  Target, Range, Cooldown, Cast, Hint, Cost, Charges, Recharge,
+  Toggle, Recast, RecastWindow).
+* `crates/dsl_ast/src/ast.rs::EffectStmt` (29 verb dispatch arms +
+  modifier slots: tags, area, scaling, when, chance, stacking,
+  lifetime, nested).
+* `crates/dsl_ast/src/ast.rs::AbilityProgramStep` (Cast / Effects).
+* `crates/dsl_ast/src/ast.rs::CastSpec` + `InterruptSet` shapes.
+
+The walker lives in `crates/dsl_ast/tests/grammar_tree_walker.rs`
+(or a separate `grammar-fuzzer` crate if it grows large). Its
+algorithm:
+
+```rust
+fn walk_grammar() -> Vec<String> {
+    let mut authored: Vec<String> = Vec::new();
+    for header_combo in iterate_header_combos() {        // ~40 shapes
+        for body in iterate_bodies() {                    // 29 verbs * modifier slots
+            for program_shape in [None, Some(cast_only), Some(cast_effect),
+                                   Some(cast_effect_cast_effect)] {
+                authored.push(synthesize_ability_text(header_combo, body, program_shape));
+            }
+        }
+    }
+    authored
+}
+```
+
+The synthesis loop is bounded: not Cartesian over every modifier
+combination (would explode to millions), but rather a **per-axis
+sweep** — for each axis (header / verb / modifier), iterate its
+variants while holding others at default. Total: ~500-1000
+synthesized files (manageable).
+
+Each authored file goes through:
+
+```rust
+let parsed = parse_ability_file(&authored).expect("parse");
+let lowered = lower_ability_decl(&parsed.abilities[0]).expect("lower");
+// emit + naga validate happen via existing apply_ability_smoke harness
+```
+
+Failures = the test panics with the failing file printed. Author can
+copy-paste into a permanent regression test.
+
+## Hot-reload variant (deferred)
+
+The optional second mode: rather than authoring files in memory,
+write them to disk, point a runtime crate at the file, exercise
+hot-reload (re-parse + re-emit on change). This requires:
+
+1. A runtime crate that exposes a `reload_ability(path: &Path)`
+   method.
+2. File-system watching (e.g. `notify` crate) that triggers reload.
+3. The runtime's AbilityRegistry can swap an ability's program
+   in-place — needs a new `update(id: AbilityId, program:
+   AbilityProgram)` API on the registry.
+
+Hot-reload is plumbing-heavy (file watching + registry mutability)
+and has marginal value for the grammar-coverage goal — the
+in-memory walker is sufficient. **Defer hot-reload to Plan I-step-2.**
+
+## Implementation slices
+
+1. **I1 — In-memory walker.** Iterate header combos × verb arms ×
+   program shapes. For each, synthesize text and run through
+   parse + lower + emit. Test in `dsl_ast/tests/`.
+2. **I2 — Coverage report.** The walker emits a coverage matrix:
+   "production X exercised by N synthesized files". Surfaces gaps
+   where a production isn't reachable from the synthesis loop.
+3. **I3 — Hot-reload (deferred).** Per the disclaimer above.
+
+I1 ~3-4 hours; I2 ~1 hour; I3 deferred.
+
+## Why this matters
+
+Right now, the `.ability` grammar is implicitly defined by the
+parser + 172 LoL corpus files. New grammar additions (Plan G's
+`cast { } effect { }` blocks; recast/recast_window; scaling
+modifiers) get one ad-hoc test each, but no systematic coverage of
+ALL the valid combinations. A regression that breaks `cooldown:
+5s @ resolve` (a Plan G CooldownPhase shape) might slip through if
+no LoL corpus file uses that exact combo.
+
+The tree-walker IS the systematic coverage — every valid grammar
+shape gets exercised exactly once per test run. Failures localize
+to a single synthesized file the author can copy into a permanent
+regression.


### PR DESCRIPTION
Two design docs landing ahead of their implementation slices. Plan G G3 (threats infrastructure) is currently in flight on 3 parallel agents; Plan H + I sequence after.

## Plan H — Threat stresstest + scoring effectiveness

256-agent fixture exercising short-term cast threats (3-10 tick decay, populated by `EffectCastBeginApplied`) + long-term grudges (10k+ tick decay, populated by `BargainBroken`/`OutbidSimulated`/`MerchantSlightedSimulated`). Two scoring verbs:

* `Dodge(self, target: Vec3)` — score reads `cast_threats.intensity_at(target)`. Asserts ≥5% damage reduction baseline-vs-threat-aware.
* `RaidCaravan(self, target: Agent)` — score reads `grudges.intensity_against(self, target.owner)`. Asserts ≥30% rival-bias increase.

Estimate: 4-5 hours across 4 implementation slices.

## Plan I — Ability-grammar tree walker

Tree-walker over `.ability` AST grammar. Per-axis sweep — header combos × verb arms × program shapes — synthesizes ~500-1000 .ability files; each goes through parse → lower → emit → naga validate. Failures localize to a single synthesized file the author can copy into a permanent regression.

Hot-reload variant explicitly deferred to Plan I-step-2 (file-watching + registry mutability are plumbing-heavy with marginal coverage value beyond what the in-memory walker provides).

Estimate: 3-4 hours across 2 implementation slices.

## Both docs include AISs per P8

🤖 Generated with [Claude Code](https://claude.com/claude-code)