### PR TITLE
feat(plan-g/g3d): DispatchShape::PerAgentEventScan for per-(observer, busy-source) folds

### DIFF
--- a/assets/sim/per_agent_event_scan_probe.sim
+++ b/assets/sim/per_agent_event_scan_probe.sim
@@ -1,0 +1,88 @@
+// per_agent_event_scan_probe — Plan G G3d smoke fixture.
+//
+// Lights up the new `DispatchShape::PerAgentEventScan` variant added
+// alongside the threats-view design (`docs/plans/g3_threats_view_design.md`).
+// The shape dispatches one thread per `(observer_agent, source_agent)`
+// pair, with an early-exit when the source agent's
+// `busy_with_ability_id` SoA column is zero (no in-flight cast).
+//
+// **Why a separate dispatch shape?** Existing view-fold dispatches
+// today are PerEvent (one thread per event in a source ring). The
+// threats view (G3g) needs to project per-(observer, busy-caster)
+// zones — the source candidate set is "all agents currently mid-cast",
+// which is a per-agent SoA column read, NOT an event-ring entry. The
+// PerAgentEventScan shape closes that gap.
+//
+// **What this fixture proves.**
+//   * The new dispatch shape lowers cleanly through the existing
+//     ViewFold lowering pipeline.
+//   * The kernel's WGSL has the 2-D `(observer, source_candidate)`
+//     preamble + the busy-filter early-exit (`agent_busy_with_ability_id
+//     [source_candidate] == 0u`).
+//   * The fold body still routes through the standard
+//     `lower_cg_stmt_list_to_wgsl` path — a `self += 1.0` body lowers
+//     just like every other view-fold body, but executes once per
+//     (observer, busy-source) pair instead of once per event.
+//
+// **Shape (this fixture).** A scalar f32 view per agent, accumulating
+// the count of distinct busy-caster sources visible to each observer.
+// With one agent always busy and N observers, every observer's view
+// resolves to `N - 1` (each observer skips itself if the source-equals-
+// observer guard is added; the MVP body unconditionally += 1.0 over
+// every busy candidate, so the count includes self).
+//
+// The probe doesn't cover threat-zone semantics (G3g) or struct
+// payloads (G3b) or multi-statement fold bodies (G3c). It exclusively
+// pins the dispatch-shape mechanism so future slices can land each
+// piece in isolation.
+
+event Tick { }
+event CastStarted { source: AgentId, target: AgentId, ability_id: u32 }
+
+entity Subject : Agent { }
+
+config probe {
+  // Tick at which one agent starts casting. Before this tick every
+  // observer's threat_count view is 0; after, it is 1 (one busy source
+  // visible to all observers).
+  cast_begin_tick: u32 = 1,
+  // Ability id stamped on the busy SoA column. Any non-zero u32 marks
+  // the agent as "currently casting".
+  cast_ability_id: u32 = 7,
+  // The single casting agent's slot.
+  caster_slot: u32 = 0,
+}
+
+// Mark every agent as busy at `cast_begin_tick`. Writes to the
+// `busy_with_ability_id` SoA column so the threat_count fold's busy-
+// filter sees a non-zero value at every `source_candidate`.
+//
+// MVP scope — the probe only exercises the dispatch shape, not the
+// per-agent threat-zone projection (G3g). A real threats fixture
+// would mark only specific agents and assert per-observer counts;
+// here we just need enough busy agents to drive the fold body
+// through the busy-filter at least once.
+@phase(per_agent)
+physics StartCast {
+  on Tick {} where (
+    self.alive
+    && world.tick == config.probe.cast_begin_tick
+  ) {
+    agents.set_busy_with_ability_id(self, config.probe.cast_ability_id);
+  }
+}
+
+// G3d's view-under-test. Per-observer scalar count of busy-caster
+// sources visible. Annotated `@dispatch(per_agent_event_scan)` to
+// override the default `PerEvent { source_ring }` dispatch with the
+// 2-D `(observer, source_candidate)` shape. The `@materialized` slot
+// names CastStarted as a placeholder source — the dispatch shape
+// ignores the event ring entirely (the runtime drives the dispatch
+// directly off `agent_cap`), but the resolver requires `on_event = [...]`
+// for materialized fold views to validate.
+@materialized(on_event = [CastStarted])
+@dispatch(per_agent_event_scan)
+view threat_count(observer: Agent) -> f32 {
+  initial: 0.0,
+  on CastStarted { source: _, target: _, ability_id: _ } { self += 1.0 }
+}

--- a/crates/dsl_compiler/src/cg/dispatch.rs
+++ b/crates/dsl_compiler/src/cg/dispatch.rs
@@ -91,6 +91,17 @@ pub const PER_WORD_BITS: u32 = 32;
 /// Tracks `MAX_PER_CELL` — must stay in sync. Today both are 32.
 pub const PER_CELL_WORKGROUP_X: u32 = 32;
 
+/// Workgroup x-dim for [`DispatchShape::PerAgentEventScan`]. The shape
+/// dispatches a 2-D `(observer, source_candidate)` grid; we pick an
+/// 8×8 = 64-thread workgroup so the total invocation count matches the
+/// 64-lane pattern every other compute kernel uses (consistent register
+/// pressure + occupancy). The y-dim is pinned to the same value below.
+pub const PER_AGENT_EVENT_SCAN_WORKGROUP_X: u32 = 8;
+
+/// Workgroup y-dim for [`DispatchShape::PerAgentEventScan`]. See
+/// [`PER_AGENT_EVENT_SCAN_WORKGROUP_X`].
+pub const PER_AGENT_EVENT_SCAN_WORKGROUP_Y: u32 = 8;
+
 /// Workgroup x-dim for [`DispatchShape::PerScanChunk`]. The parallel
 /// prefix-scan over `spatial_grid_offsets` partitions `num_cells` into
 /// chunks of this many cells, with one workgroup per chunk and one
@@ -165,6 +176,26 @@ pub enum DispatchShape {
     /// lanes (`chunk_base + lane >= num_cells`) participate with
     /// count = 0 inside the scan and skip their slot writes.
     PerScanChunk,
+
+    /// Per-(observer_agent, source_agent) 2-D dispatch where the source
+    /// candidate set is "all agents with `busy_with_ability_id != 0`"
+    /// (i.e. agents currently mid-cast). Lays out as `gid.x = observer`,
+    /// `gid.y = source_candidate`. The kernel preamble early-exits any
+    /// `(observer, source)` pair where the source is not busy, so the
+    /// fold body only runs for live (observer, busy-caster) pairs.
+    ///
+    /// Workgroup geometry is 8×8 = 64 threads per group; the dispatch
+    /// count is `(ceil(agent_cap / 8), ceil(agent_cap / 8), 1)`. The
+    /// busy-filter is hardcoded to the `busy_with_ability_id` SoA
+    /// column today (added in Plan G G2.1) — future iterations may
+    /// generalise to `(observer, source-with-property)` by carrying a
+    /// predicate filter alongside the variant.
+    ///
+    /// Used by Plan G G3's threats materialised view; see
+    /// `docs/plans/g3_threats_view_design.md` for the full design and
+    /// `assets/sim/per_agent_event_scan_probe.sim` for the smoke
+    /// fixture that exercises the dispatch shape end-to-end.
+    PerAgentEventScan,
 }
 
 /// What drives the per-agent candidate list for a [`DispatchShape::PerPair`]
@@ -220,6 +251,7 @@ impl fmt::Display for DispatchShape {
             DispatchShape::PerWord => f.write_str("per_word"),
             DispatchShape::PerCell => f.write_str("per_cell"),
             DispatchShape::PerScanChunk => f.write_str("per_scan_chunk"),
+            DispatchShape::PerAgentEventScan => f.write_str("per_agent_event_scan"),
         }
     }
 }
@@ -358,6 +390,15 @@ pub enum ThreadIndexing {
     /// memory Hillis-Steele reduction (out-of-range lanes contribute
     /// count = 0 but stay through every barrier).
     PerScanChunkLane,
+    /// `let observer = gid.x; let source_candidate = gid.y; if (observer
+    /// >= cfg.agent_cap || source_candidate >= cfg.agent_cap) { return; }
+    /// if (agent_busy_with_ability_id[source_candidate] == 0u) { return; }`.
+    /// Used by [`DispatchShape::PerAgentEventScan`] to project per-(observer,
+    /// busy-source) work onto a 2-D dispatch. The busy-filter early-exits
+    /// candidates whose `busy_with_ability_id` SoA column is zero (no
+    /// in-flight cast), so non-busy agents do not contribute to the per-
+    /// observer fold body.
+    PerAgentEventScanSlot,
 }
 
 impl fmt::Display for ThreadIndexing {
@@ -372,6 +413,7 @@ impl fmt::Display for ThreadIndexing {
             ThreadIndexing::PerAgentWord => f.write_str("per_agent_word"),
             ThreadIndexing::PerCellWorkgroup => f.write_str("per_cell_workgroup"),
             ThreadIndexing::PerScanChunkLane => f.write_str("per_scan_chunk_lane"),
+            ThreadIndexing::PerAgentEventScanSlot => f.write_str("per_agent_event_scan_slot"),
         }
     }
 }
@@ -398,6 +440,11 @@ impl DispatchShape {
             DispatchShape::PerWord => WorkgroupSize::linear(PER_WORD_WORKGROUP_X),
             DispatchShape::PerCell => WorkgroupSize::linear(PER_CELL_WORKGROUP_X),
             DispatchShape::PerScanChunk => WorkgroupSize::linear(PER_SCAN_CHUNK_WORKGROUP_X),
+            DispatchShape::PerAgentEventScan => WorkgroupSize {
+                x: PER_AGENT_EVENT_SCAN_WORKGROUP_X,
+                y: PER_AGENT_EVENT_SCAN_WORKGROUP_Y,
+                z: 1,
+            },
         }
     }
 
@@ -473,6 +520,17 @@ impl DispatchShape {
                     z: 1,
                 }
             }
+            DispatchShape::PerAgentEventScan => {
+                // 2-D dispatch over `(observer, source_candidate)` pairs.
+                // Each axis is `ceil(agent_cap / workgroup_<axis>)`.
+                // workgroup geometry is 8×8 = 64 threads per group.
+                let wg = self.workgroup_size();
+                DispatchCount::Direct {
+                    x: ctx.agent_cap.div_ceil(wg.x),
+                    y: ctx.agent_cap.div_ceil(wg.y),
+                    z: 1,
+                }
+            }
         }
     }
 
@@ -508,6 +566,7 @@ impl DispatchShape {
             DispatchShape::PerWord => ThreadIndexing::PerAgentWord,
             DispatchShape::PerCell => ThreadIndexing::PerCellWorkgroup,
             DispatchShape::PerScanChunk => ThreadIndexing::PerScanChunkLane,
+            DispatchShape::PerAgentEventScan => ThreadIndexing::PerAgentEventScanSlot,
         }
     }
 }
@@ -950,6 +1009,55 @@ mod tests {
 
             let _idx = s.thread_indexing();
         }
+    }
+
+    // --- PerAgentEventScan -------------------------------------------------
+
+    #[test]
+    fn per_agent_event_scan_display_and_roundtrip() {
+        let s = DispatchShape::PerAgentEventScan;
+        assert_eq!(format!("{}", s), "per_agent_event_scan");
+        assert_roundtrip(&s);
+    }
+
+    #[test]
+    fn workgroup_size_per_agent_event_scan_is_8x8() {
+        let s = DispatchShape::PerAgentEventScan;
+        let wg = s.workgroup_size();
+        assert_eq!(wg.x, 8);
+        assert_eq!(wg.y, 8);
+        assert_eq!(wg.z, 1);
+        assert_eq!(wg.total(), 64, "8x8 should match the 64-thread budget");
+    }
+
+    #[test]
+    fn dispatch_count_per_agent_event_scan_is_2d_grid() {
+        // agent_cap = 200_000, wg = 8 ⇒ 200_000.div_ceil(8) = 25_000 per axis.
+        let count = DispatchShape::PerAgentEventScan
+            .dispatch_count(&DispatchCtx::per_agent(200_000));
+        assert_eq!(
+            count,
+            DispatchCount::Direct {
+                x: 25_000,
+                y: 25_000,
+                z: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn dispatch_count_per_agent_event_scan_zero_cap() {
+        let count =
+            DispatchShape::PerAgentEventScan.dispatch_count(&DispatchCtx::per_agent(0));
+        assert_eq!(count, DispatchCount::Direct { x: 0, y: 0, z: 1 });
+    }
+
+    #[test]
+    fn thread_indexing_per_agent_event_scan() {
+        assert_eq!(
+            DispatchShape::PerAgentEventScan.thread_indexing(),
+            ThreadIndexing::PerAgentEventScanSlot
+        );
     }
 
     #[test]

--- a/crates/dsl_compiler/src/cg/emit/kernel.rs
+++ b/crates/dsl_compiler/src/cg/emit/kernel.rs
@@ -321,10 +321,12 @@ pub fn kernel_topology_to_spec_and_body(
                     .and_then(|sig| sig.storage_hint),
                 _ => None,
             });
-        let bindings = build_view_fold_bindings(view_name, &cfg_struct, storage_hint);
+        let bindings =
+            build_view_fold_bindings(view_name, &cfg_struct, storage_hint, &dispatch);
         let cfg_struct_decl = build_view_fold_cfg_struct_decl(&cfg_struct);
         let cfg_build_expr = build_view_fold_cfg_build_expr(&cfg_struct);
-        let wgsl_body = build_view_fold_wgsl_body(&body_ops, prog, ctx, storage_hint)?;
+        let wgsl_body =
+            build_view_fold_wgsl_body(&body_ops, prog, ctx, storage_hint, &dispatch)?;
         let spec = KernelSpec {
             name,
             pascal,
@@ -2219,6 +2221,7 @@ fn build_view_fold_bindings(
     view_name: &str,
     cfg_struct: &str,
     storage_hint: Option<crate::cg::program::CgStorageHint>,
+    dispatch: &DispatchShape,
 ) -> Vec<KernelBinding> {
     use crate::cg::program::CgStorageHint;
     let accessor = format!("fold_view_{view_name}_handles");
@@ -2235,7 +2238,7 @@ fn build_view_fold_bindings(
     } else {
         (AccessMode::ReadWriteStorage, "array<u32>".to_string())
     };
-    vec![
+    let mut bindings = vec![
         KernelBinding {
             slot: 0,
             name: "event_ring".into(),
@@ -2310,7 +2313,36 @@ fn build_view_fold_bindings(
             wgsl_ty: cfg_struct.to_string(),
             bg_source: BgSource::Cfg,
         },
-    ]
+    ];
+    // Plan G G3d — PerAgentEventScan ViewFolds need the
+    // `busy_with_ability_id` SoA column for the busy-filter early-exit
+    // in the kernel preamble. The runtime side does not yet wire this
+    // column through `KernelBindingsContext::state` (it lives outside
+    // the `STANDARD_COLUMNS` set today), so the binding lands as
+    // `BgSource::Extras` — the per-runtime `from_context_with_extras`
+    // shim must thread the buffer in until the column is promoted to
+    // standard. Other dispatch shapes keep the legacy 7-binding
+    // shape unchanged.
+    if matches!(dispatch, DispatchShape::PerAgentEventScan) {
+        // `BgSource::External` lands the buffer on the per-runtime
+        // `<Pascal>Extras` shim so the runtime side passes
+        // `extras.agent_busy_with_ability_id` into `bind()`. When the
+        // column is later promoted to `STANDARD_COLUMNS`, the
+        // generic-kernel path's `classify_binding` would auto-route it
+        // through `ctx.state.busy_with_ability_id_buf`; this binding
+        // would then collapse to `BgSource::Resident` (or be dropped
+        // entirely if ViewFold's binding builder is taught the same
+        // routing). For G3d's smoke-test scope, the External binding
+        // is sufficient — no per-runtime crate is built.
+        bindings.push(KernelBinding {
+            slot: 7,
+            name: "agent_busy_with_ability_id".into(),
+            access: AccessMode::ReadStorage,
+            wgsl_ty: "array<u32>".into(),
+            bg_source: BgSource::External("agent_busy_with_ability_id".into()),
+        });
+    }
+    bindings
 }
 
 /// Compose the ViewFold-specific WGSL body. Adds the per-kind preamble
@@ -2340,8 +2372,20 @@ fn build_view_fold_wgsl_body(
     prog: &CgProgram,
     ctx: &EmitCtx<'_>,
     storage_hint: Option<crate::cg::program::CgStorageHint>,
+    dispatch: &DispatchShape,
 ) -> Result<String, KernelEmitError> {
     use crate::cg::program::CgStorageHint;
+    // Plan G G3d — PerAgentEventScan dispatches one thread per
+    // `(observer, source_candidate)` pair with a busy-filter early-
+    // exit on the source. The fold body sees both as locals; there is
+    // no event ring to read from, so the standard `event_idx` /
+    // `cfg.event_count` preamble is wrong. Hand-emit the 2-D preamble
+    // here so the kernel composer's `thread_indexing_preamble`
+    // (which is currently bypassed for ViewFold) doesn't have to grow
+    // a ViewFold special-case.
+    if matches!(dispatch, DispatchShape::PerAgentEventScan) {
+        return build_view_fold_per_agent_event_scan_body(body_ops, prog, ctx);
+    }
     // Plan G G3a — PerEntityRing diverts from the generic CgStmt::Assign
     // lowering and emits a hand-written ring-append body. The body
     // hardcodes the well-known event-ring layout
@@ -2475,6 +2519,123 @@ fn build_view_fold_wgsl_body(
         } else {
             out.push_str(&indented);
         }
+        out.push_str("\n    }");
+    }
+
+    Ok(out)
+}
+
+/// Plan G G3d — synthesise the WGSL body for a `PerAgentEventScan`-
+/// dispatched ViewFold.
+///
+/// Diverts from the standard PerEvent preamble (`event_idx`,
+/// `cfg.event_count`, per-event tag check) and emits a 2-D
+/// `(observer, source_candidate)` preamble with a busy-filter
+/// early-exit:
+///
+/// ```wgsl
+/// let observer = gid.x;
+/// let source_candidate = gid.y;
+/// if (observer >= cfg.agent_cap) { return; }
+/// if (source_candidate >= cfg.agent_cap) { return; }
+/// if (agent_busy_with_ability_id[source_candidate] == 0u) { return; }
+/// let tick = cfg.tick;
+/// // <per-op fold body lowers here, with `observer` + `source_candidate`
+/// //  available as locals>
+/// ```
+///
+/// **Cfg shape note.** The standard ViewFold cfg layout is
+/// `{ event_count, tick, second_key_pop, _pad0 }`; PerAgentEventScan
+/// overloads `event_count` to mean `agent_cap` so the bounds check on
+/// `observer` / `source_candidate` reads the right value. The runtime
+/// side populates the field with the agent slot count instead of an
+/// event count when dispatching this shape — until we promote the
+/// rename to a proper cfg-shape variant, the field stays `event_count`
+/// and the kernel reads it as `cfg.agent_cap` via a documented alias.
+///
+/// **MVP scope.** Hardcodes the busy-filter to
+/// `agent_busy_with_ability_id != 0u`. Future iterations may carry a
+/// predicate filter on the dispatch shape so the source candidate set
+/// can be `(observer, source-with-property)` for arbitrary
+/// per-agent properties.
+///
+/// **Body lowering.** Each ViewFold op's body is lowered through the
+/// standard `lower_cg_stmt_list_to_wgsl` path; the body sees both
+/// `observer` and `source_candidate` as in-scope WGSL locals. The
+/// per-op tag guard (PerEvent's `event_ring[...] == kind`) is dropped
+/// — there is no event ring read.
+fn build_view_fold_per_agent_event_scan_body(
+    body_ops: &[OpId],
+    prog: &CgProgram,
+    ctx: &EmitCtx<'_>,
+) -> Result<String, KernelEmitError> {
+    let mut out = String::new();
+    // 2-D dispatch preamble. Mirrors `thread_indexing_preamble`'s
+    // PerAgentEventScan arm; we duplicate inline here because
+    // `build_view_fold_wgsl_body` does not route through that helper
+    // (the ViewFold path has its own preamble structure today).
+    //
+    // Field aliasing: the cfg struct stamped by ViewFold is
+    // `{ event_count, tick, second_key_pop, _pad0 }`; we read
+    // `cfg.event_count` as the agent slot count for the bounds check
+    // on this dispatch shape (the runtime supplies agent_cap there
+    // when issuing the 2-D dispatch). Future cleanup: split the cfg
+    // shape so the field name matches its semantic.
+    out.push_str("    let observer = gid.x;\n");
+    out.push_str("    let source_candidate = gid.y;\n");
+    out.push_str("    if (observer >= cfg.event_count) { return; }\n");
+    out.push_str("    if (source_candidate >= cfg.event_count) { return; }\n");
+    out.push_str(
+        "    if (agent_busy_with_ability_id[source_candidate] == 0u) { return; }\n",
+    );
+    out.push_str("    let tick = cfg.tick;\n\n");
+
+    for (i, op_id) in body_ops.iter().enumerate() {
+        if i > 0 {
+            out.push_str("\n\n");
+        }
+        let op = resolve_op(prog, *op_id)?;
+        let fragment = match &op.kind {
+            ComputeOpKind::ViewFold { body, .. } => {
+                lower_cg_stmt_list_to_wgsl(*body, ctx).map_err(KernelEmitError::from)?
+            }
+            ComputeOpKind::MaskPredicate { .. }
+            | ComputeOpKind::PhysicsRule { .. }
+            | ComputeOpKind::ScoringArgmax { .. }
+            | ComputeOpKind::SpatialQuery { .. }
+            | ComputeOpKind::Plumbing { .. }
+            | ComputeOpKind::ViewDecay { .. } => {
+                // Same structural-unreachable defense as
+                // `build_view_fold_wgsl_body` — the classifier
+                // returns Generic for non-ViewFold ops.
+                "// TODO: non-ViewFold op in PerAgentEventScan ViewFold kernel — \
+                 classifier should have routed through generic path."
+                    .to_string()
+            }
+        };
+        writeln!(
+            out,
+            "    // op#{} ({})",
+            op.id.0,
+            compute_op_kind_short(&op.kind)
+        )
+        .expect("write to String never fails");
+        // Wrap the per-op body in a `{ ... }` scope so multiple ops
+        // in a fused kernel each get their own local-binding scope.
+        let body_indent = 8;
+        let indented = fragment
+            .lines()
+            .map(|l| {
+                if l.is_empty() {
+                    String::new()
+                } else {
+                    format!("{:indent$}{l}", "", indent = body_indent)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        out.push_str("    {\n");
+        out.push_str(&indented);
         out.push_str("\n    }");
     }
 
@@ -3480,10 +3641,13 @@ fn lower_op_body(
                 | DispatchShape::OneShot
                 | DispatchShape::PerWord
                 | DispatchShape::PerCell
-                | DispatchShape::PerScanChunk => Err(KernelEmitError::InvalidDispatchForOpKind {
-                    op_kind: "MaskPredicate",
-                    dispatch: format!("{dispatch}"),
-                }),
+                | DispatchShape::PerScanChunk
+                | DispatchShape::PerAgentEventScan => {
+                    Err(KernelEmitError::InvalidDispatchForOpKind {
+                        op_kind: "MaskPredicate",
+                        dispatch: format!("{dispatch}"),
+                    })
+                }
             }
         }
         ComputeOpKind::PhysicsRule { body, .. } => {
@@ -4639,6 +4803,31 @@ fn thread_indexing_preamble(dispatch: &DispatchShape) -> String {
             // last chunk has out-of-range lanes.
             "let chunk_id = workgroup_id.x;\n\
              let lane = local_invocation_id.x;\n\n"
+                .to_string()
+        }
+        DispatchShape::PerAgentEventScan => {
+            // 2-D dispatch: gid.x = observer agent, gid.y = source
+            // candidate. Bounds-check both axes against agent_cap
+            // (over-dispatched workgroup-rounding lanes outside the
+            // live agent range early-exit). The busy-filter then
+            // skips any source candidate whose `busy_with_ability_id`
+            // SoA column is zero — i.e. agents with no in-flight
+            // cast. The fold body downstream sees both `observer`
+            // and `source_candidate` as locals.
+            //
+            // `tick` + `seed` mirror the PerAgent / PerEvent preamble
+            // shape so any rng.* / world.tick references in the body
+            // resolve cleanly. `agent_busy_with_ability_id` is the
+            // existing per-agent buffer binding (Plan G G2.1) — emit
+            // synthesises the read-only binding under the standard
+            // `agent_<field>` naming convention.
+            "let observer = gid.x;\n\
+             let source_candidate = gid.y;\n\
+             if (observer >= cfg.agent_cap) { return; }\n\
+             if (source_candidate >= cfg.agent_cap) { return; }\n\
+             if (agent_busy_with_ability_id[source_candidate] == 0u) { return; }\n\
+             let tick = cfg.tick;\n\
+             let seed = cfg.seed;\n\n"
                 .to_string()
         }
     }

--- a/crates/dsl_compiler/src/cg/emit/program.rs
+++ b/crates/dsl_compiler/src/cg/emit/program.rs
@@ -936,7 +936,15 @@ fn compose_wgsl_file(
         ));
     }
 
-    let workgroup_x = topology_workgroup_size_x(topology);
+    let workgroup = topology_workgroup_size(topology);
+    // 2-D dispatches (today: only PerAgentEventScan) declare both
+    // `(x, y)` on the @workgroup_size annotation; 1-D shapes drop the
+    // y-dim so the WGSL stays unchanged for every existing kernel.
+    let workgroup_attr = if workgroup.y > 1 {
+        format!("@workgroup_size({}, {})", workgroup.x, workgroup.y)
+    } else {
+        format!("@workgroup_size({})", workgroup.x)
+    };
 
     if is_per_cell || is_per_scan_chunk {
         // PerCell + PerScanChunk entry points: take `workgroup_id`
@@ -946,7 +954,7 @@ fn compose_wgsl_file(
         // `thread_indexing_preamble`) reads these to derive its
         // working indices.
         out.push_str(&format!(
-            "@compute @workgroup_size({workgroup_x})\n\
+            "@compute {workgroup_attr}\n\
              fn {entry}(\n\
              \x20   @builtin(workgroup_id) workgroup_id: vec3<u32>,\n\
              \x20   @builtin(local_invocation_id) local_invocation_id: vec3<u32>,\n\
@@ -955,7 +963,7 @@ fn compose_wgsl_file(
         ));
     } else {
         out.push_str(&format!(
-            "@compute @workgroup_size({workgroup_x})\n\
+            "@compute {workgroup_attr}\n\
              fn {entry}(@builtin(global_invocation_id) gid: vec3<u32>) {{\n",
             entry = spec.entry_point
         ));
@@ -1881,6 +1889,21 @@ fn compose_dispatch_call(topology: &KernelTopology) -> String {
                 chunks
             )
         }
+        DispatchShape::PerAgentEventScan => {
+            // 2-D dispatch: ceil(agent_cap / wg.x) by ceil(agent_cap / wg.y).
+            // Inline both axes — every per-(observer, source) pair lands
+            // in exactly one thread, with the busy-filter dropping any
+            // (observer, non-busy-source) combination at the kernel
+            // preamble.
+            let wg = dispatch.workgroup_size();
+            format!(
+                "        pass.dispatch_workgroups((agent_cap + {wg_x_minus_one}u32) / {wg_x}u32, (agent_cap + {wg_y_minus_one}u32) / {wg_y}u32, 1);\n",
+                wg_x = wg.x,
+                wg_x_minus_one = wg.x - 1,
+                wg_y = wg.y,
+                wg_y_minus_one = wg.y - 1,
+            )
+        }
     }
 }
 
@@ -1995,7 +2018,7 @@ pub fn synthesize_lib_rs(kernel_index: &[String]) -> String {
 // Topology → workgroup size
 // ---------------------------------------------------------------------------
 
-/// Pick the `@workgroup_size(x)` value a kernel emitted from `topology`
+/// Pick the `@workgroup_size(...)` value a kernel emitted from `topology`
 /// should declare. Routes through Task 1.4's
 /// [`DispatchShape::workgroup_size`] so the WGSL annotation and the
 /// dispatch-count rule never disagree.
@@ -2004,7 +2027,12 @@ pub fn synthesize_lib_rs(kernel_index: &[String]) -> String {
 /// drives the size — every consumer carries the same `PerEvent` shape,
 /// so picking the first is structural (the well-formed pass already
 /// guards mismatches).
-fn topology_workgroup_size_x(topology: &KernelTopology) -> u32 {
+///
+/// Returns the full [`crate::cg::dispatch::WorkgroupSize`] so 2-D
+/// dispatches (Plan G G3d's `PerAgentEventScan`) can emit
+/// `@workgroup_size(x, y)` without losing the y-dim. Callers that
+/// only care about the x-dim project via `.x`.
+fn topology_workgroup_size(topology: &KernelTopology) -> crate::cg::dispatch::WorkgroupSize {
     let dispatch = match topology {
         KernelTopology::Fused { dispatch, .. } => *dispatch,
         KernelTopology::Split { dispatch, .. } => *dispatch,
@@ -2018,7 +2046,7 @@ fn topology_workgroup_size_x(topology: &KernelTopology) -> u32 {
             }
         }
     };
-    dispatch.workgroup_size().x
+    dispatch.workgroup_size()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/dsl_compiler/src/cg/lower/view.rs
+++ b/crates/dsl_compiler/src/cg/lower/view.rs
@@ -286,6 +286,16 @@ pub fn lower_view(
             // populated in Phase 1 (`populate_view_bodies_and_signatures`)
             // — see driver.rs.
 
+            // Plan G G3d — `@dispatch(per_agent_event_scan)` annotation
+            // flips the fold handler's dispatch shape from the default
+            // `PerEvent { source_ring }` to `PerAgentEventScan`. The
+            // annotation is detected up-front so the choice is made once
+            // for the view (every fold handler shares the shape).
+            // Future: if heterogeneous per-handler dispatches arrive,
+            // move the lookup inside `lower_one_handler` and key it on
+            // the handler's own annotations.
+            let dispatch_override = view_dispatch_override(ir);
+
             // B2: when the view carries `@decay(rate, per=tick)`, lower a
             // singleton [`ComputeOpKind::ViewDecay`] op BEFORE any fold
             // handler. The schedule synthesizer keys op ordering on
@@ -306,6 +316,7 @@ pub fn lower_view(
                 ir.decay.as_ref(),
                 handlers,
                 handler_resolutions,
+                dispatch_override,
                 ctx,
             )?;
             op_ids.extend(fold_ids);
@@ -366,6 +377,7 @@ fn lower_fold_handlers(
     decay: Option<&DecayHint>,
     handlers: &[FoldHandlerIR],
     handler_resolutions: &[HandlerResolution],
+    dispatch_override: Option<DispatchShape>,
     ctx: &mut LoweringCtx<'_>,
 ) -> Result<Vec<OpId>, LoweringError> {
     debug_assert_eq!(
@@ -375,10 +387,50 @@ fn lower_fold_handlers(
     );
     let mut op_ids = Vec::with_capacity(handlers.len());
     for (handler, resolution) in handlers.iter().zip(handler_resolutions.iter()) {
-        let op_id = lower_one_handler(view_id, hint, decay, handler, *resolution, ctx)?;
+        let op_id = lower_one_handler(
+            view_id,
+            hint,
+            decay,
+            handler,
+            *resolution,
+            dispatch_override,
+            ctx,
+        )?;
         op_ids.push(op_id);
     }
     Ok(op_ids)
+}
+
+/// Inspect a view's `annotations` for `@dispatch(per_agent_event_scan)`
+/// and produce the overriding [`DispatchShape`] when present. Returns
+/// `None` (default `PerEvent` dispatch) when the annotation is absent
+/// or carries an unrecognised argument.
+///
+/// **Surface today:** the annotation accepts a single positional arg —
+/// the dispatch shape's snake_case label. Only `per_agent_event_scan`
+/// is recognised. Unknown labels fall through to `None` so the resolver
+/// can later land a typed warning without breaking lowering.
+///
+/// **Future:** as more dispatch shapes need annotation surface, lift
+/// the (label → shape) table out of this helper and into a shared
+/// resolver pass, with typed errors for unknown labels.
+fn view_dispatch_override(ir: &dsl_ast::ir::ViewIR) -> Option<DispatchShape> {
+    use dsl_ast::ast::AnnotationValue;
+    let ann = ir.annotations.iter().find(|a| a.name == "dispatch")?;
+    for arg in &ann.args {
+        // Positional arg only — `@dispatch(per_agent_event_scan)`.
+        // Future: support `@dispatch(shape = per_agent_event_scan, ...)`
+        // by also matching `arg.key == Some("shape")`.
+        if arg.key.is_some() {
+            continue;
+        }
+        if let AnnotationValue::Ident(name) = &arg.value {
+            if name == "per_agent_event_scan" {
+                return Some(DispatchShape::PerAgentEventScan);
+            }
+        }
+    }
+    None
 }
 
 /// Lower a view's `@decay(rate, per=tick)` annotation into a
@@ -408,12 +460,19 @@ fn lower_decay_op(
 }
 
 /// Lower a single fold handler to one [`ComputeOpKind::ViewFold`] op.
+///
+/// `dispatch_override` lets the caller swap the default
+/// `DispatchShape::PerEvent { source_ring }` for an alternate shape
+/// (Plan G G3d's `PerAgentEventScan`). When `None` the handler keeps
+/// the legacy per-event ring dispatch — every existing fixture lands
+/// here.
 fn lower_one_handler(
     view_id: ViewId,
     hint: StorageHint,
     decay: Option<&DecayHint>,
     handler: &FoldHandlerIR,
     resolution: HandlerResolution,
+    dispatch_override: Option<DispatchShape>,
     ctx: &mut LoweringCtx<'_>,
 ) -> Result<OpId, LoweringError> {
     // Synthesize a `CgStmt::Let` per fold-handler event-pattern
@@ -459,9 +518,16 @@ fn lower_one_handler(
         on_event: resolution.event_kind,
         body: body_list_id,
     };
-    let shape = DispatchShape::PerEvent {
+    // Default: `PerEvent { source_ring }` — every existing fold view
+    // dispatches one thread per event in the source ring. Plan G G3d's
+    // `@dispatch(per_agent_event_scan)` annotation overrides to the
+    // 2-D `(observer, source_candidate)` shape; the source-ring
+    // identity stays on the resolution but is unused by the
+    // PerAgentEventScan emit (the kernel reads from per-agent SoA
+    // columns, not from an event ring).
+    let shape = dispatch_override.unwrap_or(DispatchShape::PerEvent {
         source_ring: resolution.source_ring,
-    };
+    });
     let op_id = ctx
         .builder
         .add_op(kind, shape, handler.span)

--- a/crates/dsl_compiler/src/cg/schedule/fusion.rs
+++ b/crates/dsl_compiler/src/cg/schedule/fusion.rs
@@ -115,6 +115,12 @@ pub enum DispatchShapeKey {
     /// `scan_shared` array across ops, which the current emit
     /// pipeline does not support.
     PerScanChunk,
+    /// Per-(observer, source) 2-D dispatch (Plan G G3 threats view).
+    /// Sits in its own key class today — the 2-D dispatch geometry +
+    /// busy-filter preamble are structurally distinct from every
+    /// 1-D shape, so fusion would require reconciling the per-thread
+    /// indexing and the early-exit predicate.
+    PerAgentEventScan,
 }
 
 /// Project a [`DispatchShape`] to its [`DispatchShapeKey`]. The
@@ -129,6 +135,7 @@ pub fn dispatch_shape_key(shape: &DispatchShape) -> DispatchShapeKey {
         DispatchShape::PerWord => DispatchShapeKey::PerWord,
         DispatchShape::PerCell => DispatchShapeKey::PerCell,
         DispatchShape::PerScanChunk => DispatchShapeKey::PerScanChunk,
+        DispatchShape::PerAgentEventScan => DispatchShapeKey::PerAgentEventScan,
     }
 }
 
@@ -1267,7 +1274,8 @@ pub(super) fn classify(ops: &[OpId], shape: &DispatchShape) -> FusibilityClass {
         | DispatchShape::OneShot
         | DispatchShape::PerWord
         | DispatchShape::PerCell
-        | DispatchShape::PerScanChunk => {
+        | DispatchShape::PerScanChunk
+        | DispatchShape::PerAgentEventScan => {
             if ops.len() < 2 {
                 FusibilityClass::Split
             } else {

--- a/crates/dsl_compiler/src/cg/schedule/synthesis.rs
+++ b/crates/dsl_compiler/src/cg/schedule/synthesis.rs
@@ -499,7 +499,8 @@ fn group_to_topology(
                 | DispatchShape::OneShot
                 | DispatchShape::PerWord
                 | DispatchShape::PerCell
-                | DispatchShape::PerScanChunk => unreachable!(
+                | DispatchShape::PerScanChunk
+                | DispatchShape::PerAgentEventScan => unreachable!(
                     "FusibilityClass::Indirect groups always carry \
                      DispatchShape::PerEvent (see super::fusion::classify)"
                 ),

--- a/crates/dsl_compiler/src/cg/well_formed.rs
+++ b/crates/dsl_compiler/src/cg/well_formed.rs
@@ -409,6 +409,7 @@ enum DispatchShapeLabel {
     PerWord,
     PerCell,
     PerScanChunk,
+    PerAgentEventScan,
 }
 
 impl DispatchShapeLabel {
@@ -421,6 +422,7 @@ impl DispatchShapeLabel {
             DispatchShape::PerWord => DispatchShapeLabel::PerWord,
             DispatchShape::PerCell => DispatchShapeLabel::PerCell,
             DispatchShape::PerScanChunk => DispatchShapeLabel::PerScanChunk,
+            DispatchShape::PerAgentEventScan => DispatchShapeLabel::PerAgentEventScan,
         }
     }
 
@@ -433,6 +435,7 @@ impl DispatchShapeLabel {
             DispatchShapeLabel::PerWord => "per_word",
             DispatchShapeLabel::PerCell => "per_cell",
             DispatchShapeLabel::PerScanChunk => "per_scan_chunk",
+            DispatchShapeLabel::PerAgentEventScan => "per_agent_event_scan",
         }
     }
 }
@@ -490,7 +493,14 @@ fn allowed_shapes_for_kind(kind: &ComputeOpKind) -> &'static [DispatchShapeLabel
             DispatchShapeLabel::PerCell,
             DispatchShapeLabel::OneShot,
         ],
-        ComputeOpKind::ViewFold { .. } => &[DispatchShapeLabel::PerEvent],
+        // ViewFold normally dispatches PerEvent (one thread per event in
+        // the source ring). Plan G G3d adds PerAgentEventScan to admit
+        // per-(observer, busy-source) folds whose source candidate set
+        // is a per-agent SoA column rather than an event ring.
+        ComputeOpKind::ViewFold { .. } => &[
+            DispatchShapeLabel::PerEvent,
+            DispatchShapeLabel::PerAgentEventScan,
+        ],
         // Per-tick anchor multiplication runs one thread per slot.
         ComputeOpKind::ViewDecay { .. } => &[DispatchShapeLabel::PerAgent],
         ComputeOpKind::SpatialQuery { kind } => match kind {

--- a/crates/dsl_compiler/tests/per_agent_event_scan_probe_lower.rs
+++ b/crates/dsl_compiler/tests/per_agent_event_scan_probe_lower.rs
@@ -1,0 +1,128 @@
+//! Plan G G3d — smoke test for `assets/sim/per_agent_event_scan_probe.sim`.
+//!
+//! Lights up the new `DispatchShape::PerAgentEventScan` variant added
+//! alongside the threats-view design. The variant dispatches one
+//! thread per `(observer_agent, source_agent)` pair, with an early-
+//! exit when the source agent's `busy_with_ability_id` SoA column is
+//! zero. The threats view (Plan G G3g) will be the first real
+//! consumer; this fixture proves the dispatch-shape mechanism in
+//! isolation with a trivially-simple per-agent counter view.
+//!
+//! Asserts:
+//!
+//! 1. The fixture parses + resolves + lowers (no errors).
+//! 2. The `threat_count` view emits a kernel.
+//! 3. The kernel's WGSL declares `@workgroup_size(8, 8)` (the 2-D
+//!    geometry pinned to 8×8 = 64 threads per group).
+//! 4. The kernel preamble binds `gid.y` to `source_candidate` (the
+//!    structural signal that the dispatch is 2-D, not 1-D).
+//! 5. The kernel preamble has the busy-filter early-exit
+//!    (`agent_busy_with_ability_id[source_candidate] == 0u`).
+//! 6. The kernel does NOT use the standard PerEvent preamble
+//!    (`event_idx = gid.x; event_idx >= cfg.event_count`) — that
+//!    would indicate the new shape silently fell back to PerEvent.
+
+#[test]
+fn per_agent_event_scan_probe_sim_lowers_clean() {
+    let src = std::fs::read_to_string("../../assets/sim/per_agent_event_scan_probe.sim")
+        .expect("read assets/sim/per_agent_event_scan_probe.sim");
+    let program = dsl_compiler::parse(&src).expect("parse per_agent_event_scan_probe.sim");
+    let comp = dsl_ast::resolve::resolve(program)
+        .expect("resolve per_agent_event_scan_probe.sim");
+
+    let (cg, lower_diags) = match dsl_compiler::cg::lower::lower_compilation_to_cg(&comp) {
+        Ok(p) => (p, Vec::new()),
+        Err(o) => {
+            let diags: Vec<String> = o.diagnostics.iter().map(|d| format!("{d}")).collect();
+            (o.program, diags)
+        }
+    };
+    for d in &lower_diags {
+        eprintln!("[lower diag] {d}");
+    }
+
+    let schedule = dsl_compiler::cg::schedule::synthesize_schedule(
+        &cg,
+        dsl_compiler::cg::schedule::ScheduleStrategy::Default,
+    );
+    let artifacts = dsl_compiler::cg::emit::emit_cg_program(&schedule.schedule, &cg)
+        .expect("emit per_agent_event_scan_probe");
+
+    assert!(
+        !artifacts.kernel_index.is_empty(),
+        "expected at least one emitted kernel, got none"
+    );
+
+    let kernel_names: Vec<&str> =
+        artifacts.kernel_index.iter().map(|s| s.as_str()).collect();
+    for expected in ["StartCast", "threat_count"] {
+        assert!(
+            kernel_names.iter().any(|n| n.contains(expected)),
+            "expected kernel containing {expected:?}; got: {kernel_names:?}"
+        );
+    }
+
+    // Pull the threat_count fold WGSL out and inspect its preamble.
+    let fold_wgsl = artifacts
+        .wgsl_files
+        .iter()
+        .find(|(name, _)| name.contains("threat_count") && name.ends_with(".wgsl"))
+        .map(|(name, body)| (name.as_str(), body.as_str()))
+        .expect("threat_count fold kernel must emit a .wgsl artifact");
+
+    eprintln!("[G3d smoke] inspecting {}", fold_wgsl.0);
+    eprintln!("[G3d smoke] body length: {} bytes", fold_wgsl.1.len());
+
+    // 2-D workgroup geometry — the new shape pins `@workgroup_size(8, 8)`.
+    assert!(
+        fold_wgsl.1.contains("@workgroup_size(8, 8)"),
+        "PerAgentEventScan emit must declare a 2-D `@workgroup_size(8, 8)` annotation. \
+         WGSL did not contain the substring.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+
+    // 2-D thread indexing — the body must read `gid.y` for the source
+    // candidate. Without it, the dispatch silently fell back to a 1-D
+    // PerEvent / PerAgent shape.
+    assert!(
+        fold_wgsl.1.contains("let source_candidate = gid.y"),
+        "PerAgentEventScan emit must bind `source_candidate = gid.y` \
+         (the structural signal that the dispatch is 2-D). WGSL did not \
+         contain the substring.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+    assert!(
+        fold_wgsl.1.contains("let observer = gid.x"),
+        "PerAgentEventScan emit must bind `observer = gid.x`. WGSL did \
+         not contain the substring.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+
+    // Busy-filter early-exit — drops any `(observer, non-busy-source)`
+    // pair before the per-op fold body runs.
+    assert!(
+        fold_wgsl.1.contains("agent_busy_with_ability_id[source_candidate]"),
+        "PerAgentEventScan emit must early-exit any source candidate \
+         whose `agent_busy_with_ability_id[source_candidate]` is zero. \
+         WGSL did not contain the substring.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+
+    // Negative pin: the standard PerEvent preamble (`let event_idx =
+    // gid.x; if (event_idx >= cfg.event_count) ...`) must NOT appear
+    // in the body — its presence would mean the dispatch silently
+    // fell back to PerEvent and the busy-filter never ran.
+    //
+    // Note: `cfg.event_count` itself can still appear in the
+    // PerAgentEventScan preamble as the bounds source for `observer` /
+    // `source_candidate` (the cfg layout aliasing is documented on the
+    // body builder); we pin against the `event_idx = gid.x` substring
+    // specifically to catch the wrong-preamble regression.
+    assert!(
+        !fold_wgsl.1.contains("let event_idx = gid.x"),
+        "PerAgentEventScan emit must NOT use the standard PerEvent \
+         preamble (`let event_idx = gid.x`). The presence of that \
+         substring means the dispatch silently fell back to PerEvent.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+}


### PR DESCRIPTION
## Summary

Plan G G3d — adds a new `DispatchShape::PerAgentEventScan` variant that lays
out compute work as a 2-D `(observer_agent, source_candidate)` grid with a
busy-filter early-exit on the source's `busy_with_ability_id` SoA column.

This closes the gap between the existing PerEvent fold dispatch (one thread
per event in a source ring) and the threats view's needs (one thread per
(observer, busy-caster) pair, with the candidate set being "all agents
currently mid-cast"). The threats view (Plan G G3g) will be the first real
consumer; this slice plumbs the dispatch-shape mechanism in isolation so
G3g doesn't need to land it alongside the rest of the threats-view
machinery.

- New `DispatchShape::PerAgentEventScan` variant, with companion
  `WorkgroupSize { x: 8, y: 8 }`, 2-D `dispatch_count`, and
  `ThreadIndexing::PerAgentEventScanSlot`.
- New `@dispatch(per_agent_event_scan)` view annotation parsed in
  `cg/lower/view.rs::view_dispatch_override` (no resolver-level surface
  yet — the lowering helper inspects `ir.annotations` directly; promoting
  to a typed resolver pass is a follow-up).
- Routing through `well_formed::allowed_shapes_for_kind` (admits the new
  shape for `ViewFold`), `schedule::fusion::dispatch_shape_key` +
  `classify` (sits in its own fusion key class, classifies as Split/Fused
  — never Indirect), and `schedule::synthesis` (Indirect arm marks the
  new variant unreachable).
- WGSL emit: `compose_wgsl_file` extends to support 2-D
  `@workgroup_size(x, y)` annotations; `compose_dispatch_call` adds the
  2-D dispatch line; `build_view_fold_wgsl_body` diverts to a new
  `build_view_fold_per_agent_event_scan_body` that emits the
  observer/source preamble + busy-filter early-exit; the ViewFold binding
  shape gains an 8th binding (`agent_busy_with_ability_id`,
  `BgSource::External`) when the dispatch is the new shape.

### Cfg shape note

The standard ViewFold cfg layout is `{ event_count, tick, second_key_pop,
_pad0 }`. The PerAgentEventScan body builder reads `cfg.event_count` as
agent_cap for its bounds checks; the runtime side will populate the field
with the agent slot count when dispatching this shape. A future cleanup
splits the cfg shape so the field name matches its semantic, but that
isn't required for the smoke-test scope.

### Smoke fixture

`assets/sim/per_agent_event_scan_probe.sim` — a per-observer scalar f32
counter view annotated `@dispatch(per_agent_event_scan)` with a single
`StartCast` rule that marks every agent busy at a configured tick. The
companion test (`crates/dsl_compiler/tests/per_agent_event_scan_probe_lower.rs`)
asserts the WGSL has `@workgroup_size(8, 8)`, the
`source_candidate = gid.y` binding, and the busy-filter early-exit, plus
a negative pin against the standard PerEvent preamble (regression
catch).

## Test plan

- [x] `cargo test -p dsl_ast --release` — 145 passed, 0 failed
- [x] `cargo test -p dsl_compiler --release` — 850 lib + 32 probe-suite +
  the rest all pass; new `per_agent_event_scan_probe_sim_lowers_clean`
  passes
- [x] `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)