### PR TITLE
feat(plan-g/g3bc): struct-payload PerEntityRing + multi-statement view fold body

### DIFF
--- a/assets/sim/per_entity_ring_struct_probe.sim
+++ b/assets/sim/per_entity_ring_struct_probe.sim
@@ -1,0 +1,79 @@
+// per_entity_ring_struct_probe — Plan G G3b/G3c smoke fixture.
+//
+// Lights up the struct-payload extension to the existing-but-unused
+// `@per_entity_ring(K = N)` view shape. Sibling to G3a's
+// `per_entity_ring_probe.sim` (which exercises the SCALAR ring-append
+// path with a single-f32 payload); this fixture exercises the struct-
+// cell ring-append path where each cell holds a multi-field struct
+// `(timestamp: u32, amount: f32)`.
+//
+// Also smoke-tests Plan G G3c (multi-statement view fold body) by
+// admitting an intermediate `let` binding before the `self.append(...)`
+// — the Let admission is required for the struct-cell shape to compose
+// with future fixtures that derive a per-cell field from prior locals
+// (cursor offsets, q8 packing, ...).
+//
+// Shape: per-agent ring of K = 4 cells. Each Damaged event appends one
+// cell; the cell's first field is the tick at which the event landed,
+// the second is the damage amount. The cursor allocation +
+// per-target stride logic is identical to G3a's scalar shape; only the
+// per-field payload writes differ.
+//
+// **Behavioural pin (target shape — runtime not built yet).**
+//
+//   AGENT_COUNT=2, INITIAL_HP=200.0
+//   Tick 0: scripted Damaged{target=0, amount=10}.
+//     Ring[0] = [(t=0, a=10), (?, ?), (?, ?), (?, ?)].
+//   Tick 1: scripted Damaged{target=0, amount=20}.
+//     Ring[0] = [(t=0, a=10), (t=1, a=20), (?, ?), (?, ?)].
+//   ... (struct-cell layout matches G3a's slot wraparound semantics —
+//   K=4 cells, FIFO with cursor mod K)
+//
+// MVP scope:
+//   * Two-field struct payload (`timestamp: u32, amount: f32`). Future
+//     fixtures (the threats view) extend this to ~8 fields.
+//   * `let` admission: the body's `let now = ...` binding flows
+//     through the new G3c Let arm in `view::lower_stmt`.
+//   * Single-handler fold (Damaged only). Multi-handler folds are out
+//     of scope for this slice.
+
+event Tick { }
+event Damaged { source: AgentId, target: AgentId, amount: f32 }
+
+entity Subject : Agent { }
+
+config inject {
+  inject_at_tick: u32 = 0,
+  inject_base:    f32 = 10.0,
+  inject_step:    f32 = 10.0,
+  target_slot:    u32 = 0,
+}
+
+@phase(per_agent)
+physics InjectDamage {
+  on Tick {} where (self.alive && world.tick >= config.inject.inject_at_tick) {
+    emit Damaged {
+      source: self,
+      target: self,
+      amount: config.inject.inject_base + ((world.tick - config.inject.inject_at_tick) * 1.0) * config.inject.inject_step,
+    }
+  }
+}
+
+// G3b/G3c's view-under-test. Per-target ring of K=4 cells, each
+// storing a `(timestamp: u32, amount: f32)` pair. The fold body
+// derives `now` via a Let (G3c admission), then appends the struct
+// cell via `self.append(...)` (G3b/G3c new shape).
+//
+// Note: `self.append(...)` is the new struct-payload primitive. The
+// scalar-payload `self += <expr>` shape (per_entity_ring_probe.sim)
+// stays in place for views that only need a single per-cell value.
+@materialized(on_event = [Damaged])
+@per_entity_ring(K = 4)
+view recent_damage_records(target: Agent) -> f32 {
+  initial: 0.0,
+  on Damaged { source: _, target: t, amount: a } {
+    let now = world.tick
+    self.append(timestamp: now, amount: a)
+  }
+}

--- a/crates/dsl_ast/src/ast.rs
+++ b/crates/dsl_ast/src/ast.rs
@@ -708,6 +708,14 @@ pub enum Stmt {
     Match { scrutinee: Expr, arms: Vec<MatchArm>, span: Span },
     /// Self-delta in fold bodies: `self -= 0.1 * e.damage`, `self += 0.3`.
     SelfUpdate { op: String, value: Expr, span: Span },
+    /// Plan G G3b/G3c — `self.append(field1: expr1, field2: expr2, ...)` —
+    /// struct-payload ring append in a `@per_entity_ring(...)` view fold
+    /// body. The field list defines the per-cell struct layout (in
+    /// declaration order); types are inferred from the bound exprs at
+    /// lowering time. The ring index is allocated via the per-agent
+    /// cursor counter; per-field stores write into
+    /// `primary[ring_idx * field_count + field_idx]`.
+    SelfAppend { fields: Vec<FieldInit>, span: Span },
     /// Bare expression (for fold bodies that set self).
     Expr(Expr),
     /// `beliefs(observer).observe(target) with { field: expr, ... }` — belief

--- a/crates/dsl_ast/src/eval/physics.rs
+++ b/crates/dsl_ast/src/eval/physics.rs
@@ -373,6 +373,15 @@ fn exec_stmt<C: CascadeContext>(stmt: &IrStmt, ctx: &mut C, locals: &mut Locals)
              see docs/superpowers/notes/2026-04-22-wolves-humans-interp-coverage.md §3"
         ),
 
+        IrStmt::SelfAppend { .. } => {
+            // Plan G G3b/G3c — `self.append(...)` is a view-fold-body
+            // primitive (struct ring append). Physics rules don't have
+            // a `self` cell to ring-append into; the resolver normally
+            // separates view bodies from physics bodies, so this arm is
+            // structurally unreachable from valid sources. Silently
+            // skip to keep the interpreter total over the IR.
+        }
+
         IrStmt::BeliefObserve { .. } => {
             // Theory-of-Mind belief-observe statements are not evaluated by
             // the wolves+humans interpreter path. This variant was added on

--- a/crates/dsl_ast/src/ir.rs
+++ b/crates/dsl_ast/src/ir.rs
@@ -475,6 +475,21 @@ pub enum IrStmt {
         value: IrExprNode,
         span: Span,
     },
+    /// Plan G G3b/G3c — `self.append(field1: expr1, field2: expr2, ...)` —
+    /// struct-payload ring append in a `@per_entity_ring(...)` view fold
+    /// body. Each cell of the ring stores a multi-field struct whose
+    /// layout is implied by the field list (declaration order, types
+    /// inferred from the bound exprs at lowering time). The ring index
+    /// is allocated via the per-agent cursor counter; the per-field
+    /// stores write into `primary[ring_idx * field_count + field_idx]`.
+    ///
+    /// Distinct from `SelfUpdate { op = "+=" }` — that scalar accumulate
+    /// path stays in place for `recent_damages` style folds; this new
+    /// shape unblocks the threats view's struct-cell payload.
+    SelfAppend {
+        fields: Vec<IrFieldInit>,
+        span: Span,
+    },
     Expr(IrExprNode),
     /// `beliefs(observer).observe(target) with { field: expr, ... }` — belief
     /// mutation primitive resolved from the DSL surface (Plan ToM Task 4).

--- a/crates/dsl_ast/src/parser.rs
+++ b/crates/dsl_ast/src/parser.rs
@@ -2036,8 +2036,10 @@ fn parse_stmt(c: &mut Cursor) -> PResult<Stmt> {
     if starts_with_keyword(c, "beliefs") && is_belief_observe_stmt(c) {
         return Ok(Stmt::BeliefObserve(parse_belief_observe_stmt(c)?));
     }
-    if c.starts_with("self") {
-        // Check for `self += / -= / *= / |=` operators.
+    if starts_with_keyword(c, "self") {
+        // Check for `self += / -= / *= / |=` operators, OR
+        // `self.append( field: expr, ... )` (Plan G G3b/G3c — struct
+        // ring append).
         let save = c.pos;
         c.bump("self".len());
         c.skip_ws();
@@ -2050,6 +2052,56 @@ fn parse_stmt(c: &mut Cursor) -> PResult<Stmt> {
                 let value = parse_expr(c)?;
                 return Ok(Stmt::SelfUpdate { op: op.to_string(), value, span: Span::new(start, c.pos) });
             }
+        }
+        // `self.append(...)` — struct-payload ring append. Each arg is
+        // a `name: <expr>` pair; the name list defines the per-cell
+        // struct layout in declaration order.
+        if c.starts_with_char('.') {
+            let dot_save = c.pos;
+            c.bump(1);
+            c.skip_ws();
+            if starts_with_keyword(c, "append") {
+                c.bump("append".len());
+                c.skip_ws();
+                expect_char(c, '(')
+                    .map_err(|e| e.with_context("parsing `self.append(` open paren"))?;
+                let mut fields: Vec<FieldInit> = Vec::new();
+                loop {
+                    c.skip_ws();
+                    if c.starts_with_char(')') {
+                        c.bump(1);
+                        break;
+                    }
+                    let fstart = c.pos;
+                    let name = ident(c)
+                        .map_err(|e| e.with_context("parsing self.append field name"))?;
+                    c.skip_ws();
+                    expect_char(c, ':').map_err(|e| {
+                        e.with_context("parsing `:` after self.append field name")
+                    })?;
+                    c.skip_ws();
+                    let value = parse_expr(c)?;
+                    fields.push(FieldInit { name, value, span: Span::new(fstart, c.pos) });
+                    c.skip_ws();
+                    if c.starts_with_char(',') {
+                        c.bump(1);
+                        continue;
+                    }
+                    if c.starts_with_char(')') {
+                        c.bump(1);
+                        break;
+                    }
+                    return Err(ParseErr::at(
+                        here(c),
+                        "expected `,` or `)` in self.append(...)",
+                    ));
+                }
+                return Ok(Stmt::SelfAppend {
+                    fields,
+                    span: Span::new(start, c.pos),
+                });
+            }
+            c.pos = dot_save;
         }
         c.pos = save;
     }

--- a/crates/dsl_ast/src/resolve.rs
+++ b/crates/dsl_ast/src/resolve.rs
@@ -1960,6 +1960,24 @@ fn resolve_stmt(
             let value = resolve_expr(value, scope, symbols)?;
             Ok(IrStmt::SelfUpdate { op: op.clone(), value, span: *span })
         }
+        Stmt::SelfAppend { fields, span } => {
+            // Plan G G3b/G3c — resolve each `field: <expr>` binding.
+            // The field name list is preserved verbatim; the per-cell
+            // struct layout is inferred from these names + the
+            // resolved expression types at lowering time.
+            let resolved: Vec<IrFieldInit> = fields
+                .iter()
+                .map(|f| {
+                    let value = resolve_expr(&f.value, scope, symbols)?;
+                    Ok::<_, ResolveError>(IrFieldInit {
+                        name: f.name.clone(),
+                        value,
+                        span: f.span,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(IrStmt::SelfAppend { fields: resolved, span: *span })
+        }
         Stmt::Expr(e) => Ok(IrStmt::Expr(resolve_expr(e, scope, symbols)?)),
         Stmt::BeliefObserve(b) => {
             // Validate that each assigned field is a known BeliefState field.
@@ -3385,6 +3403,16 @@ fn validate_fold_stmt(view_name: &str, s: &IrStmt) -> Result<(), ResolveError> {
             }
             validate_fold_expr(view_name, value)
         }
+        IrStmt::SelfAppend { fields, .. } => {
+            // Plan G G3b/G3c — struct ring append. Each field's bound
+            // expression must be a fold-legal expression (no Emit, no
+            // ApplyAbility, etc.); validate per-field. The per-cell
+            // struct layout is inferred at lowering time.
+            for f in fields {
+                validate_fold_expr(view_name, &f.value)?;
+            }
+            Ok(())
+        }
         IrStmt::If { cond, then_body, else_body, .. } => {
             validate_fold_expr(view_name, cond)?;
             for ts in then_body {
@@ -3815,6 +3843,17 @@ fn validate_physics_stmt(physics_name: &str, s: &IrStmt) -> Result<(), ResolveEr
             Ok(())
         }
         IrStmt::SelfUpdate { value, .. } => validate_physics_expr(physics_name, value),
+        IrStmt::SelfAppend { fields, .. } => {
+            // Plan G G3b/G3c — physics rules don't have a `self` cell to
+            // ring-append into; the resolver normally rejects this via
+            // the fold-vs-physics body separation, but defensively
+            // validate the bound exprs here so synthetic ASTs still get
+            // surfaced cleanly.
+            for f in fields {
+                validate_physics_expr(physics_name, &f.value)?;
+            }
+            Ok(())
+        }
         IrStmt::Expr(e) => validate_physics_expr(physics_name, e),
         IrStmt::ApplyAbility { ability, caster, target, .. } => {
             // Slice ε: validate the new optional caster/target operands
@@ -4164,6 +4203,7 @@ fn collect_emitted_events(body: &[IrStmt], out: &mut Vec<String>) {
             }
             IrStmt::Let { .. }
             | IrStmt::SelfUpdate { .. }
+            | IrStmt::SelfAppend { .. }
             | IrStmt::Expr(_)
             | IrStmt::BeliefObserve { .. }
             | IrStmt::ApplyAbility { .. } => {}
@@ -4306,6 +4346,9 @@ fn stmt_references_cascade_ceiling(s: &IrStmt) -> bool {
                 || arms.iter().any(|a| stmts_reference_cascade_ceiling(&a.body))
         }
         IrStmt::SelfUpdate { value, .. } => expr_references_cascade_ceiling(value),
+        IrStmt::SelfAppend { fields, .. } => {
+            fields.iter().any(|f| expr_references_cascade_ceiling(&f.value))
+        }
         IrStmt::Expr(e) => expr_references_cascade_ceiling(e),
         IrStmt::BeliefObserve { observer, target, fields, .. } => {
             expr_references_cascade_ceiling(observer)

--- a/crates/dsl_compiler/src/cg/emit/kernel.rs
+++ b/crates/dsl_compiler/src/cg/emit/kernel.rs
@@ -109,7 +109,8 @@ use crate::kernel_binding_ir::{
 
 use super::wgsl_body::EmitError as InnerEmitError;
 use super::wgsl_body::{
-    lower_cg_expr_to_wgsl, lower_cg_stmt_list_to_wgsl, stmt_list_contains_set_alive_false, EmitCtx,
+    lower_cg_expr_to_wgsl, lower_cg_stmt_list_to_wgsl, lower_cg_stmt_to_wgsl,
+    stmt_list_contains_set_alive_false, EmitCtx,
 };
 
 // ---------------------------------------------------------------------------
@@ -2397,7 +2398,7 @@ fn build_view_fold_wgsl_body(
     // we lock in the per_entity_ring_probe.sim shape so the smoke test can
     // assert ring-append semantics without G3b's struct-payload work.
     if let Some(CgStorageHint::PerEntityRing { k }) = storage_hint {
-        return build_view_fold_ring_append_body(body_ops, prog, k as u32);
+        return build_view_fold_ring_append_body(body_ops, prog, ctx, k as u32);
     }
     let mut out = String::new();
     out.push_str("    let event_idx = gid.x;\n");
@@ -2686,8 +2687,10 @@ const EVENT_RING_DEFAULT_STRIDE_U32: u32 = 10;
 fn build_view_fold_ring_append_body(
     body_ops: &[OpId],
     prog: &CgProgram,
+    ctx: &EmitCtx<'_>,
     k: u32,
 ) -> Result<String, KernelEmitError> {
+    use crate::cg::stmt::CgStmt;
     let mut out = String::new();
     out.push_str("    let event_idx = gid.x;\n");
     out.push_str("    if (event_idx >= cfg.event_count) { return; }\n");
@@ -2695,42 +2698,177 @@ fn build_view_fold_ring_append_body(
 
     for op_id in body_ops {
         let op = resolve_op(prog, *op_id)?;
-        let (event_id, stride) = match &op.kind {
-            ComputeOpKind::ViewFold { on_event, .. } => {
+        let (event_id, body_list_id, view_id, stride) = match &op.kind {
+            ComputeOpKind::ViewFold {
+                on_event,
+                body,
+                view,
+            } => {
                 let stride = prog
                     .event_layouts
                     .get(&on_event.0)
                     .map(|l| l.record_stride_u32)
                     .unwrap_or(EVENT_RING_DEFAULT_STRIDE_U32);
-                (on_event.0, stride)
+                (on_event.0, *body, *view, stride)
             }
             _ => continue,
         };
+
+        // Plan G G3b/G3c — branch on the registered struct-cell
+        // ViewLayout. When present, the body's `CgStmt::ViewStorageAppend`
+        // drives a per-field ring-append; without one, fall through to
+        // the G3a scalar shape (`view_storage_primary[ring_idx] =
+        // amount_bits`) hard-coded against the well-known event ring
+        // offset 3 / 4 (target / amount).
+        let layout = prog.view_layouts.get(&view_id.0);
+
         out.push_str(&format!(
             "    // PerEntityRing append (K = {k}, on_event = {event_id}).\n"
         ));
         out.push_str(&format!(
             "    if (event_ring[event_idx * {stride}u + 0u] == {event_id}u) {{\n"
         ));
-        out.push_str(&format!(
-            "        let target_slot = event_ring[event_idx * {stride}u + 3u];\n"
-        ));
-        out.push_str(&format!(
-            "        let amount_bits = event_ring[event_idx * {stride}u + 4u];\n"
-        ));
-        out.push_str(
-            "        let cursor_idx = atomicAdd(&view_storage_anchor[target_slot], 1u);\n",
-        );
-        out.push_str(&format!(
-            "        let ring_idx = target_slot * {k}u + (cursor_idx % {k}u);\n"
-        ));
-        // primary is `array<u32>` for PerEntityRing (non-atomic — the
-        // cursor atomicAdd already serialized slot allocation, so
-        // each writer's `ring_idx` is distinct within one tick for
-        // ≤K events per agent). Plain assignment, not atomicStore.
-        out.push_str(
-            "        view_storage_primary[ring_idx] = amount_bits;\n",
-        );
+
+        if let Some(layout) = layout {
+            // ----- G3b/G3c struct-payload path -----
+            //
+            // Step 1: emit prelude statements (event-pattern binding
+            // `Let`s synthesized by the lowering, plus user `Let`s),
+            // PROVIDING the bound locals reads in the SelfAppend's
+            // field expressions can resolve.
+            //
+            // Step 2: emit the cursor allocation + per-field stores.
+            //
+            // The walker locates the `ViewStorageAppend` stmt and uses
+            // its lowered field-expression CgExprIds.
+            let body_list = prog
+                .stmt_lists
+                .get(body_list_id.0 as usize)
+                .ok_or(KernelEmitError::Inner(InnerEmitError::StmtListIdOutOfRange {
+                    id: body_list_id,
+                    arena_len: prog.stmt_lists.len() as u32,
+                }))?;
+
+            // Lower every prelude stmt (Let / Assign / etc.) until we
+            // hit the ViewStorageAppend.
+            let mut append_fields: Option<&Vec<(String, crate::cg::data_handle::CgExprId)>> = None;
+            for stmt_id in &body_list.stmts {
+                let Some(stmt) = prog.stmts.get(stmt_id.0 as usize) else {
+                    continue;
+                };
+                match stmt {
+                    CgStmt::ViewStorageAppend { fields, .. } => {
+                        append_fields = Some(fields);
+                        break;
+                    }
+                    CgStmt::Let { .. } => {
+                        // Plan G G3c — delegate to the shared single-
+                        // stmt lowerer so event-pattern bindings +
+                        // local typing flow through their normal path
+                        // (no parallel emit logic to maintain).
+                        let stmt_wgsl =
+                            lower_cg_stmt_to_wgsl(*stmt_id, ctx).map_err(KernelEmitError::from)?;
+                        for line in stmt_wgsl.lines() {
+                            if line.is_empty() {
+                                out.push('\n');
+                            } else {
+                                out.push_str(&format!("        {line}\n"));
+                            }
+                        }
+                    }
+                    // Skip non-let prelude shapes (Assign, etc.) — for
+                    // the struct-cell append shape today, only Lets
+                    // appear before the ViewStorageAppend.
+                    _ => {}
+                }
+            }
+
+            let Some(fields) = append_fields else {
+                // No ViewStorageAppend in the body — close the if-block
+                // and continue. The auto-walker still recorded the
+                // primary/cursors writes, but the body has no actual
+                // append to emit.
+                out.push_str("    }\n");
+                continue;
+            };
+
+            // Step 2: cursor allocation. The cursor counter (BGL slot 3,
+            // declared as `array<atomic<u32>>`) is keyed on the
+            // append-target — by convention, the FIRST field's value if
+            // that field is named `target` or one of the layout's
+            // declared fields names a target binding. To keep the MVP
+            // scope tight, we hardcode the target slot from
+            // `event_ring[event_idx * stride + 3u]` (matching the
+            // existing G3a scalar shape's `target_slot` derivation).
+            // The struct-payload threats view follows the same shape
+            // (the cursor is keyed on the per-agent observer slot,
+            // which the event payload's target field carries).
+            out.push_str(&format!(
+                "        let target_slot = event_ring[event_idx * {stride}u + 3u];\n"
+            ));
+            out.push_str(
+                "        let cursor_idx = atomicAdd(&view_storage_anchor[target_slot], 1u);\n",
+            );
+            let field_count = layout.cell_stride_u32();
+            out.push_str(&format!(
+                "        let ring_idx = target_slot * {k}u + (cursor_idx % {k}u);\n"
+            ));
+            // Step 3: per-field stores. Each field writes to
+            // `view_storage_primary[ring_idx * field_count + field_idx]`.
+            // For non-u32 types, bitcast to u32 (primary is
+            // `array<u32>`).
+            for (field_idx, ((name, expr_id), layout_field)) in
+                fields.iter().zip(layout.fields.iter()).enumerate()
+            {
+                let value_wgsl =
+                    lower_cg_expr_to_wgsl(*expr_id, ctx).map_err(KernelEmitError::from)?;
+                let bits_expr = match layout_field.ty {
+                    crate::cg::expr::CgTy::U32
+                    | crate::cg::expr::CgTy::AgentId
+                    | crate::cg::expr::CgTy::Tick => value_wgsl,
+                    crate::cg::expr::CgTy::F32 => format!("bitcast<u32>({value_wgsl})"),
+                    crate::cg::expr::CgTy::I32 => format!("bitcast<u32>({value_wgsl})"),
+                    crate::cg::expr::CgTy::Bool => format!("select(0u, 1u, {value_wgsl})"),
+                    crate::cg::expr::CgTy::Vec3F32 => {
+                        // Vec3 doesn't fit in a single u32 word; the
+                        // type-checker gates this at the lowering, but
+                        // emit a placeholder so the body still
+                        // compiles.
+                        format!("/* vec3 packing TODO */ 0u")
+                    }
+                    crate::cg::expr::CgTy::ViewKey { .. } => value_wgsl,
+                };
+                out.push_str(&format!(
+                    "        view_storage_primary[ring_idx * {field_count}u + {field_idx}u] = {bits_expr}; // {name}\n",
+                    field_count = field_count,
+                    field_idx = field_idx,
+                    bits_expr = bits_expr,
+                    name = name,
+                ));
+            }
+        } else {
+            // ----- G3a scalar-payload fallback (preserve existing emit) -----
+            out.push_str(&format!(
+                "        let target_slot = event_ring[event_idx * {stride}u + 3u];\n"
+            ));
+            out.push_str(&format!(
+                "        let amount_bits = event_ring[event_idx * {stride}u + 4u];\n"
+            ));
+            out.push_str(
+                "        let cursor_idx = atomicAdd(&view_storage_anchor[target_slot], 1u);\n",
+            );
+            out.push_str(&format!(
+                "        let ring_idx = target_slot * {k}u + (cursor_idx % {k}u);\n"
+            ));
+            // primary is `array<u32>` for PerEntityRing (non-atomic — the
+            // cursor atomicAdd already serialized slot allocation, so
+            // each writer's `ring_idx` is distinct within one tick for
+            // ≤K events per agent). Plain assignment, not atomicStore.
+            out.push_str(
+                "        view_storage_primary[ring_idx] = amount_bits;\n",
+            );
+        }
+
         out.push_str("    }\n");
     }
 
@@ -2978,6 +3116,11 @@ fn stmt_list_has_emit(list_id: crate::cg::stmt::CgStmtListId, prog: &CgProgram) 
             // the dispatcher kernel binds the chronicle ring on its
             // own once #136's emit-side companion lands.
             CgStmt::ApplyAbility { .. } => false,
+            // Plan G G3b/G3c — view-storage append writes to the
+            // per-entity ring's primary + cursors slots, not to an
+            // event ring. Treat as false here so the emit-list scan
+            // doesn't miscount it as an event emitter.
+            CgStmt::ViewStorageAppend { .. } => false,
         };
         if hit {
             return true;

--- a/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
+++ b/crates/dsl_compiler/src/cg/emit/wgsl_body.rs
@@ -2471,6 +2471,20 @@ fn lower_cg_stmt_body_to_wgsl(
             );
             Ok(body)
         }
+        CgStmt::ViewStorageAppend { .. } => {
+            // Plan G G3b/G3c — struct-payload ring append. The actual
+            // WGSL is hand-synthesised by `build_view_fold_ring_append_body`
+            // in `cg/emit/kernel.rs` from the registered `ViewLayout` +
+            // the storage hint's K. The generic stmt → wgsl walker is
+            // bypassed entirely for PerEntityRing fold bodies (the
+            // kernel composer special-cases the body), so this arm is
+            // structurally unreachable in production. Emit an empty
+            // placeholder so a synthetic IR walking through the generic
+            // path still produces parseable WGSL.
+            Ok(String::from(
+                "    // ViewStorageAppend — handled by ring-append emit at kernel.rs\n",
+            ))
+        }
     }
 }
 

--- a/crates/dsl_compiler/src/cg/lower/driver.rs
+++ b/crates/dsl_compiler/src/cg/lower/driver.rs
@@ -2967,7 +2967,8 @@ fn list_contains_apply_ability(list_id: CgStmtListId, prog: &CgProgram) -> bool 
             | CgStmt::Assign { .. }
             | CgStmt::Let { .. }
             | CgStmt::ForEachAgent { .. }
-            | CgStmt::ForEachNeighbor { .. } => {}
+            | CgStmt::ForEachNeighbor { .. }
+            | CgStmt::ViewStorageAppend { .. } => {}
         }
     }
     false
@@ -3014,7 +3015,8 @@ fn list_contains_apply_ability_with_aoe(list_id: CgStmtListId, prog: &CgProgram)
             | CgStmt::Assign { .. }
             | CgStmt::Let { .. }
             | CgStmt::ForEachAgent { .. }
-            | CgStmt::ForEachNeighbor { .. } => {}
+            | CgStmt::ForEachNeighbor { .. }
+            | CgStmt::ViewStorageAppend { .. } => {}
         }
     }
     false
@@ -3195,6 +3197,15 @@ fn collect_belief_state_setter_writes(
                     walk_expr(*caster, prog, out);
                     walk_expr(*target, prog, out);
                 }
+                CgStmt::ViewStorageAppend { fields, .. } => {
+                    // Plan G G3b/G3c — each field's bound expression
+                    // could carry an embedded BeliefState column read
+                    // (e.g. `last_known_hp` lookup as a struct-cell
+                    // value). Walk every field expr just like Emit.
+                    for (_, expr_id) in fields {
+                        walk_expr(*expr_id, prog, out);
+                    }
+                }
             }
         }
     }
@@ -3345,6 +3356,11 @@ fn collect_belief_state_getter_reads(
                 CgStmt::ApplyAbility { caster, target, .. } => {
                     walk_expr(*caster, prog, out);
                     walk_expr(*target, prog, out);
+                }
+                CgStmt::ViewStorageAppend { fields, .. } => {
+                    for (_, expr_id) in fields {
+                        walk_expr(*expr_id, prog, out);
+                    }
                 }
             }
         }
@@ -3754,7 +3770,12 @@ fn collect_emits_in_list(list_id: CgStmtListId, prog: &CgProgram, out: &mut Vec<
             CgStmt::Assign { .. }
             | CgStmt::Let { .. }
             | CgStmt::ForEachAgent { .. }
-            | CgStmt::ForEachNeighbor { .. } => {}
+            | CgStmt::ForEachNeighbor { .. }
+            | CgStmt::ViewStorageAppend { .. } => {
+                // Plan G G3b/G3c — view-storage append writes to the
+                // per-entity ring's primary + cursors slots, NOT to an
+                // event ring. No emit-destination contribution.
+            }
             CgStmt::ApplyAbility { .. } => {
                 // #136 slice β step 4: ApplyAbility's WGSL dispatcher
                 // (cg/emit/wgsl_body.rs) atomic-appends to the

--- a/crates/dsl_compiler/src/cg/lower/error.rs
+++ b/crates/dsl_compiler/src/cg/lower/error.rs
@@ -750,6 +750,30 @@ pub enum LoweringError {
         span: Span,
     },
 
+    /// Plan G G3b/G3c — `self.append(...)` declared in a view fold
+    /// body but the view's storage hint is not
+    /// `@per_entity_ring(...)`. The struct-cell ring-append shape only
+    /// makes sense for a per-entity ring; other hints (PairMap,
+    /// PerEntityTopK, SymmetricPairTopK, LazyCached) have no cursor
+    /// counter to allocate ring slots through.
+    SelfAppendRequiresPerEntityRing {
+        view: ViewId,
+        hint_label: &'static str,
+        span: Span,
+    },
+
+    /// Plan G G3b/G3c — two `self.append(...)` statements in the same
+    /// view body declare different field lists. Today the per-cell
+    /// struct layout is implied by the first SelfAppend's field list;
+    /// a second SelfAppend with a different shape would mean the cell
+    /// has two layouts simultaneously, which is incoherent.
+    ConflictingViewLayout {
+        view: ViewId,
+        prior_field_count: usize,
+        new_field_count: usize,
+        span: Span,
+    },
+
     // -- Driver pass (Task 2.8) ------------------------------------------
 
     /// A view fold-handler or physics-rule kind-pattern names an
@@ -1205,6 +1229,25 @@ impl fmt::Display for LoweringError {
                 f,
                 "view #{} self-update operator {} not supported by CG IR; only += is lowered today",
                 view.0, op_label
+            ),
+            LoweringError::SelfAppendRequiresPerEntityRing {
+                view,
+                hint_label,
+                span,
+            } => write!(
+                f,
+                "view#{} at {}..{} uses `self.append(...)` but the storage hint is `{}`; struct-cell ring append requires `@per_entity_ring(...)`",
+                view.0, span.start, span.end, hint_label
+            ),
+            LoweringError::ConflictingViewLayout {
+                view,
+                prior_field_count,
+                new_field_count,
+                span,
+            } => write!(
+                f,
+                "view#{} at {}..{} declares conflicting `self.append(...)` field counts ({} vs {}); a single view's struct-cell layout must be uniform across all SelfAppend statements",
+                view.0, span.start, span.end, prior_field_count, new_field_count
             ),
 
             // -- Physics pass -----------------------------------------

--- a/crates/dsl_compiler/src/cg/lower/physics.rs
+++ b/crates/dsl_compiler/src/cg/lower/physics.rs
@@ -593,6 +593,15 @@ fn lower_stmt(
             ast_label: "SelfUpdate",
             span: *span,
         }),
+        IrStmt::SelfAppend { span, .. } => Err(LoweringError::UnsupportedPhysicsStmt {
+            // Plan G G3b/G3c — `self.append(...)` is a view-fold-body
+            // primitive (struct-payload ring append). Physics rules
+            // have no `self` cell to ring-append into, so reject up
+            // front with a typed deferral.
+            rule: rule_id,
+            ast_label: "SelfAppend",
+            span: *span,
+        }),
         IrStmt::BeliefObserve { span, .. } => Err(LoweringError::UnsupportedPhysicsStmt {
             rule: rule_id,
             ast_label: "BeliefObserve",
@@ -1455,7 +1464,8 @@ fn list_contains_for_each_agent_body(
             | CgStmt::Emit { .. }
             | CgStmt::ApplyAbility { .. }
             | CgStmt::ForEachAgent { .. }
-            | CgStmt::ForEachNeighbor { .. } => {}
+            | CgStmt::ForEachNeighbor { .. }
+            | CgStmt::ViewStorageAppend { .. } => {}
         }
     }
     false
@@ -1519,7 +1529,8 @@ fn is_tile_eligible_body(
             | CgStmt::If { .. }
             | CgStmt::Match { .. }
             | CgStmt::Emit { .. }
-            | CgStmt::ApplyAbility { .. } => {
+            | CgStmt::ApplyAbility { .. }
+            | CgStmt::ViewStorageAppend { .. } => {
                 // ForEachNeighborBody carries an emit-bearing body —
                 // not a pure fold over fields. The tiled-MoveBoid
                 // optimisation only applies to fold-shaped bodies; a
@@ -2529,7 +2540,8 @@ mod tests {
                 | CgStmt::ForEachNeighbor { .. }
                 | CgStmt::ForEachNeighborBody { .. }
                 | CgStmt::ForEachAgentBody { .. }
-                | CgStmt::ApplyAbility { .. } => {
+                | CgStmt::ApplyAbility { .. }
+                | CgStmt::ViewStorageAppend { .. } => {
                     // Other body shapes — not produced by this fixture.
                 }
             }

--- a/crates/dsl_compiler/src/cg/lower/view.rs
+++ b/crates/dsl_compiler/src/cg/lower/view.rs
@@ -667,11 +667,107 @@ fn lower_stmt(
             };
             push_assign(target, value_id, *span, ctx)
         }
-        IrStmt::Let { span, .. } => Err(LoweringError::UnsupportedViewFoldStmt {
-            view: view_id,
-            ast_label: "Let",
-            span: *span,
-        }),
+        IrStmt::Let {
+            local,
+            value,
+            span,
+            ..
+        } => {
+            // Plan G G3c — admit `let <name> = <expr>;` inside fold
+            // bodies. Mirrors the physics-side `lower_let` shape: the
+            // bound expression lowers via `lower_expr`, the LocalRef →
+            // LocalId mapping is allocated (or reused if pre-registered),
+            // and the binding's CG type is recorded so later reads
+            // (`IrExpr::Local(local_ref, _)`) resolve through
+            // `CgExpr::ReadLocal`. This unblocks multi-statement view
+            // bodies that compute an intermediate value before
+            // appending to the per-entity ring (e.g. derive a
+            // `cursor_idx` or pre-format a struct field).
+            let value_id = lower_expr(value, ctx)?;
+            let value_ty = super::expr::typecheck_node(ctx, value_id, value.span)?;
+            let local_id = match ctx.local_ids.get(local).copied() {
+                Some(id) => id,
+                None => ctx.allocate_local(*local),
+            };
+            ctx.record_local_ty(local_id, value_ty);
+            ctx.builder
+                .add_stmt(CgStmt::Let {
+                    local: local_id,
+                    value: value_id,
+                    ty: value_ty,
+                })
+                .map_err(|e| LoweringError::BuilderRejected {
+                    error: e,
+                    span: *span,
+                })
+        }
+        IrStmt::SelfAppend { fields, span } => {
+            // Plan G G3b/G3c — struct-payload ring append. Lower each
+            // field's bound expression, capture its CgTy, then register
+            // the per-cell struct layout on the program builder. The
+            // struct layout is implied by the field-name list +
+            // per-field types; subsequent SelfAppend statements in the
+            // same view body must declare the same field count (a
+            // future extension permits the resolver to enforce
+            // identical name/type tuples — today only count is checked
+            // structurally).
+            //
+            // Storage-hint gate: only `@per_entity_ring(...)` carries
+            // the cursor counter that allocates ring slots. Other
+            // hints surface as
+            // [`LoweringError::SelfAppendRequiresPerEntityRing`].
+            if !matches!(hint, StorageHint::PerEntityRing { .. }) {
+                return Err(LoweringError::SelfAppendRequiresPerEntityRing {
+                    view: view_id,
+                    hint_label: storage_hint_label(hint),
+                    span: *span,
+                });
+            }
+            let mut lowered_fields: Vec<(String, CgExprId)> = Vec::with_capacity(fields.len());
+            let mut layout_fields: Vec<crate::cg::program::ViewLayoutField> =
+                Vec::with_capacity(fields.len());
+            for field in fields {
+                let expr_id = lower_expr(&field.value, ctx)?;
+                let ty = super::expr::typecheck_node(ctx, expr_id, field.value.span)?;
+                lowered_fields.push((field.name.clone(), expr_id));
+                layout_fields.push(crate::cg::program::ViewLayoutField {
+                    name: field.name.clone(),
+                    ty,
+                });
+            }
+            let new_layout = crate::cg::program::ViewLayout {
+                fields: layout_fields,
+            };
+            // Conflict gate: a re-register with a different field count
+            // surfaces as a typed defect. Equal layouts (re-register
+            // with the same shape) silently no-op — the second
+            // SelfAppend in a multi-statement body might want to write
+            // the same cell shape under different conditions.
+            let prior_count = ctx.builder.view_layout(view_id).map(|l| l.fields.len());
+            match prior_count {
+                Some(n) if n != new_layout.fields.len() => {
+                    return Err(LoweringError::ConflictingViewLayout {
+                        view: view_id,
+                        prior_field_count: n,
+                        new_field_count: new_layout.fields.len(),
+                        span: *span,
+                    });
+                }
+                Some(_) => {} // matching layout — no re-register needed
+                None => {
+                    ctx.builder.register_view_layout(view_id, new_layout);
+                }
+            }
+            ctx.builder
+                .add_stmt(CgStmt::ViewStorageAppend {
+                    view: view_id,
+                    fields: lowered_fields,
+                })
+                .map_err(|e| LoweringError::BuilderRejected {
+                    error: e,
+                    span: *span,
+                })
+        }
         IrStmt::If { span, .. } => Err(LoweringError::UnsupportedViewFoldStmt {
             view: view_id,
             ast_label: "If",
@@ -1465,9 +1561,17 @@ mod tests {
     // ---- Negative: unsupported fold-body statement form -----------------
 
     #[test]
-    fn rejects_let_in_fold_body() {
-        // A `let` statement in a fold body — the resolver permits
-        // `Let`, but Task 2.3's `lower_stmt` defers it.
+    fn admits_let_in_fold_body() {
+        // Plan G G3c — `let` statements are admitted inside fold
+        // bodies (lifted from the previous "Unsupported(Let)" gate).
+        // The let lowers via the same path as physics: allocate a
+        // LocalId for the AST LocalRef, lower the bound value, record
+        // the binding's CgTy on the lowering context, then push a
+        // `CgStmt::Let { local, value, ty }` into the builder. The
+        // builder's lowered stmt list contains both the Let and any
+        // subsequent statements (here a follow-up SelfUpdate so the
+        // body has a final fold-body shape that emits a Primary
+        // write).
         let handler = FoldHandlerIR {
             pattern: IrEventPattern {
                 name: "AgentAttacked".to_string(),
@@ -1475,12 +1579,19 @@ mod tests {
                 bindings: vec![],
                 span: span(0, 0),
             },
-            body: vec![IrStmt::Let {
-                name: "tmp".to_string(),
-                local: dsl_ast::ir::LocalRef(0),
-                value: lit_f32(1.0),
-                span: span(7, 14),
-            }],
+            body: vec![
+                IrStmt::Let {
+                    name: "tmp".to_string(),
+                    local: dsl_ast::ir::LocalRef(0),
+                    value: lit_f32(1.0),
+                    span: span(7, 14),
+                },
+                IrStmt::SelfUpdate {
+                    op: "+=".to_string(),
+                    value: lit_f32(2.0),
+                    span: span(15, 25),
+                },
+            ],
             span: span(0, 0),
         };
         let view = fold_view(
@@ -1491,7 +1602,7 @@ mod tests {
 
         let mut builder = CgProgramBuilder::new();
         let mut ctx = LoweringCtx::new(&mut builder);
-        let err = lower_view(
+        let ops = lower_view(
             ViewId(0),
             &view,
             &[HandlerResolution {
@@ -1500,22 +1611,22 @@ mod tests {
             }],
             &mut ctx,
         )
-        .expect_err("Let unsupported in fold body");
-        match err {
-            LoweringError::UnsupportedViewFoldStmt {
-                view,
-                ast_label,
-                span,
-            } => {
-                assert_eq!(view, ViewId(0));
-                assert_eq!(ast_label, "Let");
-                assert_eq!(span.start, 7);
-                assert_eq!(span.end, 14);
-            }
-            other => panic!("expected UnsupportedViewFoldStmt(Let), got {other:?}"),
-        }
+        .expect("Let now lowers cleanly inside fold body");
+        assert_eq!(ops.len(), 1);
         let prog = builder.finish();
-        assert!(prog.ops.is_empty());
+        // The body list contains 2 stmts: a Let and an Assign.
+        let op = &prog.ops[0];
+        match &op.kind {
+            ComputeOpKind::ViewFold { body, .. } => {
+                let list = &prog.stmt_lists[body.0 as usize];
+                assert_eq!(list.stmts.len(), 2);
+                let let_stmt = &prog.stmts[list.stmts[0].0 as usize];
+                let assign_stmt = &prog.stmts[list.stmts[1].0 as usize];
+                assert!(matches!(let_stmt, CgStmt::Let { .. }));
+                assert!(matches!(assign_stmt, CgStmt::Assign { .. }));
+            }
+            other => panic!("unexpected kind: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/dsl_compiler/src/cg/program.rs
+++ b/crates/dsl_compiler/src/cg/program.rs
@@ -432,6 +432,73 @@ pub enum ViewFoldOp {
     Or,
 }
 
+// ---------------------------------------------------------------------------
+// Plan G G3b — per-view struct-cell layout for PerEntityRing folds whose
+// body uses `self.append(...)` instead of `self += <expr>`.
+// ---------------------------------------------------------------------------
+
+/// Single field inside a struct-cell `ViewLayout`.
+///
+/// `name` is the source-level field identifier (`"timestamp"`,
+/// `"amount"`, …); preserved verbatim for diagnostics and emit so
+/// per-field stores carry their source name in WGSL comments.
+///
+/// `ty` is the CG-typed scalar type the field stores. Today every
+/// field rounds to a 4-byte `u32` slot (the per-field WGSL store is
+/// `view_storage_primary[ring_idx * field_count + field_idx] = bits`,
+/// where bits is the `bitcast<u32>(...)` of the field's value). This
+/// matches the alignment rule pinned in the threats-view design doc:
+/// "round each field to its own size's alignment; total padded to 4
+/// bytes". A future widening (i64 / f64 fields, bit-packed sub-32-bit
+/// fields) extends the per-field stride; today every field is one
+/// 32-bit word so the layout's total stride equals `field_count`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ViewLayoutField {
+    /// Source-level field name. Carried for diagnostics + emit
+    /// comments.
+    pub name: String,
+    /// CG-typed scalar type. Sub-32-bit widths still occupy a full
+    /// 32-bit slot today (no bit-packing).
+    pub ty: super::expr::CgTy,
+}
+
+/// Per-cell struct layout for a `@per_entity_ring(K = N)` view whose
+/// fold body uses `self.append(field1: expr1, field2: expr2, ...)`
+/// instead of the scalar `self += <expr>` shape.
+///
+/// `fields` carries one entry per source-level append field in
+/// declaration order. The cell's total width in u32 words equals
+/// `fields.len()` under today's all-fields-are-32-bit rule (see
+/// [`ViewLayoutField::ty`] notes); the per-runtime
+/// `view_storage_primary` allocation grows from `agent_count * K * 4`
+/// (scalar) to `agent_count * K * fields.len() * 4` (struct).
+///
+/// Populated by the view-body lowerer the first time it lowers a
+/// `IrStmt::SelfAppend` for a given view. Conflicting layouts (two
+/// `SelfAppend` statements with different field lists in the same
+/// view body) surface as a typed lowering error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViewLayout {
+    pub fields: Vec<ViewLayoutField>,
+}
+
+impl ViewLayout {
+    /// Total stride per cell, in u32 words. Today each field occupies
+    /// one 32-bit slot regardless of `ty` (see
+    /// [`ViewLayoutField::ty`]); `field_count` is therefore both the
+    /// number of fields AND the cell's u32 stride.
+    pub fn cell_stride_u32(&self) -> u32 {
+        self.fields.len() as u32
+    }
+
+    /// Total size per cell in bytes — `cell_stride_u32() * 4`. Used by
+    /// per-runtime crates to compute the `view_storage_primary` buffer
+    /// size: `agent_count * K * cell_size_bytes()`.
+    pub fn cell_size_bytes(&self) -> u32 {
+        self.cell_stride_u32() * 4
+    }
+}
+
 /// CG-side storage-hint enum mirroring the discriminator subset of
 /// [`dsl_ast::ir::StorageHint`] that the WGSL emit + dispatch sizing
 /// path actually consults. Decoupled from the AST type so the cg crate
@@ -955,6 +1022,19 @@ pub struct CgProgram {
     /// [`super::lower::expr::LoweringCtx::view_signatures`]). Empty
     /// for programs that don't have materialized views.
     pub view_signatures: BTreeMap<u32, ViewSignature>,
+    /// Plan G G3b — per-view struct-cell layout for PerEntityRing folds
+    /// whose body uses `self.append(field1: expr, field2: expr, ...)`.
+    /// Keyed on `ViewId.0`. Empty for fixtures that don't author the
+    /// struct-payload shape; existing scalar-payload PerEntityRing
+    /// fixtures (per_entity_ring_probe.sim) and every other storage
+    /// hint stay unaffected. Consulted by the WGSL emit
+    /// (`build_view_fold_ring_append_body`) to decide between the
+    /// single-field ring-append shape and the per-field struct-cell
+    /// shape, AND by per-runtime build.rs scripts to size the
+    /// `view_storage_primary` allocation
+    /// (`agent_count * K * cell_size_bytes()`).
+    #[serde(default)]
+    pub view_layouts: BTreeMap<u32, ViewLayout>,
     /// Per-`ConfigConstId` literal default value, harvested from the
     /// resolved DSL `config <block> { <field>: <ty> = <default>, ... }`
     /// declarations by the driver's `populate_config_consts`. Populated
@@ -1549,6 +1629,16 @@ impl CgProgramBuilder {
                 self.check_expr_id(*caster)?;
                 self.check_expr_id(*target)
             }
+            CgStmt::ViewStorageAppend { fields, .. } => {
+                // Plan G G3b/G3c — every per-field expression id must
+                // already exist in the arena. The `view` payload is a
+                // typed [`ViewId`] (arena-independent — the view name
+                // table validates ids on intern, not here).
+                for (_, expr_id) in fields {
+                    self.check_expr_id(*expr_id)?;
+                }
+                Ok(())
+            }
         }
     }
 
@@ -1677,6 +1767,27 @@ impl CgProgramBuilder {
     /// fold-body `Assign(ViewStorage{Primary}, scalar)` shapes.
     pub fn set_view_signatures(&mut self, sigs: BTreeMap<u32, ViewSignature>) {
         self.inner.view_signatures = sigs;
+    }
+
+    /// Plan G G3b — register the per-view struct-cell layout for a
+    /// `@per_entity_ring(...)` fold whose body uses `self.append(...)`.
+    /// Idempotent within a single lowering pass: a re-register with an
+    /// equal layout is a no-op; a re-register with a *different* layout
+    /// returns the prior entry so the caller can surface a typed
+    /// "conflicting struct-cell layout" defect.
+    pub fn register_view_layout(
+        &mut self,
+        view_id: super::data_handle::ViewId,
+        layout: ViewLayout,
+    ) -> Option<ViewLayout> {
+        self.inner.view_layouts.insert(view_id.0, layout)
+    }
+
+    /// Plan G G3b — read the registered struct-cell layout for a view,
+    /// if any. Returns `None` for views without a registered layout
+    /// (every scalar-payload view today).
+    pub fn view_layout(&self, view_id: super::data_handle::ViewId) -> Option<&ViewLayout> {
+        self.inner.view_layouts.get(&view_id.0)
     }
 
     /// Append-only seam for post-construction registry-resolved bindings

--- a/crates/dsl_compiler/src/cg/schedule/fusion.rs
+++ b/crates/dsl_compiler/src/cg/schedule/fusion.rs
@@ -1060,7 +1060,12 @@ fn collect_emits_in_list(
             CgStmt::Assign { .. }
             | CgStmt::Let { .. }
             | CgStmt::ForEachAgent { .. }
-            | CgStmt::ForEachNeighbor { .. } => {}
+            | CgStmt::ForEachNeighbor { .. }
+            | CgStmt::ViewStorageAppend { .. } => {
+                // Plan G G3b/G3c — view-storage append writes to the
+                // per-entity ring's primary + cursors slots, not to an
+                // event ring. No emit-destination contribution.
+            }
             CgStmt::ApplyAbility { ability, .. } => {
                 push_apply_ability_event_kinds(*ability, prog, registry, out);
             }

--- a/crates/dsl_compiler/src/cg/stmt.rs
+++ b/crates/dsl_compiler/src/cg/stmt.rs
@@ -474,6 +474,28 @@ pub enum CgStmt {
     ///
     /// Lands in #136 (initial: 4 EffectOp variants — Damage, Heal,
     /// Stun, Slow), then #137 expands to the full vocabulary.
+    /// Plan G G3b/G3c — struct-payload ring append in a
+    /// `@per_entity_ring(...)` view fold body. Source form:
+    /// `self.append(field1: expr1, field2: expr2, ...)`.
+    ///
+    /// `view` names the materialized view whose ring receives the cell.
+    /// `fields` carries the per-field name + bound expression in
+    /// declaration order; the per-cell struct layout (field count +
+    /// per-field types + total cell width in u32 words) lives on
+    /// [`crate::cg::program::CgProgram::view_layouts`] keyed by `view`,
+    /// registered at the same time the lowering produces this stmt.
+    ///
+    /// Emit (per-storage-hint synthesized in `kernel.rs`): allocates a
+    /// ring index via the per-target cursor counter, then writes each
+    /// field at `primary[ring_idx * field_count + field_idx]`. The
+    /// auto-walker surfaces all field-expr reads + the
+    /// `ViewStorage{view, Primary}` and `ViewStorage{view, Cursors}`
+    /// writes.
+    ViewStorageAppend {
+        view: super::data_handle::ViewId,
+        fields: Vec<(String, CgExprId)>,
+    },
+
     ApplyAbility {
         ability: CgExprId,
         /// Caster slot — u32-typed expression. Written into the actor
@@ -584,6 +606,16 @@ impl fmt::Display for CgStmt {
                     "for_each_agent_body(binder={}, body=stmts#{})",
                     binder, body.0
                 )
+            }
+            CgStmt::ViewStorageAppend { view, fields } => {
+                write!(f, "view_storage_append(view=#{}, [", view.0)?;
+                for (i, (name, expr)) in fields.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, "{}=expr#{}", name, expr.0)?;
+                }
+                f.write_str("])")
             }
             CgStmt::ApplyAbility { ability, caster, target, with_aoe_dispatch } => {
                 // Slice ε: include caster + target operand ids in the
@@ -981,6 +1013,24 @@ pub fn collect_stmt_dependencies(
             collect_expr_reads(*ability, exprs, reads);
             collect_expr_reads(*caster, exprs, reads);
             collect_expr_reads(*target, exprs, reads);
+        }
+        CgStmt::ViewStorageAppend { view, fields } => {
+            // Plan G G3b/G3c — struct-payload ring append. Each
+            // field's bound expression contributes reads (event-pattern
+            // bindings, locals, agent-field reads); the writes are
+            // both Primary (per-field cell stores) and Cursors (the
+            // atomicAdd that allocates the ring slot).
+            for (_, expr_id) in fields {
+                collect_expr_reads(*expr_id, exprs, reads);
+            }
+            writes.push(DataHandle::ViewStorage {
+                view: *view,
+                slot: super::data_handle::ViewStorageSlot::Primary,
+            });
+            writes.push(DataHandle::ViewStorage {
+                view: *view,
+                slot: super::data_handle::ViewStorageSlot::Cursors,
+            });
         }
     }
 }

--- a/crates/dsl_compiler/src/cg/well_formed.rs
+++ b/crates/dsl_compiler/src/cg/well_formed.rs
@@ -1051,6 +1051,14 @@ fn walk_body_expr_subtrees(
                 validate_expr_subtree(arena, *caster, op_id, expr_arena_len, errors);
                 validate_expr_subtree(arena, *target, op_id, expr_arena_len, errors);
             }
+            CgStmt::ViewStorageAppend { fields, .. } => {
+                // Plan G G3b/G3c — every field's bound expression
+                // subtree must be range-valid. The `view` payload is a
+                // typed [`ViewId`] (arena-independent).
+                for (_, expr_id) in fields {
+                    validate_expr_subtree(arena, *expr_id, op_id, expr_arena_len, errors);
+                }
+            }
         }
     }
 }
@@ -1092,7 +1100,8 @@ fn walk_list_id_ranges(
             | CgStmt::Let { .. }
             | CgStmt::ForEachAgent { .. }
             | CgStmt::ForEachNeighbor { .. }
-            | CgStmt::ApplyAbility { .. } => {
+            | CgStmt::ApplyAbility { .. }
+            | CgStmt::ViewStorageAppend { .. } => {
                 // Nothing to range-check at the list-walk level —
                 // these statements only embed expr-ids and (for
                 // Assign) a target handle, all of which are validated
@@ -1707,6 +1716,23 @@ fn type_check_list(
                     }
                 }
             }
+            CgStmt::ViewStorageAppend { fields, .. } => {
+                // Plan G G3b/G3c — type-check every field's bound
+                // expression. Field types are inferred at lowering
+                // time and recorded on the registered `ViewLayout`;
+                // this walk only re-runs `type_check` to surface any
+                // structural defect in a field's expression subtree.
+                for (_, expr_id) in fields {
+                    if let Some(expr) = prog.exprs.get(expr_id.0 as usize) {
+                        if let Err(err) = type_check(expr, *expr_id, ctx) {
+                            errors.push(CgError::TypeMismatch {
+                                op: op_id,
+                                error: err,
+                            });
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -1849,6 +1875,13 @@ fn p6_walk_list(
                 // ApplyAbility writes to the chronicle ring per
                 // emitted ApplyEvent — the P6 mutation channel. No
                 // direct AgentField write surface to police.
+            }
+            CgStmt::ViewStorageAppend { .. } => {
+                // Plan G G3b/G3c — writes to the per-entity ring's
+                // primary + cursors slots, NOT to AgentField. P6 only
+                // polices AgentField writes; ViewStorage writes flow
+                // through the existing slot validator in
+                // `validate_storage_slot`.
             }
         }
     }
@@ -2011,6 +2044,21 @@ fn event_field_scope_walk_list(
                     errors,
                 );
             }
+            CgStmt::ViewStorageAppend { fields, .. } => {
+                // Plan G G3b/G3c — each field's bound expression may
+                // read event-payload bindings through `IrExpr::Local`
+                // resolution; the scope walker visits each like Emit.
+                for (_, expr_id) in fields {
+                    event_field_scope_walk_expr(
+                        *expr_id,
+                        op_id,
+                        kind_label,
+                        shape_label,
+                        prog,
+                        errors,
+                    );
+                }
+            }
         }
     }
 }
@@ -2125,7 +2173,8 @@ fn match_uniqueness_walk_list(
             | CgStmt::Let { .. }
             | CgStmt::ForEachAgent { .. }
             | CgStmt::ForEachNeighbor { .. }
-            | CgStmt::ApplyAbility { .. } => {
+            | CgStmt::ApplyAbility { .. }
+            | CgStmt::ViewStorageAppend { .. } => {
                 // Leaves — no nested bodies to descend into.
             }
             CgStmt::ForEachNeighborBody { body, .. }
@@ -2674,7 +2723,11 @@ fn collect_emit_kinds_in_list(
             CgStmt::Assign { .. }
             | CgStmt::Let { .. }
             | CgStmt::ForEachAgent { .. }
-            | CgStmt::ForEachNeighbor { .. } => {}
+            | CgStmt::ForEachNeighbor { .. }
+            | CgStmt::ViewStorageAppend { .. } => {
+                // Plan G G3b/G3c — view-storage append writes to the
+                // ring's primary + cursors slots, not to an event ring.
+            }
         }
     }
 }

--- a/crates/dsl_compiler/src/schema_hash.rs
+++ b/crates/dsl_compiler/src/schema_hash.rs
@@ -612,6 +612,21 @@ fn hash_stmt(h: &mut Sha256, s: &IrStmt) {
                 None    => { h.update([0x00u8]); }
             }
         }
+        IrStmt::SelfAppend { fields, .. } => {
+            // Plan G G3b/G3c — discriminant 0x1A (next free after
+            // ForEachAgent's 0x19). The struct-cell layout is implied
+            // by the field-name list + bound-expr types; encode names
+            // verbatim + the per-field bound expressions in declaration
+            // order so reordering or rebinding is a hash-affecting
+            // change.
+            h.update([0x1Au8]);
+            h.update(&(fields.len() as u32).to_le_bytes());
+            for f in fields {
+                h.update(f.name.as_bytes());
+                h.update([0u8]);
+                hash_expr(h, &f.value);
+            }
+        }
     }
 }
 

--- a/crates/dsl_compiler/tests/per_entity_ring_struct_probe_lower.rs
+++ b/crates/dsl_compiler/tests/per_entity_ring_struct_probe_lower.rs
@@ -1,0 +1,159 @@
+//! Plan G G3b/G3c — smoke test for `assets/sim/per_entity_ring_struct_probe.sim`.
+//!
+//! Lights up the struct-payload extension to the existing
+//! `@per_entity_ring(K = N)` view shape (G3a's scalar-payload
+//! ring-append), plus the multi-statement-fold-body admission (G3c).
+//! The test asserts:
+//!
+//! 1. The fixture parses + resolves + lowers (no errors). The
+//!    `let now = world.tick` binding inside the fold body must be
+//!    accepted (the prior "Unsupported(Let)" gate is lifted).
+//! 2. The `recent_damage_records` view's struct-cell layout is
+//!    registered on the program (`prog.view_layouts`) with the
+//!    expected (timestamp, amount) field shape.
+//! 3. The view's fold WGSL contains per-field stores at indices
+//!    `ring_idx * field_count + field_idx`, NOT the single-field
+//!    `view_storage_primary[ring_idx] = amount_bits` shape.
+//! 4. The auto-walker recorded both `view_storage_primary` and
+//!    `view_storage_anchor` (cursors) writes — the same ring-append
+//!    primitive surface as the scalar shape.
+
+#[test]
+fn per_entity_ring_struct_probe_sim_lowers_clean() {
+    let src = std::fs::read_to_string("../../assets/sim/per_entity_ring_struct_probe.sim")
+        .expect("read assets/sim/per_entity_ring_struct_probe.sim");
+    let program = dsl_compiler::parse(&src).expect("parse per_entity_ring_struct_probe.sim");
+    let comp = dsl_ast::resolve::resolve(program)
+        .expect("resolve per_entity_ring_struct_probe.sim");
+
+    let (cg, lower_diags) = match dsl_compiler::cg::lower::lower_compilation_to_cg(&comp) {
+        Ok(p) => (p, Vec::new()),
+        Err(o) => {
+            let diags: Vec<String> = o.diagnostics.iter().map(|d| format!("{d}")).collect();
+            (o.program, diags)
+        }
+    };
+    for d in &lower_diags {
+        eprintln!("[lower diag] {d}");
+    }
+    assert!(
+        lower_diags.is_empty(),
+        "expected clean lowering; got diagnostics: {lower_diags:#?}"
+    );
+
+    // ---- ViewLayout assertions (G3b core) ----
+    //
+    // The lowering pass should have registered the struct-cell layout
+    // for `recent_damage_records` with two fields in declaration order:
+    // `(timestamp: u32, amount: f32)`. The fixture uses bit-32 types
+    // for both fields so the cell stride is exactly 2 u32 words.
+    assert!(
+        !cg.view_layouts.is_empty(),
+        "expected at least one registered ViewLayout for the struct-cell view, \
+         got an empty `view_layouts` map"
+    );
+    let layout = cg
+        .view_layouts
+        .values()
+        .next()
+        .expect("at least one ViewLayout registered");
+    assert_eq!(
+        layout.fields.len(),
+        2,
+        "expected 2 fields (timestamp, amount); got {}: {:?}",
+        layout.fields.len(),
+        layout.fields
+    );
+    assert_eq!(layout.fields[0].name, "timestamp");
+    assert_eq!(layout.fields[1].name, "amount");
+    assert_eq!(layout.cell_stride_u32(), 2);
+    assert_eq!(layout.cell_size_bytes(), 8);
+
+    // ---- Schedule + emit ----
+    let schedule = dsl_compiler::cg::schedule::synthesize_schedule(
+        &cg,
+        dsl_compiler::cg::schedule::ScheduleStrategy::Default,
+    );
+    let artifacts = dsl_compiler::cg::emit::emit_cg_program(&schedule.schedule, &cg)
+        .expect("emit per_entity_ring_struct_probe");
+
+    assert!(
+        !artifacts.kernel_index.is_empty(),
+        "expected at least one emitted kernel, got none"
+    );
+    let kernel_names: Vec<&str> = artifacts.kernel_index.iter().map(|s| s.as_str()).collect();
+    for expected in ["InjectDamage", "recent_damage_records"] {
+        assert!(
+            kernel_names.iter().any(|n| n.contains(expected)),
+            "expected kernel containing {expected:?}; got: {kernel_names:?}"
+        );
+    }
+
+    // ---- WGSL emit assertions (G3b struct-payload path) ----
+    let fold_wgsl = artifacts
+        .wgsl_files
+        .iter()
+        .find(|(name, _)| name.contains("recent_damage_records") && name.ends_with(".wgsl"))
+        .map(|(name, body)| (name.as_str(), body.as_str()))
+        .expect("recent_damage_records fold kernel must emit a .wgsl artifact");
+
+    eprintln!("[G3b struct] inspecting {}", fold_wgsl.0);
+    eprintln!("[G3b struct] body length: {} bytes", fold_wgsl.1.len());
+    eprintln!("[G3b struct] body:\n{}", fold_wgsl.1);
+
+    // The cursor allocation primitive is shared with G3a — same
+    // `atomicAdd(&view_storage_anchor[target_slot], 1u)` surface.
+    assert!(
+        fold_wgsl.1.contains("atomicAdd(&view_storage_anchor"),
+        "PerEntityRing struct emit must atomicAdd the cursors slot to allocate \
+         a ring index. WGSL did not contain the substring.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+
+    // The K=4 modulo + per-field stride must both appear. The stride
+    // is `field_count = 2` (timestamp + amount).
+    assert!(
+        fold_wgsl.1.contains("% 4u"),
+        "PerEntityRing emit must compute `ring_idx = target_slot * K + (cursor_idx % K)`. \
+         WGSL did not contain `% 4u` (K=4 from the .sim's @per_entity_ring(K = 4)).\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+
+    // Per-field store at index `ring_idx * field_count + field_idx`.
+    // The first field (timestamp, idx=0) writes at `ring_idx * 2u + 0u`;
+    // the second field (amount, idx=1) writes at `ring_idx * 2u + 1u`.
+    assert!(
+        fold_wgsl.1.contains("ring_idx * 2u + 0u"),
+        "struct-cell emit must store field 0 (timestamp) at \
+         `view_storage_primary[ring_idx * field_count + 0]`. \
+         WGSL did not contain the substring.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+    assert!(
+        fold_wgsl.1.contains("ring_idx * 2u + 1u"),
+        "struct-cell emit must store field 1 (amount) at \
+         `view_storage_primary[ring_idx * field_count + 1]`. \
+         WGSL did not contain the substring.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+
+    // Negative pin: the SCALAR-shape store
+    // (`view_storage_primary[ring_idx] = amount_bits`) should NOT be in
+    // the body — that path only fires when `view_layouts` is empty.
+    assert!(
+        !fold_wgsl.1.contains("view_storage_primary[ring_idx] = amount_bits"),
+        "struct-cell emit must NOT fall back to the scalar single-field shape; \
+         WGSL contained the scalar `view_storage_primary[ring_idx] = amount_bits` \
+         substring.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+
+    // The `f32 → bitcast<u32>` conversion for the amount field (since
+    // `view_storage_primary` is `array<u32>` for PerEntityRing).
+    assert!(
+        fold_wgsl.1.contains("bitcast<u32>"),
+        "struct-cell emit must bitcast f32 fields to u32 for the primary \
+         array store. WGSL did not contain `bitcast<u32>`.\n\nWGSL:\n{}",
+        fold_wgsl.1
+    );
+}


### PR DESCRIPTION
## Summary

Plan G G3b + G3c bundled. Extends the materialised-view fold path so PerEntityRing folds can store struct cells (multi-field payloads) and view fold bodies can declare intermediate `let` bindings.

- **G3b** — struct-cell payload for `@per_entity_ring(...)` views. New `IrStmt::SelfAppend { fields }` AST + `CgStmt::ViewStorageAppend` CG IR, plus a per-view `ViewLayout` table on `CgProgram` recording the (field_name, CgTy) tuples in declaration order. The WGSL emit at `build_view_fold_ring_append_body` branches on the registered layout: with one, per-field stores fire at `view_storage_primary[ring_idx * field_count + field_idx]` with `bitcast<u32>` for f32/i32 fields. Without one, the existing G3a scalar-payload shape fires unchanged.
- **G3c** — admit `IrStmt::Let` inside fold bodies (the prior "Unsupported(Let)" gate at `view::lower_stmt` is lifted) and add a `self.append(field: expr, ...)` statement form for the struct-cell ring append. Existing `self += <expr>` scalar accumulators stay in place.

New fixture `assets/sim/per_entity_ring_struct_probe.sim` exercises both slices with a 2-field cell `(timestamp: u32, amount: f32)` and a `let now = world.tick` prelude. Smoke test `crates/dsl_compiler/tests/per_entity_ring_struct_probe_lower.rs` asserts the registered layout, the per-field WGSL stores, and the bitcast for the f32 amount.

## Architectural Impact (AIS)

- **Storage**: `CgProgram` gains an optional `view_layouts: BTreeMap<u32, ViewLayout>` table. Empty for every existing fixture; populated at lowering time when a view body uses `self.append(...)`.
- **CG IR**: new `CgStmt::ViewStorageAppend { view, fields }` variant. The auto-walker records writes to both `Primary` and `Cursors` slots (mirroring the scalar ring-append's structural surface).
- **AST**: new `IrStmt::SelfAppend { fields }` + `Stmt::SelfAppend` parser surface (`self.append(name: expr, ...)`).
- **Lowering**: view-body `Let` admission (G3c). `SelfAppend` lowering registers the per-cell layout; conflicting field counts in the same view body surface as `LoweringError::ConflictingViewLayout`. Non-`PerEntityRing` storage hints reject `SelfAppend` via `LoweringError::SelfAppendRequiresPerEntityRing`.
- **Emit**: WGSL ring-append body branches on the registered layout. Scalar fixtures (per_entity_ring_probe.sim) unaffected.

## Test plan

- [x] `cargo test -p dsl_ast --release` — green (44+ tests pass).
- [x] `cargo test -p dsl_compiler --release` — green; new `per_entity_ring_struct_probe_lower` test passes; existing `per_entity_ring_probe_lower` test still passes.
- [x] `cargo check --workspace` — clean.
- [x] `RUST_MIN_STACK=33554432 cargo test -p per_entity_ring_probe_runtime --release` — 3 GPU pins still pass (G3a scalar path unaffected).

## Notes

- The per-runtime struct-payload runtime crate (G3a-step-4 sibling for the struct path) is out of scope; the existing per_entity_ring_probe_runtime continues to cover the scalar-payload GPU pin.
- The `ViewLayout::cell_size_bytes()` accessor is already wired so per-runtime build.rs scripts can size `view_storage_primary` as `agent_count * K * cell_size_bytes()` when they opt into the struct-payload path; today no runtime crate consumes it.
- Threats view (G3g) is the natural next slice — it composes G3b/G3c (struct cell + multi-statement body) with G3d (PerAgentEventScan dispatch, already landed) and G3ef (telegraph metadata + threats.* Builtin variants, already landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)